### PR TITLE
docs for metadata

### DIFF
--- a/docs/customizing-plugin-listing.md
+++ b/docs/customizing-plugin-listing.md
@@ -44,7 +44,7 @@ Plugin developers can modify these fields by adding a `.napari` configuration fo
 We currently support two configuration files:
 
 - `.napari/DESCRIPTION.md` for a napari-specific description (see [Description](#description))
-- `.napari/config.yml` for all other fields that can be configured
+- `.napari/config.yml` for all other configurable fields
 
 Fields that can be defined through the napari config include...
 
@@ -54,14 +54,14 @@ Fields that can be defined through the napari config include...
 - [Project Site](#project-site)
 - [Documentation](#documentation)
 - [Support](#support)
-- [Report issues](#report-issues)
+- [Report Issues](#report-issues)
 - [Twitter](#twitter)
 
 ## Fields
 
 For each of the fields in a plugin's listing, we outline below how the field is used and where we source the data.
 
-| Metadata             | Full view   |  Card view  | Filterable  | Sortable      | Searched  |
+| Metadata             | Full view   |  List view  | Filterable  | Sortable      | Searched  |
 |----------------------|:-----------:|:-----------:|:-----------:|:-------------:|:---------:|
 | Name                 |     ✅      |     ✅      |     ⛔      |      ✅       |    ✅    |
 | Summary              |     ✅      |     ✅      |     ⛔      |      ⛔       |    ✅    |
@@ -70,17 +70,17 @@ For each of the fields in a plugin's listing, we outline below how the field is 
 | License              |     ✅      |     ✅      |     ✅      |      ⛔       |    ⛔    |
 | Version              |     ✅      |     ✅      |     ⛔      |      ⛔       |    ⛔    |
 | Development Status   |     ✅      |     ⛔      |     ✅      |      ⛔       |    ⛔    |
-| Python version(s)    |     ✅      |     ⛔      |     ✅      |      ⛔       |    ⛔    |
+| Python Version       |     ✅      |     ⛔      |     ✅      |      ⛔       |    ⛔    |
 | Operating System     |     ✅      |     ⛔      |     ✅      |      ⛔       |    ⛔    |
 | Requirements         |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |
 | Project Site         |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |
 | Documentation        |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |
 | Support              |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |
-| Report issues        |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |
+| Report Issues        |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |
 | Twitter              |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |
-| Code repository      |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |
-| Release date         |     ✅      |     ✅      |     ⛔      |      ✅       |    ⛔    |
-| First released       |     ✅      |     ⛔      |     ⛔      |      ✅       |    ⛔    |
+| Code Repository      |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |
+| Release Date         |     ✅      |     ✅      |     ⛔      |      ✅       |    ⛔    |
+| First Released       |     ✅      |     ⛔      |     ⛔      |      ✅       |    ⛔    |
 
 ### Name
 
@@ -127,13 +127,47 @@ This file will take precedence over the `long_description` in your Python packag
 
 ### Authors
 
+This is a list of authors of the plugin.
+
+We display this on the detailed plugin page and the plugin listings.
+
+We source this from the "author" field of the JSON returned by the PyPI API.
+
+You can set this by setting the "author" of your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+
+If you wish to customize this field with a full list of authors, you can also set this field by adding authors, along with an optional [ORCID ID](https://orcid.org/), to your napari configuration file.
+
+``` YAML
+# .napari/config.yml
+
+authors:
+  - name: Shannon Axelrod
+  - name: Matthew Cai
+    orcid: 0000-0003-4998-6328
+  - name: Ambrose J. Carr
+    orcid: 0000-0002-8457-2836
+  - name: Jeremy Freeman
+    orcid: 0000-0001-7077-7972
+  - name: Deep Ganguli
+  - name: Justin T. Kiggins
+    orcid: 0000-0002-4638-7015
+  - name: Brian Long
+    orcid: 0000-0002-7793-5969
+  - name: Tony Tung
+  - name: Kevin A. Yamauchi
+    orcid: 0000-0002-7818-1388
+
+```
+
+Authors listed in your napari config file will take precedence over the `author` specified in your Python package.
+
 ### License
 
 ### Version
 
 ### Development Status
 
-### Python versions
+### Python Versions
 
 ### Operating System
 
@@ -145,12 +179,12 @@ This file will take precedence over the `long_description` in your Python packag
 
 ### Support
 
-### Report issues
+### Report Issues
 
 ### Twitter
 
-### Code repository
+### Code Repository
 
-### Release date
+### Release Date
 
-### First released
+### First Released

--- a/docs/customizing-plugin-listing.md
+++ b/docs/customizing-plugin-listing.md
@@ -94,7 +94,7 @@ We source this from the `["info"]["name"]` field of the JSON returned by the PyP
 
 You can set this by setting the `name` of your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
-``` TOML
+``` INI
 # setup.cfg
 [metadata]
 # ...
@@ -114,7 +114,7 @@ We source this from the `["info"]["summary"]` field of the JSON returned by the 
 
 You can set this by setting the `summary` of your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
-``` TOML
+``` INI
 # setup.cfg
 [metadata]
 # ...
@@ -135,7 +135,7 @@ If the `["info"]["description_content_type"]` field denotes Markdown, then this 
 
 You can set this by setting the `description` or `description-file` of your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
-``` TOML
+``` INI
 # setup.cfg
 [metadata]
 # ...
@@ -160,7 +160,7 @@ We source this from the `["info"]["author"]` field of the JSON returned by the P
 
 You can set this by setting the `author` of your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
-``` TOML
+``` INI
 # setup.cfg
 [metadata]
 # ...
@@ -209,7 +209,7 @@ You can set this by setting the `license` of your Python package in `setup.py`, 
 > You can find the full list of SPDX Identifiers at https://spdx.org/licenses/
 
 
-``` TOML
+``` INI
 # setup.cfg
 [metadata]
 # ...
@@ -242,7 +242,7 @@ If multiple "Development Status" classifiers are listed, we source one with the 
 You can set this by setting a ["Development Status" classifier](https://pypi.org/classifiers/) for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
 
-``` TOML
+``` INI
 # setup.cfg
 [metadata]
 # ...
@@ -262,7 +262,7 @@ We source this from `["info"]["requires_python"]` field of the JSON returned by 
 You can set this by [setting the `python_requires` value](https://packaging.python.org/guides/distributing-packages-using-setuptools/#id54) for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
 
-``` TOML
+``` INI
 # setup.cfg
 [metadata]
 # ...
@@ -281,7 +281,7 @@ We source this from the list of classifiers in the `["info"]["classifiers"]` fie
 You can set this by setting the relevant ["Operating System" classifiers](https://pypi.org/classifiers/) for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
 
-``` TOML
+``` INI
 # setup.cfg
 [metadata]
 # ...
@@ -292,7 +292,7 @@ classifier =
 # ...
 ```
 
-``` TOML
+``` INI
 # setup.cfg
 [metadata]
 # ...
@@ -313,7 +313,7 @@ We do not display requirements for `napari-plugin-engine` or `napari`.
 
 You can set this by setting the `install_requires` value for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
-``` TOML
+``` INI
 # setup.cfg
 [options]
 # ...
@@ -347,7 +347,7 @@ We source this from `["info"]["project_url"]` field of the JSON returned by the 
 
 You can set this by setting the `url` value for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
-``` TOML
+``` INI
 # setup.cfg
 [metadata]
 # ...
@@ -369,7 +369,7 @@ We source this from `["info"]["project_urls"]["Documentation"]` field of the JSO
 
 You can set this by adding a `Documentation` link to the `project_urls` value for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
-``` TOML
+``` INI
 # setup.cfg
 [metadata]
 # ...
@@ -392,7 +392,7 @@ We source this from `["info"]["project_urls"]["User Support"]` field of the JSON
 
 You can set this by adding a `User Support` link to the `project_urls` value for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
-``` TOML
+``` INI
 # setup.cfg
 [metadata]
 # ...
@@ -415,7 +415,7 @@ We source this from `["info"]["project_urls"]["Bug Tracker"]` field of the JSON 
 
 You can set this by adding a `Bug Tracker` link to the `project_urls` value for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
-``` TOML
+``` INI
 # setup.cfg
 [metadata]
 # ...
@@ -438,7 +438,7 @@ We source this from `["info"]["project_urls"]["Twitter"]` field of the JSON retu
 
 You can set this by adding a `Twitter` link to the `project_urls` value for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
-``` TOML
+``` INI
 # setup.cfg
 [metadata]
 # ...
@@ -457,7 +457,7 @@ We source this from `["info"]["project_urls"]["Source Code"]` field of the JSON 
 
 You can set this by adding a `Source Code` link to the `project_urls` value for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
-``` TOML
+``` INI
 # setup.cfg
 [metadata]
 # ...

--- a/docs/customizing-plugin-listing.md
+++ b/docs/customizing-plugin-listing.md
@@ -13,7 +13,7 @@ Much of the information about a napari plugin is specified in the Python package
 The PyPI API provides information about Python packages through a simple JSON structure.
 We use PyPI to source information such as the Python versions that a plugin supports, its dependencies, etc.
 
-Plugin developers can modify these fields when they package their plugin by setting values in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+Plugin developers can modify these fields when they package their plugin by setting values in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
 Fields that can be defined through the Python package configuration include the following:
 
@@ -92,7 +92,7 @@ We index this field for searching.
 
 We source this from the `["info"]["name"]` field of the JSON returned by the PyPI API.
 
-You can set this by setting the `name` of your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+You can set this by setting the `name` of your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
 ``` TOML
 # setup.cfg
@@ -112,7 +112,7 @@ We index this field for searching.
 
 We source this from the `["info"]["summary"]` field of the JSON returned by the PyPI API.
 
-You can set this by setting the `summary` of your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+You can set this by setting the `summary` of your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
 ``` TOML
 # setup.cfg
@@ -133,7 +133,7 @@ We index this field for searching.
 We source this from the `["info"]["description"]` field of the JSON returned by the PyPI API.
 If the `["info"]["description_content_type"]` field denotes Markdown, then this field will be rendered as HTML.
 
-You can set this by setting the `description` or `description-file` of your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+You can set this by setting the `description` or `description-file` of your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
 ``` TOML
 # setup.cfg
@@ -158,7 +158,7 @@ We display this on the detailed plugin page and the plugin listings.
 
 We source this from the `["info"]["author"]` field of the JSON returned by the PyPI API.
 
-You can set this by setting the `author` of your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+You can set this by setting the `author` of your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
 ``` TOML
 # setup.cfg
@@ -202,7 +202,7 @@ We display this on the detailed plugin page and the plugin listings. We support 
 
 We source this from the `["info"]["license"]` field of the JSON returned by the PyPI API.
 
-You can set this by setting the `license` of your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+You can set this by setting the `license` of your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
 > **_NOTE:_**  You must use either a valid SPDX Identifier or "Other".
 > If you specify a license here which is not an SPDX Identifier, we will display "Other".
@@ -239,7 +239,7 @@ We display this on the detailed plugin page and the plugin listings. We support 
 We source this from the list of classifiers in the `["info"]["classifiers"]` field of the JSON returned by the PyPI API.
 If multiple "Development Status" classifiers are listed, we source one with the highest value.
 
-You can set this by setting a ["Development Status" classifier](https://pypi.org/classifiers/) for your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+You can set this by setting a ["Development Status" classifier](https://pypi.org/classifiers/) for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
 
 ``` TOML
@@ -259,7 +259,7 @@ We display this on the detailed plugin page and the plugin listings. We support 
 
 We source this from `["info"]["requires_python"]` field of the JSON returned by the PyPI API.
 
-You can set this by [setting the `python_requires` value](https://packaging.python.org/guides/distributing-packages-using-setuptools/#id54) for your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+You can set this by [setting the `python_requires` value](https://packaging.python.org/guides/distributing-packages-using-setuptools/#id54) for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
 
 ``` TOML
@@ -278,7 +278,7 @@ We display this on the detailed plugin page and the plugin listings. We support 
 
 We source this from the list of classifiers in the `["info"]["classifiers"]` field of the JSON returned by the PyPI API.
 
-You can set this by setting the relevant ["Operating System" classifiers](https://pypi.org/classifiers/) for your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+You can set this by setting the relevant ["Operating System" classifiers](https://pypi.org/classifiers/) for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
 
 ``` TOML
@@ -311,7 +311,7 @@ We display this on the detailed plugin page.
 We source this from the list of requirements in the `["info"]["requires_dist"]` field of the JSON returned by the PyPI API.
 We do not display requirements for `napari-plugin-engine` or `napari`.
 
-You can set this by setting the `install_requires` value for your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+You can set this by setting the `install_requires` value for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
 ``` TOML
 # setup.cfg
@@ -345,7 +345,7 @@ We display this on the detailed plugin page.
 
 We source this from `["info"]["project_url"]` field of the JSON returned by the PyPI API.
 
-You can set this by setting the `url` value for your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+You can set this by setting the `url` value for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
 ``` TOML
 # setup.cfg
@@ -367,7 +367,7 @@ We display this on the detailed plugin page.
 
 We source this from `["info"]["project_urls"]["Documentation"]` field of the JSON returned by the PyPI API.
 
-You can set this by adding a `Documentation` link to the `project_urls` value for your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+You can set this by adding a `Documentation` link to the `project_urls` value for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
 ``` TOML
 # setup.cfg
@@ -390,7 +390,7 @@ We display this on the detailed plugin page.
 
 We source this from `["info"]["project_urls"]["User Support"]` field of the JSON returned by the PyPI API.
 
-You can set this by adding a `User Support` link to the `project_urls` value for your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+You can set this by adding a `User Support` link to the `project_urls` value for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
 ``` TOML
 # setup.cfg
@@ -413,7 +413,7 @@ We display this on the detailed plugin page.
 
 We source this from `["info"]["project_urls"]["Bug Tracker"]` field of the JSON returned by the PyPI API.
 
-You can set this by adding a `Bug Tracker` link to the `project_urls` value for your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+You can set this by adding a `Bug Tracker` link to the `project_urls` value for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
 ``` TOML
 # setup.cfg
@@ -436,7 +436,7 @@ We display this on the detailed plugin page.
 
 We source this from `["info"]["project_urls"]["Twitter"]` field of the JSON returned by the PyPI API.
 
-You can set this by adding a `Twitter` link to the `project_urls` value for your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+You can set this by adding a `Twitter` link to the `project_urls` value for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
 ``` TOML
 # setup.cfg
@@ -455,7 +455,7 @@ We display this on the detailed plugin page.
 
 We source this from `["info"]["project_urls"]["Source Code"]` field of the JSON returned by the PyPI API.
 
-You can set this by adding a `Source Code` link to the `project_urls` value for your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+You can set this by adding a `Source Code` link to the `project_urls` value for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
 
 ``` TOML
 # setup.cfg

--- a/docs/customizing-plugin-listing.md
+++ b/docs/customizing-plugin-listing.md
@@ -61,26 +61,26 @@ Fields that can be defined through the napari config include...
 
 For each of the fields in a plugin's listing, we outline below how the field is used and where we source the data.
 
-| Metadata             | Full view   |  List view  | Filterable  | Sortable      | Searched  |
-|----------------------|:-----------:|:-----------:|:-----------:|:-------------:|:---------:|
-| Name                 |     ✅      |     ✅      |     ⛔      |      ✅       |    ✅    |
-| Summary              |     ✅      |     ✅      |     ⛔      |      ⛔       |    ✅    |
-| Description          |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ✅    |
-| Authors              |     ✅      |     ✅      |     ✅      |      ⛔       |    ⛔    |
-| License              |     ✅      |     ✅      |     ✅      |      ⛔       |    ⛔    |
-| Version              |     ✅      |     ✅      |     ⛔      |      ⛔       |    ⛔    |
-| Development Status   |     ✅      |     ⛔      |     ✅      |      ⛔       |    ⛔    |
-| Python Version       |     ✅      |     ⛔      |     ✅      |      ⛔       |    ⛔    |
-| Operating System     |     ✅      |     ⛔      |     ✅      |      ⛔       |    ⛔    |
-| Requirements         |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |
-| Project Site         |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |
-| Documentation        |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |
-| Support              |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |
-| Report Issues        |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |
-| Twitter              |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |
-| Code Repository      |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |
-| Release Date         |     ✅      |     ✅      |     ⛔      |      ✅       |    ⛔    |
-| First Released       |     ✅      |     ⛔      |     ⛔      |      ✅       |    ⛔    |
+| Metadata             | Full view   |  List view  | Filterable  | Sortable      | Searched  | Source(s)  |
+|----------------------|:-----------:|:-----------:|:-----------:|:-------------:|:---------:|:---------:|
+| Name                 |     ✅      |     ✅      |     ⛔      |      ✅       |    ✅    |    <img src="https://pypi.org/static/images/logo-small.svg" height="24"> |
+| Summary              |     ✅      |     ✅      |     ⛔      |      ⛔       |    ✅    |    <img src="https://pypi.org/static/images/logo-small.svg" height="24"> |
+| Description          |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ✅    |    <img src="https://github.com/favicon.ico" height="24"> > <img src="https://pypi.org/static/images/logo-small.svg" height="24"> |
+| Authors              |     ✅      |     ✅      |     ✅      |      ⛔       |    ⛔    |    <img src="https://github.com/favicon.ico" height="24"> > <img src="https://pypi.org/static/images/logo-small.svg" height="24"> |
+| License              |     ✅      |     ✅      |     ✅      |      ⛔       |    ⛔    |    <img src="https://pypi.org/static/images/logo-small.svg" height="24"> |
+| Version              |     ✅      |     ✅      |     ⛔      |      ⛔       |    ⛔    |    <img src="https://pypi.org/static/images/logo-small.svg" height="24"> |
+| Development Status   |     ✅      |     ⛔      |     ✅      |      ⛔       |    ⛔    |    <img src="https://pypi.org/static/images/logo-small.svg" height="24"> |
+| Python Version       |     ✅      |     ⛔      |     ✅      |      ⛔       |    ⛔    |    <img src="https://pypi.org/static/images/logo-small.svg" height="24"> |
+| Operating System     |     ✅      |     ⛔      |     ✅      |      ⛔       |    ⛔    |    <img src="https://pypi.org/static/images/logo-small.svg" height="24"> |
+| Requirements         |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |    <img src="https://pypi.org/static/images/logo-small.svg" height="24"> |
+| Project Site         |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |    <img src="https://pypi.org/static/images/logo-small.svg" height="24"> |
+| Documentation        |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |    <img src="https://pypi.org/static/images/logo-small.svg" height="24"> |
+| Support              |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |    <img src="https://pypi.org/static/images/logo-small.svg" height="24"> |
+| Report Issues        |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |    <img src="https://pypi.org/static/images/logo-small.svg" height="24"> |
+| Twitter              |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |    <img src="https://pypi.org/static/images/logo-small.svg" height="24"> |
+| Code Repository      |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |    <img src="https://pypi.org/static/images/logo-small.svg" height="24"> |
+| Release Date         |     ✅      |     ✅      |     ⛔      |      ✅       |    ⛔    |    <img src="https://pypi.org/static/images/logo-small.svg" height="24"> |
+| First Released       |     ✅      |     ⛔      |     ⛔      |      ✅       |    ⛔    |    <img src="https://pypi.org/static/images/logo-small.svg" height="24"> |
 
 ### Name
 

--- a/docs/customizing-plugin-listing.md
+++ b/docs/customizing-plugin-listing.md
@@ -10,7 +10,7 @@ We have two sources of plugin information for the napari hub: PyPI and GitHub.
 ### PyPI
 
 Much of the information about a napari plugin is specified in the Python package metadata & PyPI is our primary source of plugin metadata.
-The PyPI API provides information about Python packages through a simple JSON structure.
+The [PyPI API](https://warehouse.pypa.io/api-reference/json.html) provides information about Python packages through a simple JSON structure.
 We use PyPI to source information such as the Python versions that a plugin supports, its dependencies, etc.
 
 Plugin developers can modify these fields when they package their plugin by setting values in `setup.py`, `setup.cfg`, or `pyproject.toml`.

--- a/docs/customizing-plugin-listing.md
+++ b/docs/customizing-plugin-listing.md
@@ -145,8 +145,9 @@ long_description_content_type = text/markdown
 # ...
 ```
 
-You can denote sections your plugin description by adding Level 1 Headings (e.g. `# Summary`).
-We will automatically generate sidebar navigation for your plugin from the Level 1 Headings present in your plugin description.
+You can denote sections your plugin description by adding Level 2 Headings (e.g. `## Summary`).
+We will automatically generate sidebar navigation for your plugin from the Level 2 Headings present in your plugin description.
+If your `description` begins with a Level 1 Heading, we will assume that this is a title (e.g. for your README) and drop it from the description.
 
 If you wish to customize this field with a napari-specific description which is different from the Python package description shown in PyPI, you can also set this field by adding a Markdown file to your GitHub repository at `.napari/DESCRIPTION.md`.
 This file will take precedence over the `description` in your Python package.

--- a/docs/customizing-plugin-listing.md
+++ b/docs/customizing-plugin-listing.md
@@ -1,0 +1,53 @@
+# Customizing your plugin's listing
+
+napari plugin developers can customize their plugin's listing on the napari hub by updating the metadata associated with their Python package or adding napari-specific configuration files to their Github repository.
+
+
+## Data sources
+
+## Fields
+
+For each of the fields in a plugin's listing, we outline below how the field is used and where we source the data.
+
+### Name
+
+This is the name of the Python package that implements the plugin.
+
+We display this on the detailed plugin page and the plugin listings.
+
+We index this field for searching.
+
+We source this from the "name" field of the JSON returned by the PyPI API.
+
+You can set this by setting the "name" of your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+
+### Summary
+
+This is a short summary of the plugin.
+
+We display this on the detailed plugin page and the plugin listings.
+
+We index this field for searching.
+
+We source this from the "short_description" field of the JSON returned by the PyPI API.
+
+You can set this by setting the "short_description" of your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+
+### Description
+
+This is a detailed description of the plugin.
+
+We display this on the detailed plugin page only.
+
+We index this field for searching.
+
+We source this from the "long_description" field of the JSON returned by the PyPI API.
+If the "X" field denotes Markdown, then this field will be rendered as HTML.
+
+You can set this by setting the "long_description" of your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+
+You can denote sections your plugin description by adding Level 1 Headings (e.g. `# Summary`).
+We will automatically generate sidebar navigation for your plugin from the Level 1 Headings present in your plugin description.
+
+If you wish to customize this field with a napari-specific description which is different from the Python package description shown in PyPI, you can also set this field by adding a Markdown file to your Github repository at `.napari/DESCRIPTION.md`.
+This file will take precedence over the `long_description` in your Python package.

--- a/docs/customizing-plugin-listing.md
+++ b/docs/customizing-plugin-listing.md
@@ -97,9 +97,9 @@ You can set this by setting the `name` of your Python package in `setup.py`, `se
 ``` TOML
 # setup.cfg
 [metadata]
-...
+# ...
 name=starfish
-...
+# ...
 ```
 
 ### Summary
@@ -117,9 +117,9 @@ You can set this by setting the `summary` of your Python package in `setup.py`, 
 ``` TOML
 # setup.cfg
 [metadata]
-...
+# ...
 summary = Pipelines and pipeline components for the analysis of image-based transcriptomics data
-...
+# ...
 ```
 
 ### Description
@@ -138,10 +138,10 @@ You can set this by setting the `description` or `description-file` of your Pyth
 ``` TOML
 # setup.cfg
 [metadata]
-...
+# ...
 description-file = README.md
 description-content-type = text/markdown
-...
+# ...
 ```
 
 You can denote sections your plugin description by adding Level 1 Headings (e.g. `# Summary`).
@@ -163,16 +163,16 @@ You can set this by setting the `author` of your Python package in `setup.py`, `
 ``` TOML
 # setup.cfg
 [metadata]
-...
+# ...
 author=Deep Ganguli
-...
+# ...
 ```
 
 If you wish to customize this field with a full list of authors, you can also set this field by adding authors, along with an optional [ORCID ID](https://orcid.org/) for each author, to your napari configuration file.
 
 ``` YAML
 # .napari/config.yml
-...
+# ...
 authors:
   - name: Shannon Axelrod
   - name: Matthew Cai
@@ -189,7 +189,7 @@ authors:
   - name: Tony Tung
   - name: Kevin A. Yamauchi
     orcid: 0000-0002-7818-1388
-...
+# ...
 ```
 
 Authors listed in your napari config file will take precedence over the `author` specified in your Python package.
@@ -212,9 +212,9 @@ You can set this by setting the `license` of your Python package in `setup.py`, 
 ``` TOML
 # setup.cfg
 [metadata]
-...
+# ...
 license = MIT
-...
+# ...
 ```
 
 ### Version
@@ -245,10 +245,10 @@ You can set this by setting a ["Development Status" classifier](https://pypi.org
 ``` TOML
 # setup.cfg
 [metadata]
-...
+# ...
 classifier =
   Development Status :: 5 - Production/Stable
-...
+# ...
 ```
 
 ### Python Versions
@@ -265,9 +265,9 @@ You can set this by [setting the `python_requires` value](https://packaging.pyth
 ``` TOML
 # setup.cfg
 [metadata]
-...
+# ...
 python_requires = '>=3.8'
-...
+# ...
 ```
 
 ### Operating System
@@ -284,21 +284,21 @@ You can set this by setting the relevant ["Operating System" classifiers](https:
 ``` TOML
 # setup.cfg
 [metadata]
-...
+# ...
 classifier =
   Operating System :: MacOS :: MacOS X
   Operating System :: Microsoft :: Windows
   Operating System :: POSIX :: Linux
-...
+# ...
 ```
 
 ``` TOML
 # setup.cfg
 [metadata]
-...
+# ...
 classifier =
   Operating System :: OS Independent
-...
+# ...
 ```
 
 
@@ -316,7 +316,7 @@ You can set this by setting the `install_requires` value for your Python package
 ``` TOML
 # setup.cfg
 [options]
-...
+# ...
 install_requires =
   dataclasses==0.6
   h5py
@@ -334,7 +334,7 @@ install_requires =
   trackpy
   validators
   xarray >= 0.14.1
-...
+# ...
 ```
 
 ### Project Site
@@ -350,13 +350,13 @@ You can set this by setting the `url` value for your Python package in `setup.py
 ``` TOML
 # setup.cfg
 [metadata]
-...
+# ...
 url = https://spacetx-starfish.readthedocs.io/en/latest/
 project_urls =
     Bug Tracker = https://github.com/spacetx/starfish/issues
     Documentation = https://spacetx-starfish.readthedocs.io/en/latest/
     Source Code = https://github.com/spacetx/starfish
-...
+# ...
 ```
 
 ### Documentation
@@ -372,14 +372,14 @@ You can set this by adding a `Documentation` link to the `project_urls` value fo
 ``` TOML
 # setup.cfg
 [metadata]
-...
+# ...
 url = https://spacetx-starfish.readthedocs.io/en/latest/
 project_urls =
     Bug Tracker = https://github.com/spacetx/starfish/issues
     Documentation = https://spacetx-starfish.readthedocs.io/en/latest/
     Source Code = https://github.com/spacetx/starfish
     User Support = https://forum.image.sc/tag/starfish
-...
+# ...
 ```
 
 ### User Support
@@ -395,14 +395,14 @@ You can set this by adding a `User Support` link to the `project_urls` value for
 ``` TOML
 # setup.cfg
 [metadata]
-...
+# ...
 url = https://spacetx-starfish.readthedocs.io/en/latest/
 project_urls =
     Bug Tracker = https://github.com/spacetx/starfish/issues
     Documentation = https://spacetx-starfish.readthedocs.io/en/latest/
     Source Code = https://github.com/spacetx/starfish
     User Support = https://forum.image.sc/tag/starfish
-...
+# ...
 ```
 
 ### Report Issues
@@ -418,14 +418,14 @@ You can set this by adding a `Bug Tracker` link to the `project_urls` value for 
 ``` TOML
 # setup.cfg
 [metadata]
-...
+# ...
 url = https://spacetx-starfish.readthedocs.io/en/latest/
 project_urls =
     Bug Tracker = https://github.com/spacetx/starfish/issues
     Documentation = https://spacetx-starfish.readthedocs.io/en/latest/
     Source Code = https://github.com/spacetx/starfish
     User Support = https://forum.image.sc/tag/starfish
-...
+# ...
 ```
 
 ### Twitter
@@ -441,10 +441,10 @@ You can set this by adding a `Twitter` link to the `project_urls` value for your
 ``` TOML
 # setup.cfg
 [metadata]
-...
+# ...
 project_urls =
   Twitter = https://twitter.com/napari_imaging
-...
+# ...
 ```
 
 ### Code Repository
@@ -460,12 +460,12 @@ You can set this by adding a `Source Code` link to the `project_urls` value for 
 ``` TOML
 # setup.cfg
 [metadata]
-...
+# ...
 url = https://spacetx-starfish.readthedocs.io/en/latest/
 project_urls =
     Bug Tracker = https://github.com/spacetx/starfish/issues
     Documentation = https://spacetx-starfish.readthedocs.io/en/latest/
     Source Code = https://github.com/spacetx/starfish
     User Support = https://forum.image.sc/tag/starfish
-...
+# ...
 ```

--- a/docs/customizing-plugin-listing.md
+++ b/docs/customizing-plugin-listing.md
@@ -5,6 +5,58 @@ napari plugin developers can customize their plugin's listing on the napari hub 
 
 ## Data sources
 
+We have two sources of plugin information for the napari hub: PyPI and GitHub.
+
+### PyPI
+
+Much of the information about a napari plugin is specified in the Python package metadata & PyPI is our primary source of plugin metadata.
+The PyPI API provides information about Python packages through a simple JSON structure.
+We use PyPI to source information such as the Python versions that a plugin supports, its dependencies, etc.
+
+Plugin developers can modify these fields when they package their plugin by setting values in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+
+Fields that can be defined through the Python package configuration include the following:
+
+- [Plugin Name](#plugin-name)
+- [Summary](#summary)
+- [Description](#description)
+- [Authors](#authors)
+- [License](#license)
+- [Version](#version)
+- [Python versions](#python-versions)
+- [Operating System](#operating-system)
+- [Requirements](#requirements)
+- [Development Status](#development-status)
+- [Project Site](#project-site)
+- [Documentation](#documentation)
+- [Support](#support)
+- [Report issues](#report-issues)
+- [Twitter](#twitter)
+- [Code repository](#code-repository)
+
+### GitHub
+
+For some fields, we look to the plugin developer's GitHub repository instead of (or in addition to) PyPI.
+This is only supported, however, if the plugin developer has added a link to their GitHub repository in their PyPI metadata.
+(TODO: Specify which fields we will look for links to the GitHub repo)
+
+Plugin developers can modify these fields by adding a `.napari` configuration folder to their repository, along with the relevant configuration files for a given field.
+We currently support two configuration files:
+
+- `.napari/DESCRIPTION.md` for a napari-specific description
+- `.napari/config.yml` for all other fields that can be configured
+
+Fields that can be defined through the napari config include...
+
+- [Summary](#summary)
+- [Description](#description)
+- [Authors](#authors)
+- [Project Site](#project-site)
+- [Documentation](#documentation)
+- [Support](#support)
+- [Report issues](#report-issues)
+- [Twitter](#twitter)
+
 ## Fields
 
 For each of the fields in a plugin's listing, we outline below how the field is used and where we source the data.
@@ -49,5 +101,35 @@ You can set this by setting the "long_description" of your Python package in `se
 You can denote sections your plugin description by adding Level 1 Headings (e.g. `# Summary`).
 We will automatically generate sidebar navigation for your plugin from the Level 1 Headings present in your plugin description.
 
-If you wish to customize this field with a napari-specific description which is different from the Python package description shown in PyPI, you can also set this field by adding a Markdown file to your Github repository at `.napari/DESCRIPTION.md`.
+If you wish to customize this field with a napari-specific description which is different from the Python package description shown in PyPI, you can also set this field by adding a Markdown file to your GitHub repository at `.napari/DESCRIPTION.md`.
 This file will take precedence over the `long_description` in your Python package.
+
+### Authors
+
+### License
+
+### Version
+
+### Development Status
+
+### Python versions
+
+### Operating System
+
+### Requirements
+
+### Project Site
+
+### Documentation
+
+### Support
+
+### Report issues
+
+### Twitter
+
+### Code repository
+
+### Release date
+
+### First released

--- a/docs/customizing-plugin-listing.md
+++ b/docs/customizing-plugin-listing.md
@@ -1,6 +1,6 @@
 # Customizing your plugin's listing
 
-napari plugin developers can customize their plugin's listing on the napari hub by updating the metadata associated with their Python package or adding napari-specific configuration files to their Github repository.
+napari plugin developers can customize their plugin's listing on the napari hub by updating the metadata associated with their Python package or adding napari-specific configuration files to their GitHub repository.
 
 
 ## Data sources

--- a/docs/customizing-plugin-listing.md
+++ b/docs/customizing-plugin-listing.md
@@ -61,26 +61,26 @@ Fields that can be defined through the napari config include...
 
 For each of the fields in a plugin's listing, we outline below how the field is used and where we source the data.
 
-| Metadata            	| Full view 	| Card view 	| Filterable 	| Sortable     	| Searched 	|
-|---------------------	|-----------	|-----------	|-----------	|-------------	|--------	|
-| Name                	|     ✅     	|     ✅     	|     ⛔     	|      ✅      	|    ✅   	|
-| Summary             	|     ✅     	|     ✅     	|     ⛔     	|      ⛔      	|    ✅   	|
-| Description         	|     ✅     	|     ⛔     	|     ⛔     	|      ⛔      	|    ✅   	|
-| Authors             	|     ✅     	|     ✅     	|     ✅     	|      ⛔      	|    ⛔   	|
-| License             	|     ✅     	|     ✅     	|     ✅     	|      ⛔      	|    ⛔   	|
-| Version             	|     ✅     	|     ✅     	|     ⛔     	|      ⛔      	|    ⛔   	|
-| Development Status  	|     ✅     	|     ⛔     	|     ✅     	|      ⛔      	|    ⛔   	|
-| Python version(s)   	|     ✅     	|     ⛔     	|     ✅     	|      ⛔      	|    ⛔   	|
-| Operating System    	|     ✅     	|     ⛔     	|     ✅     	|      ⛔      	|    ⛔   	|
-| Requirements        	|     ✅     	|     ⛔     	|     ⛔     	|      ⛔      	|    ⛔   	|
-| Project Site        	|     ✅     	|     ⛔     	|     ⛔     	|      ⛔      	|    ⛔   	|
-| Documentation       	|     ✅     	|     ⛔     	|     ⛔     	|      ⛔      	|    ⛔   	|
-| Support             	|     ✅     	|     ⛔     	|     ⛔     	|      ⛔      	|    ⛔   	|
-| Report issues       	|     ✅     	|     ⛔     	|     ⛔     	|      ⛔      	|    ⛔   	|
-| Twitter             	|     ✅     	|     ⛔     	|     ⛔     	|      ⛔      	|    ⛔   	|
-| Code repository     	|     ✅     	|     ⛔     	|     ⛔     	|      ⛔      	|    ⛔   	|
-| Release date        	|     ✅     	|     ✅     	|     ⛔     	|      ✅      	|    ⛔   	|
-| First released      	|     ✅     	|     ⛔     	|     ⛔     	|      ✅      	|    ⛔   	|
+| Metadata             | Full view   |  Card view  | Filterable  | Sortable      | Searched  |
+|----------------------|:-----------:|:-----------:|:-----------:|:-------------:|:---------:|
+| Name                 |     ✅      |     ✅      |     ⛔      |      ✅       |    ✅    |
+| Summary              |     ✅      |     ✅      |     ⛔      |      ⛔       |    ✅    |
+| Description          |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ✅    |
+| Authors              |     ✅      |     ✅      |     ✅      |      ⛔       |    ⛔    |
+| License              |     ✅      |     ✅      |     ✅      |      ⛔       |    ⛔    |
+| Version              |     ✅      |     ✅      |     ⛔      |      ⛔       |    ⛔    |
+| Development Status   |     ✅      |     ⛔      |     ✅      |      ⛔       |    ⛔    |
+| Python version(s)    |     ✅      |     ⛔      |     ✅      |      ⛔       |    ⛔    |
+| Operating System     |     ✅      |     ⛔      |     ✅      |      ⛔       |    ⛔    |
+| Requirements         |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |
+| Project Site         |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |
+| Documentation        |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |
+| Support              |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |
+| Report issues        |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |
+| Twitter              |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |
+| Code repository      |     ✅      |     ⛔      |     ⛔      |      ⛔       |    ⛔    |
+| Release date         |     ✅      |     ✅      |     ⛔      |      ✅       |    ⛔    |
+| First released       |     ✅      |     ⛔      |     ⛔      |      ✅       |    ⛔    |
 
 ### Name
 

--- a/docs/customizing-plugin-listing.md
+++ b/docs/customizing-plugin-listing.md
@@ -139,8 +139,8 @@ You can set this by setting the `description` or `description-file` of your Pyth
 # setup.cfg
 [metadata]
 ...
-description-file = README.rst
-description-content-type = text/x-rst; charset=UTF-8
+description-file = README.md
+description-content-type = text/markdown
 ...
 ```
 

--- a/docs/customizing-plugin-listing.md
+++ b/docs/customizing-plugin-listing.md
@@ -17,7 +17,7 @@ Plugin developers can modify these fields when they package their plugin by sett
 
 Fields that can be defined through the Python package configuration include the following:
 
-- [Plugin Name](#plugin-name)
+- [Name](#name)
 - [Summary](#summary)
 - [Description](#description)
 - [Authors](#authors)
@@ -60,6 +60,26 @@ Fields that can be defined through the napari config include...
 ## Fields
 
 For each of the fields in a plugin's listing, we outline below how the field is used and where we source the data.
+| Metadata            	| Full view 	| Card view 	| Filterable 	| Sortable     	| Searched 	|
+|---------------------	|-----------	|-----------	|-----------	|-------------	|--------	|
+| Name                	|     ✅     	|     ✅     	|     ⛔     	|      ✅      	|    ✅   	|
+| Summary             	|     ✅     	|     ✅     	|     ⛔     	|      ⛔      	|    ✅   	|
+| Description         	|     ✅     	|     ⛔     	|     ⛔     	|      ⛔      	|    ✅   	|
+| Authors             	|     ✅     	|     ✅     	|     ✅     	|      ⛔      	|    ⛔   	|
+| License             	|     ✅     	|     ✅     	|     ✅     	|      ⛔      	|    ⛔   	|
+| Version             	|     ✅     	|     ✅     	|     ⛔     	|      ⛔      	|    ⛔   	|
+| Development Status  	|     ✅     	|     ⛔     	|     ✅     	|      ⛔      	|    ⛔   	|
+| Python version(s)   	|     ✅     	|     ⛔     	|     ✅     	|      ⛔      	|    ⛔   	|
+| Operating System    	|     ✅     	|     ⛔     	|     ✅     	|      ⛔      	|    ⛔   	|
+| Requirements        	|     ✅     	|     ⛔     	|     ⛔     	|      ⛔      	|    ⛔   	|
+| Project Site        	|     ✅     	|     ⛔     	|     ⛔     	|      ⛔      	|    ⛔   	|
+| Documentation       	|     ✅     	|     ⛔     	|     ⛔     	|      ⛔      	|    ⛔   	|
+| Support             	|     ✅     	|     ⛔     	|     ⛔     	|      ⛔      	|    ⛔   	|
+| Report issues       	|     ✅     	|     ⛔     	|     ⛔     	|      ⛔      	|    ⛔   	|
+| Twitter             	|     ✅     	|     ⛔     	|     ⛔     	|      ⛔      	|    ⛔   	|
+| Code repository     	|     ✅     	|     ⛔     	|     ⛔     	|      ⛔      	|    ⛔   	|
+| Release date        	|     ✅     	|     ✅     	|     ⛔     	|      ✅      	|    ⛔   	|
+| First released      	|     ✅     	|     ⛔     	|     ⛔     	|      ✅      	|    ⛔   	|
 
 ### Name
 

--- a/docs/customizing-plugin-listing.md
+++ b/docs/customizing-plugin-listing.md
@@ -43,7 +43,7 @@ This is only supported, however, if the plugin developer has added a link to the
 Plugin developers can modify these fields by adding a `.napari` configuration folder to their repository, along with the relevant configuration files for a given field.
 We currently support two configuration files:
 
-- `.napari/DESCRIPTION.md` for a napari-specific description
+- `.napari/DESCRIPTION.md` for a napari-specific description (see [Description](#description))
 - `.napari/config.yml` for all other fields that can be configured
 
 Fields that can be defined through the napari config include...

--- a/docs/customizing-plugin-listing.md
+++ b/docs/customizing-plugin-listing.md
@@ -13,7 +13,7 @@ Much of the information about a napari plugin is specified in the Python package
 The [PyPI API](https://warehouse.pypa.io/api-reference/json.html) provides information about Python packages through a simple JSON structure.
 We use PyPI to source information such as the Python versions that a plugin supports, its dependencies, etc.
 
-Plugin developers can modify these fields when they package their plugin by setting values in `setup.py`, `setup.cfg`, or `pyproject.toml`.
+Plugin developers can modify these fields when they package their plugin by setting values in your package metadata.
 
 Fields that can be defined through the Python package configuration include the following:
 
@@ -92,7 +92,7 @@ We index this field for searching.
 
 We source this from the `["info"]["name"]` field of the JSON returned by the PyPI API.
 
-You can set this by setting the `name` of your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
+You can set this by setting the `name` value in your package metadata.
 
 ``` INI
 # setup.cfg
@@ -112,7 +112,7 @@ We index this field for searching.
 
 We source this from the `["info"]["summary"]` field of the JSON returned by the PyPI API.
 
-You can set this by setting the `summary` of your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
+You can set this by setting the `summary` value in your package metadata.
 
 ``` INI
 # setup.cfg
@@ -133,7 +133,7 @@ We index this field for searching.
 We source this from the `["info"]["description"]` field of the JSON returned by the PyPI API.
 If the `["info"]["description_content_type"]` field denotes Markdown, then this field will be rendered as HTML.
 
-You can set this by setting the `description` or `description-file` of your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
+You can set this by setting the `description` or `description-file` value in your package metadata.
 
 ``` INI
 # setup.cfg
@@ -158,7 +158,7 @@ We display this on the detailed plugin page and the plugin listings.
 
 We source this from the `["info"]["author"]` field of the JSON returned by the PyPI API.
 
-You can set this by setting the `author` of your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
+You can set this by setting the `author` value in your package metadata.
 
 ``` INI
 # setup.cfg
@@ -202,7 +202,7 @@ We display this on the detailed plugin page and the plugin listings. We support 
 
 We source this from the `["info"]["license"]` field of the JSON returned by the PyPI API.
 
-You can set this by setting the `license` of your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
+You can set this by setting the `license` value in your package metadata.
 
 > **_NOTE:_**  You must use either a valid SPDX Identifier or "Other".
 > If you specify a license here which is not an SPDX Identifier, we will display "Other".
@@ -239,7 +239,7 @@ We display this on the detailed plugin page and the plugin listings. We support 
 We source this from the list of classifiers in the `["info"]["classifiers"]` field of the JSON returned by the PyPI API.
 If multiple "Development Status" classifiers are listed, we source one with the highest value.
 
-You can set this by setting a ["Development Status" classifier](https://pypi.org/classifiers/) for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
+You can set this by setting a ["Development Status" classifier](https://pypi.org/classifiers/) for your Python package in your package metadata.
 
 
 ``` INI
@@ -259,7 +259,7 @@ We display this on the detailed plugin page and the plugin listings. We support 
 
 We source this from `["info"]["requires_python"]` field of the JSON returned by the PyPI API.
 
-You can set this by [setting the `python_requires` value](https://packaging.python.org/guides/distributing-packages-using-setuptools/#id54) for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
+You can set this by [setting the `python_requires` value](https://packaging.python.org/guides/distributing-packages-using-setuptools/#id54) for your Python package in your package metadata.
 
 
 ``` INI
@@ -278,7 +278,7 @@ We display this on the detailed plugin page and the plugin listings. We support 
 
 We source this from the list of classifiers in the `["info"]["classifiers"]` field of the JSON returned by the PyPI API.
 
-You can set this by setting the relevant ["Operating System" classifiers](https://pypi.org/classifiers/) for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
+You can set this by setting the relevant ["Operating System" classifiers](https://pypi.org/classifiers/) for your Python package in your package metadata.
 
 
 ``` INI
@@ -311,7 +311,7 @@ We display this on the detailed plugin page.
 We source this from the list of requirements in the `["info"]["requires_dist"]` field of the JSON returned by the PyPI API.
 We do not display requirements for `napari-plugin-engine` or `napari`.
 
-You can set this by setting the `install_requires` value for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
+You can set this by setting the `install_requires` value for your Python package in your package metadata.
 
 ``` INI
 # setup.cfg
@@ -345,7 +345,7 @@ We display this on the detailed plugin page.
 
 We source this from `["info"]["project_url"]` field of the JSON returned by the PyPI API.
 
-You can set this by setting the `url` value for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
+You can set this by setting the `url` value for your Python package in your package metadata.
 
 ``` INI
 # setup.cfg
@@ -367,7 +367,7 @@ We display this on the detailed plugin page.
 
 We source this from `["info"]["project_urls"]["Documentation"]` field of the JSON returned by the PyPI API.
 
-You can set this by adding a `Documentation` link to the `project_urls` value for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
+You can set this by adding a `Documentation` link to the `project_urls` value for your Python package in your package metadata.
 
 ``` INI
 # setup.cfg
@@ -390,7 +390,7 @@ We display this on the detailed plugin page.
 
 We source this from `["info"]["project_urls"]["User Support"]` field of the JSON returned by the PyPI API.
 
-You can set this by adding a `User Support` link to the `project_urls` value for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
+You can set this by adding a `User Support` link to the `project_urls` value for your Python package in your package metadata.
 
 ``` INI
 # setup.cfg
@@ -413,7 +413,7 @@ We display this on the detailed plugin page.
 
 We source this from `["info"]["project_urls"]["Bug Tracker"]` field of the JSON returned by the PyPI API.
 
-You can set this by adding a `Bug Tracker` link to the `project_urls` value for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
+You can set this by adding a `Bug Tracker` link to the `project_urls` value for your Python package in your package metadata.
 
 ``` INI
 # setup.cfg
@@ -436,7 +436,7 @@ We display this on the detailed plugin page.
 
 We source this from `["info"]["project_urls"]["Twitter"]` field of the JSON returned by the PyPI API.
 
-You can set this by adding a `Twitter` link to the `project_urls` value for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
+You can set this by adding a `Twitter` link to the `project_urls` value for your Python package in your package metadata.
 
 ``` INI
 # setup.cfg
@@ -455,7 +455,7 @@ We display this on the detailed plugin page.
 
 We source this from `["info"]["project_urls"]["Source Code"]` field of the JSON returned by the PyPI API.
 
-You can set this by adding a `Source Code` link to the `project_urls` value for your Python package in `setup.py`, `setup.cfg`, or `pyproject.toml`.
+You can set this by adding a `Source Code` link to the `project_urls` value for your Python package in your package metadata.
 
 ``` INI
 # setup.cfg

--- a/docs/customizing-plugin-listing.md
+++ b/docs/customizing-plugin-listing.md
@@ -9,11 +9,12 @@ We have two sources of plugin information for the napari hub: PyPI and GitHub.
 
 ### PyPI
 
-Much of the information about a napari plugin is specified in the Python package metadata & PyPI is our primary source of plugin metadata.
+napari and the napari hub support discovery of plugins on PyPI that are tagged with the `"Framework :: Napari"` trove classifier (we do not currently support discovery of plugins on Anaconda cloud).
+Most of the information about a napari plugin is specified in the [Python package metadata](https://packaging.python.org/specifications/core-metadata/) & PyPI is our primary source of plugin metadata.
 The [PyPI API](https://warehouse.pypa.io/api-reference/json.html) provides information about Python packages through a simple JSON structure.
 We use PyPI to source information such as the Python versions that a plugin supports, its dependencies, etc.
 
-Plugin developers can modify these fields when they package their plugin by setting values in your package metadata.
+Plugin developers can modify these fields when they package their plugin by setting values in the [Python package metadata](https://packaging.python.org/specifications/core-metadata/).
 
 Fields that can be defined through the Python package configuration include the following:
 
@@ -133,14 +134,14 @@ We index this field for searching.
 We source this from the `["info"]["description"]` field of the JSON returned by the PyPI API.
 If the `["info"]["description_content_type"]` field denotes Markdown, then this field will be rendered as HTML.
 
-You can set this by setting the `description` or `description-file` value in your package metadata.
+You can set this by setting the `long_description` value in your package metadata.
 
 ``` INI
 # setup.cfg
 [metadata]
 # ...
-description-file = README.md
-description-content-type = text/markdown
+long_description = README.md
+long_description_content_type = text/markdown
 # ...
 ```
 

--- a/docs/customizing-plugin-listing.md
+++ b/docs/customizing-plugin-listing.md
@@ -38,8 +38,7 @@ Fields that can be defined through the Python package configuration include the 
 ### GitHub
 
 For some fields, we look to the plugin developer's GitHub repository instead of (or in addition to) PyPI.
-This is only supported, however, if the plugin developer has added a link to their GitHub repository in their PyPI metadata.
-(TODO: Specify which fields we will look for links to the GitHub repo)
+This is only supported, however, if the plugin developer has added a link to their GitHub repository in their PyPI metadata (see [Code Repository](#code-repository)).
 
 Plugin developers can modify these fields by adding a `.napari` configuration folder to their repository, along with the relevant configuration files for a given field.
 We currently support two configuration files:

--- a/docs/customizing-plugin-listing.md
+++ b/docs/customizing-plugin-listing.md
@@ -90,9 +90,17 @@ We display this on the detailed plugin page and the plugin listings.
 
 We index this field for searching.
 
-We source this from the "name" field of the JSON returned by the PyPI API.
+We source this from the `["info"]["name"]` field of the JSON returned by the PyPI API.
 
-You can set this by setting the "name" of your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+You can set this by setting the `name` of your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+
+``` TOML
+# setup.cfg
+[metadata]
+...
+name=starfish
+...
+```
 
 ### Summary
 
@@ -102,9 +110,17 @@ We display this on the detailed plugin page and the plugin listings.
 
 We index this field for searching.
 
-We source this from the "short_description" field of the JSON returned by the PyPI API.
+We source this from the `["info"]["summary"]` field of the JSON returned by the PyPI API.
 
-You can set this by setting the "short_description" of your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+You can set this by setting the `summary` of your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+
+``` TOML
+# setup.cfg
+[metadata]
+...
+summary = Pipelines and pipeline components for the analysis of image-based transcriptomics data
+...
+```
 
 ### Description
 
@@ -114,16 +130,25 @@ We display this on the detailed plugin page only.
 
 We index this field for searching.
 
-We source this from the "long_description" field of the JSON returned by the PyPI API.
-If the "X" field denotes Markdown, then this field will be rendered as HTML.
+We source this from the `["info"]["description"]` field of the JSON returned by the PyPI API.
+If the `["info"]["description_content_type"]` field denotes Markdown, then this field will be rendered as HTML.
 
-You can set this by setting the "long_description" of your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+You can set this by setting the `description` or `description-file` of your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+
+``` TOML
+# setup.cfg
+[metadata]
+...
+description-file = README.rst
+description-content-type = text/x-rst; charset=UTF-8
+...
+```
 
 You can denote sections your plugin description by adding Level 1 Headings (e.g. `# Summary`).
 We will automatically generate sidebar navigation for your plugin from the Level 1 Headings present in your plugin description.
 
 If you wish to customize this field with a napari-specific description which is different from the Python package description shown in PyPI, you can also set this field by adding a Markdown file to your GitHub repository at `.napari/DESCRIPTION.md`.
-This file will take precedence over the `long_description` in your Python package.
+This file will take precedence over the `description` in your Python package.
 
 ### Authors
 
@@ -131,15 +156,23 @@ This is a list of authors of the plugin.
 
 We display this on the detailed plugin page and the plugin listings.
 
-We source this from the "author" field of the JSON returned by the PyPI API.
+We source this from the `["info"]["author"]` field of the JSON returned by the PyPI API.
 
-You can set this by setting the "author" of your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+You can set this by setting the `author` of your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
 
-If you wish to customize this field with a full list of authors, you can also set this field by adding authors, along with an optional [ORCID ID](https://orcid.org/), to your napari configuration file.
+``` TOML
+# setup.cfg
+[metadata]
+...
+author=Deep Ganguli
+...
+```
+
+If you wish to customize this field with a full list of authors, you can also set this field by adding authors, along with an optional [ORCID ID](https://orcid.org/) for each author, to your napari configuration file.
 
 ``` YAML
 # .napari/config.yml
-
+...
 authors:
   - name: Shannon Axelrod
   - name: Matthew Cai
@@ -156,35 +189,283 @@ authors:
   - name: Tony Tung
   - name: Kevin A. Yamauchi
     orcid: 0000-0002-7818-1388
-
+...
 ```
 
 Authors listed in your napari config file will take precedence over the `author` specified in your Python package.
 
 ### License
 
+This is the [SPDX Identifier](https://spdx.org/licenses/) for the license that the plugin is distributed under.
+
+We display this on the detailed plugin page and the plugin listings. We support filtering plugins based on this value.
+
+We source this from the `["info"]["license"]` field of the JSON returned by the PyPI API.
+
+You can set this by setting the `license` of your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+
+> **_NOTE:_**  You must use either a valid SPDX Identifier or "Other".
+> If you specify a license here which is not an SPDX Identifier, we will display "Other".
+> You can find the full list of SPDX Identifiers at https://spdx.org/licenses/
+
+
+``` TOML
+# setup.cfg
+[metadata]
+...
+license = MIT
+...
+```
+
 ### Version
+
+This is the version of the latest release of your plugin.
+
+We display this on the detailed plugin page and the plugin listings.
+
+We source this from the key of the latest release listed under `["releases"]` in the PyPI API.
+
+You can set this by setting the `version` of your Python package.
+See the [Python Packaging User Guide](https://packaging.python.org/guides/distributing-packages-using-setuptools/#version) for more info.
+
+> **_NOTE:_**  We strongly encourage plugin developers to use Semantic Versioning, along with Python conventions for pre-releases (see [PEP 440](https://www.python.org/dev/peps/pep-0440/)).
 
 ### Development Status
 
+This is the development status of your plugin.
+
+We display this on the detailed plugin page and the plugin listings. We support filtering plugins based on this value.
+
+We source this from the list of classifiers in the `["info"]["classifiers"]` field of the JSON returned by the PyPI API.
+If multiple "Development Status" classifiers are listed, we source one with the highest value.
+
+You can set this by setting a ["Development Status" classifier](https://pypi.org/classifiers/) for your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+
+
+``` TOML
+# setup.cfg
+[metadata]
+...
+classifier =
+  Development Status :: 5 - Production/Stable
+...
+```
+
 ### Python Versions
+
+These are the Python versions your plugin supports.
+
+We display this on the detailed plugin page and the plugin listings. We support filtering plugins based on this value.
+
+We source this from `["info"]["requires_python"]` field of the JSON returned by the PyPI API.
+
+You can set this by [setting the `python_requires` value](https://packaging.python.org/guides/distributing-packages-using-setuptools/#id54) for your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+
+
+``` TOML
+# setup.cfg
+[metadata]
+...
+python_requires = '>=3.8'
+...
+```
 
 ### Operating System
 
+These are the operating systems your plugin supports.
+
+We display this on the detailed plugin page and the plugin listings. We support filtering plugins based on this value.
+
+We source this from the list of classifiers in the `["info"]["classifiers"]` field of the JSON returned by the PyPI API.
+
+You can set this by setting the relevant ["Operating System" classifiers](https://pypi.org/classifiers/) for your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+
+
+``` TOML
+# setup.cfg
+[metadata]
+...
+classifier =
+  Operating System :: MacOS :: MacOS X
+  Operating System :: Microsoft :: Windows
+  Operating System :: POSIX :: Linux
+...
+```
+
+``` TOML
+# setup.cfg
+[metadata]
+...
+classifier =
+  Operating System :: OS Independent
+...
+```
+
+
 ### Requirements
+
+This is a list of Python packages that are required by your plugin.
+
+We display this on the detailed plugin page.
+
+We source this from the list of requirements in the `["info"]["requires_dist"]` field of the JSON returned by the PyPI API.
+We do not display requirements for `napari-plugin-engine` or `napari`.
+
+You can set this by setting the `install_requires` value for your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+
+``` TOML
+# setup.cfg
+[options]
+...
+install_requires =
+  dataclasses==0.6
+  h5py
+  jsonschema
+  matplotlib
+  napari-plugin-engine
+  numpy != 1.13.0
+  pandas >= 0.23.4
+  read_roi
+  regional
+  scikit-image >= 0.14.0
+  scikit-learn
+  scipy
+  sympy ~= 1.5.0
+  trackpy
+  validators
+  xarray >= 0.14.1
+...
+```
 
 ### Project Site
 
+This is a link to the main project site for your plugin.
+
+We display this on the detailed plugin page.
+
+We source this from `["info"]["project_url"]` field of the JSON returned by the PyPI API.
+
+You can set this by setting the `url` value for your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+
+``` TOML
+# setup.cfg
+[metadata]
+...
+url = https://spacetx-starfish.readthedocs.io/en/latest/
+project_urls =
+    Bug Tracker = https://github.com/spacetx/starfish/issues
+    Documentation = https://spacetx-starfish.readthedocs.io/en/latest/
+    Source Code = https://github.com/spacetx/starfish
+...
+```
+
 ### Documentation
 
-### Support
+This is a link to further documentation for your plugin.
+
+We display this on the detailed plugin page.
+
+We source this from `["info"]["project_urls"]["Documentation"]` field of the JSON returned by the PyPI API.
+
+You can set this by adding a `Documentation` link to the `project_urls` value for your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+
+``` TOML
+# setup.cfg
+[metadata]
+...
+url = https://spacetx-starfish.readthedocs.io/en/latest/
+project_urls =
+    Bug Tracker = https://github.com/spacetx/starfish/issues
+    Documentation = https://spacetx-starfish.readthedocs.io/en/latest/
+    Source Code = https://github.com/spacetx/starfish
+    User Support = https://forum.image.sc/tag/starfish
+...
+```
+
+### User Support
+
+This is a link to user support for your plugin.
+
+We display this on the detailed plugin page.
+
+We source this from `["info"]["project_urls"]["User Support"]` field of the JSON returned by the PyPI API.
+
+You can set this by adding a `User Support` link to the `project_urls` value for your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+
+``` TOML
+# setup.cfg
+[metadata]
+...
+url = https://spacetx-starfish.readthedocs.io/en/latest/
+project_urls =
+    Bug Tracker = https://github.com/spacetx/starfish/issues
+    Documentation = https://spacetx-starfish.readthedocs.io/en/latest/
+    Source Code = https://github.com/spacetx/starfish
+    User Support = https://forum.image.sc/tag/starfish
+...
+```
 
 ### Report Issues
 
+This is a link to where users can report issues with your plugin.
+
+We display this on the detailed plugin page.
+
+We source this from `["info"]["project_urls"]["Bug Tracker"]` field of the JSON returned by the PyPI API.
+
+You can set this by adding a `Bug Tracker` link to the `project_urls` value for your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+
+``` TOML
+# setup.cfg
+[metadata]
+...
+url = https://spacetx-starfish.readthedocs.io/en/latest/
+project_urls =
+    Bug Tracker = https://github.com/spacetx/starfish/issues
+    Documentation = https://spacetx-starfish.readthedocs.io/en/latest/
+    Source Code = https://github.com/spacetx/starfish
+    User Support = https://forum.image.sc/tag/starfish
+...
+```
+
 ### Twitter
+
+This is a link to the Twitter feed for your plugin.
+
+We display this on the detailed plugin page.
+
+We source this from `["info"]["project_urls"]["Twitter"]` field of the JSON returned by the PyPI API.
+
+You can set this by adding a `Twitter` link to the `project_urls` value for your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+
+``` TOML
+# setup.cfg
+[metadata]
+...
+project_urls =
+  Twitter = https://twitter.com/napari_imaging
+...
+```
 
 ### Code Repository
 
-### Release Date
+This is a link to the source code repository for your plugin.
 
-### First Released
+We display this on the detailed plugin page.
+
+We source this from `["info"]["project_urls"]["Source Code"]` field of the JSON returned by the PyPI API.
+
+You can set this by adding a `Source Code` link to the `project_urls` value for your Python package in `setup.py`, `setup.cfg`, or `pypackage.toml`.
+
+``` TOML
+# setup.cfg
+[metadata]
+...
+url = https://spacetx-starfish.readthedocs.io/en/latest/
+project_urls =
+    Bug Tracker = https://github.com/spacetx/starfish/issues
+    Documentation = https://spacetx-starfish.readthedocs.io/en/latest/
+    Source Code = https://github.com/spacetx/starfish
+    User Support = https://forum.image.sc/tag/starfish
+...
+```

--- a/docs/customizing-plugin-listing.md
+++ b/docs/customizing-plugin-listing.md
@@ -60,6 +60,7 @@ Fields that can be defined through the napari config include...
 ## Fields
 
 For each of the fields in a plugin's listing, we outline below how the field is used and where we source the data.
+
 | Metadata            	| Full view 	| Card view 	| Filterable 	| Sortable     	| Searched 	|
 |---------------------	|-----------	|-----------	|-----------	|-------------	|--------	|
 | Name                	|     ✅     	|     ✅     	|     ⛔     	|      ✅      	|    ✅   	|


### PR DESCRIPTION
This PR adds documentation for plugin developers on how to customize their plugin listing in the napari hub.

It adds a markdown file that describes where we source metadata from PyPI and Github, which fields take precedence in ambiguous circumstances, and how plugin developers can customize the information about their plugin.