### PR TITLE
Markdown TOC component

### DIFF
--- a/client/eslint/typescript.js
+++ b/client/eslint/typescript.js
@@ -15,6 +15,9 @@ module.exports = {
   plugins: ['simple-import-sort'],
 
   rules: {
+    // Throws errors for exported functions, which is a common pattern with ES modules.
+    '@typescript-eslint/unbound-method': 'off',
+
     // Named exports are nicer to work with for a variety of reasons:
     // https://basarat.gitbook.io/typescript/main-1/defaultisbad
     'import/no-default-export': 'error',

--- a/client/package.json
+++ b/client/package.json
@@ -26,9 +26,13 @@
     "@mdx-js/loader": "^1.6.22",
     "@mdx-js/react": "^1.6.22",
     "@next/mdx": "^10.1.3",
+    "@testing-library/react-hooks": "^5.1.2",
+    "@types/lodash-es": "^4.17.4",
+    "@types/unist": "^2.0.3",
     "axios": "^0.21.1",
     "clsx": "^1.1.1",
     "framer-motion": "^4.1.3",
+    "lodash-es": "^4.17.21",
     "next": "10.1.3",
     "next-dynamic-loading-props": "^0.1.1",
     "react": "17.0.2",
@@ -37,8 +41,13 @@
     "react-query": "^3.13.5",
     "react-syntax-highlighter": "^15.4.3",
     "react-use": "^17.2.3",
+    "rehype-slug": "^4.0.1",
+    "rehype-stringify": "^8.0.0",
     "remark-gfm": "^1.0.0",
-    "remark-remove-comments": "^0.2.0"
+    "remark-parse": "^9.0.0",
+    "remark-rehype": "^8.1.0",
+    "remark-remove-comments": "^0.2.0",
+    "unified": "^9.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.13.15",

--- a/client/src/components/AppBar/AppBar.tsx
+++ b/client/src/components/AppBar/AppBar.tsx
@@ -92,10 +92,10 @@ export function AppBar() {
           'gap-6 md:gap-12',
 
           // Change to 2 column grid layout when 2xl+ screens
-          '2xl:grid 2xl:grid-cols-napari-2-col',
+          '2xl:grid 2xl:grid-cols-napari-app-bar-2-col',
 
           // Use 3 column layout when 3xl+ screens
-          '3xl:grid-cols-napari-3-col',
+          '3xl:grid 3xl:grid-cols-napari-3-col',
         )}
       >
         <AppBarHeader />

--- a/client/src/components/AppBar/__snapshots__/AppBar.test.tsx.snap
+++ b/client/src/components/AppBar/__snapshots__/AppBar.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`<AppBar /> should match snapshot 1`] = `
     </button>
   </div>
   <nav
-    class="bg-napari-primary h-napari-app-bar px-6 md:px-12 2xl:p-0 grid grid-cols-napari-nav-mobile justify-center items-center gap-6 md:gap-12 2xl:grid 2xl:grid-cols-napari-2-col 3xl:grid-cols-napari-3-col"
+    class="bg-napari-primary h-napari-app-bar px-6 md:px-12 2xl:p-0 grid grid-cols-napari-nav-mobile justify-center items-center gap-6 md:gap-12 2xl:grid 2xl:grid-cols-napari-app-bar-2-col 3xl:grid 3xl:grid-cols-napari-3-col"
   >
     <header
       class="flex"

--- a/client/src/components/Layout/__snapshots__/Layout.test.tsx.snap
+++ b/client/src/components/Layout/__snapshots__/Layout.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`<Layout /> should match snapshot 1`] = `
     </button>
   </div>
   <nav
-    class="bg-napari-primary h-napari-app-bar px-6 md:px-12 2xl:p-0 grid grid-cols-napari-nav-mobile justify-center items-center gap-6 md:gap-12 2xl:grid 2xl:grid-cols-napari-2-col 3xl:grid-cols-napari-3-col"
+    class="bg-napari-primary h-napari-app-bar px-6 md:px-12 2xl:p-0 grid grid-cols-napari-nav-mobile justify-center items-center gap-6 md:gap-12 2xl:grid 2xl:grid-cols-napari-app-bar-2-col 3xl:grid 3xl:grid-cols-napari-3-col"
   >
     <header
       class="flex"

--- a/client/src/components/PluginDetails/PluginDetails.tsx
+++ b/client/src/components/PluginDetails/PluginDetails.tsx
@@ -21,8 +21,12 @@ function PluginCenterColumn({ plugin }: Props) {
   );
 }
 
-function PluginRightColumn() {
-  return <div />;
+function PluginRightColumn({ plugin }: Props) {
+  return (
+    <div>
+      <Markdown.TOC className="fixed" markdown={plugin.description} />
+    </div>
+  );
 }
 
 /**
@@ -48,7 +52,7 @@ export function PluginDetails(props: Props) {
     >
       <PluginLeftColumn />
       <PluginCenterColumn {...props} />
-      <PluginRightColumn />
+      <PluginRightColumn {...props} />
     </div>
   );
 }

--- a/client/src/components/PluginDetails/PluginDetails.tsx
+++ b/client/src/components/PluginDetails/PluginDetails.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 
 function PluginLeftColumn() {
-  return <div />;
+  return <div className="hidden 3xl:flex" />;
 }
 
 function PluginCenterColumn({ plugin }: Props) {
@@ -24,7 +24,10 @@ function PluginCenterColumn({ plugin }: Props) {
 function PluginRightColumn({ plugin }: Props) {
   return (
     <div>
-      <Markdown.TOC className="fixed" markdown={plugin.description} />
+      <Markdown.TOC
+        className="fixed hidden 2xl:flex"
+        markdown={plugin.description}
+      />
     </div>
   );
 }

--- a/client/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
+++ b/client/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
@@ -5,7 +5,9 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
   class="flex 2xl:grid 2xl:justify-center p-6 md:p-14 2xl:px-0 2xl:gap-14 2xl:grid-cols-napari-2-col 3xl:grid-cols-napari-3-col"
   data-testid="pluginDetails"
 >
-  <div />
+  <div
+    class="hidden 3xl:flex"
+  />
   <article
     class="w-full"
   >
@@ -76,7 +78,9 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       </p>
       
 
-      <h2>
+      <h2
+        id="description"
+      >
         Description
       </h2>
       
@@ -86,7 +90,9 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       </p>
       
 
-      <h2>
+      <h2
+        id="writers"
+      >
         Writers
       </h2>
       
@@ -96,7 +102,9 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       </p>
       
 
-      <h3>
+      <h3
+        id="labels_to_zarr"
+      >
         <code
           node="[object Object]"
         >
@@ -121,7 +129,9 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       </p>
       
 
-      <h3>
+      <h3
+        id="label_image_pairs_to_zarr"
+      >
         <code
           node="[object Object]"
         >
@@ -145,7 +155,9 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       </p>
       
 
-      <h2>
+      <h2
+        id="readers"
+      >
         Readers
       </h2>
       
@@ -155,7 +167,9 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       </p>
       
 
-      <h3>
+      <h3
+        id="get_zarr_labels"
+      >
         <code
           node="[object Object]"
         >
@@ -181,7 +195,9 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       </p>
       
 
-      <h3>
+      <h3
+        id="get_label_image_stack"
+      >
         <code
           node="[object Object]"
         >
@@ -207,7 +223,9 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       </p>
       
 
-      <h2>
+      <h2
+        id="zmeta"
+      >
         .zmeta
       </h2>
       
@@ -217,7 +235,9 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       </p>
       
 
-      <h3>
+      <h3
+        id="an-example-zmeta-specification"
+      >
         An example .zmeta specification
       </h3>
       
@@ -291,7 +311,9 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       </p>
       
 
-      <h2>
+      <h2
+        id="installation"
+      >
         Installation
       </h2>
       
@@ -323,7 +345,9 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       </pre>
       
 
-      <h2>
+      <h2
+        id="contributing"
+      >
         Contributing
       </h2>
       
@@ -340,7 +364,9 @@ the coverage at least stays the same before you submit a pull request.
       </p>
       
 
-      <h2>
+      <h2
+        id="license"
+      >
         License
       </h2>
       
@@ -357,7 +383,9 @@ the coverage at least stays the same before you submit a pull request.
       </p>
       
 
-      <h2>
+      <h2
+        id="issues"
+      >
         Issues
       </h2>
       
@@ -373,6 +401,107 @@ the coverage at least stays the same before you submit a pull request.
       </p>
     </div>
   </article>
-  <div />
+  <div>
+    <ul
+      class="fixed hidden 2xl:flex flex flex-col border-l border-black"
+    >
+      <li
+        class="flex pl-6 h-6 border-l-4 my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
+        data-active="false"
+        data-testid="tocItem"
+      >
+        <a
+          class=""
+          href="#description"
+        >
+          Description
+        </a>
+      </li>
+      <li
+        class="flex pl-6 h-6 border-l-4 my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
+        data-active="false"
+        data-testid="tocItem"
+      >
+        <a
+          class=""
+          href="#writers"
+        >
+          Writers
+        </a>
+      </li>
+      <li
+        class="flex pl-6 h-6 border-l-4 my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
+        data-active="false"
+        data-testid="tocItem"
+      >
+        <a
+          class=""
+          href="#readers"
+        >
+          Readers
+        </a>
+      </li>
+      <li
+        class="flex pl-6 h-6 border-l-4 my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
+        data-active="false"
+        data-testid="tocItem"
+      >
+        <a
+          class=""
+          href="#zmeta"
+        >
+          .zmeta
+        </a>
+      </li>
+      <li
+        class="flex pl-6 h-6 border-l-4 my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
+        data-active="false"
+        data-testid="tocItem"
+      >
+        <a
+          class=""
+          href="#installation"
+        >
+          Installation
+        </a>
+      </li>
+      <li
+        class="flex pl-6 h-6 border-l-4 my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
+        data-active="false"
+        data-testid="tocItem"
+      >
+        <a
+          class=""
+          href="#contributing"
+        >
+          Contributing
+        </a>
+      </li>
+      <li
+        class="flex pl-6 h-6 border-l-4 my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
+        data-active="false"
+        data-testid="tocItem"
+      >
+        <a
+          class=""
+          href="#license"
+        >
+          License
+        </a>
+      </li>
+      <li
+        class="flex pl-6 h-6 border-l-4 my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-black"
+        data-active="true"
+        data-testid="tocItem"
+      >
+        <a
+          class="font-bold"
+          href="#issues"
+        >
+          Issues
+        </a>
+      </li>
+    </ul>
+  </div>
 </div>
 `;

--- a/client/src/components/common/Markdown/Markdown.hooks.ts
+++ b/client/src/components/common/Markdown/Markdown.hooks.ts
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react';
+
+import { MarkdownHeader } from './Markdown.types';
+
+/**
+ * The designs requires a 35px margin between the heading and the top of the
+ * viewport when scrolling to a heading, so the next heading should be
+ * highlighted when hitting that offset.
+ */
+const TOP_OFFSET = 35;
+
+/**
+ * Hook for getting the selected heading anchor from an array of markdown
+ * headers.  The headers should be rendered on the DOM via the <Markdown />
+ * component for this to work.
+ *
+ * This code is inspired by the TOC for Docusaurus: https://git.io/JObbd, with
+ * small improvements.
+ *
+ * @param headers Markdown headers from `getHeadersFromMarkdown()`
+ * @returns Active header ID
+ */
+export function useActiveHeader(headers: MarkdownHeader[]): string {
+  const [active, setActive] = useState(headers[0]?.id ?? '');
+
+  useEffect(() => {
+    function findActiveHeader() {
+      // Get headers as DOM nodes.
+      const headerTags = headers.map((header) =>
+        document.getElementById(header.id),
+      );
+
+      // Find first header that is in viewport.
+      const firstHeaderIndex = headerTags.findIndex((header) => {
+        const top = header?.getBoundingClientRect()?.top ?? 0;
+        return top >= 0;
+      });
+      const firstHeader = headerTags[firstHeaderIndex];
+
+      if (firstHeader) {
+        const { top } = firstHeader.getBoundingClientRect();
+
+        // If user reaches the bottom, set the last header as selected.
+        if (
+          window.innerHeight + window.pageYOffset >=
+          document.body.scrollHeight
+        ) {
+          setActive(headers[headers.length - 1].id);
+        } else if (Math.floor(top) <= TOP_OFFSET) {
+          setActive(firstHeader.id);
+        } else {
+          /*
+            If the first header in viewport is greater than the offset, then
+            the user is still in the previous section.
+          */
+          const previousHeader = headers[firstHeaderIndex - 1] ?? firstHeader;
+          setActive(previousHeader.id);
+        }
+      }
+    }
+
+    document.addEventListener('scroll', findActiveHeader);
+    document.addEventListener('resize', findActiveHeader);
+
+    // Remove event listeners on cleanup.
+    return () => {
+      document.removeEventListener('scroll', findActiveHeader);
+      document.removeEventListener('resize', findActiveHeader);
+    };
+  }, [headers]);
+
+  return active;
+}

--- a/client/src/components/common/Markdown/Markdown.hooks.ts
+++ b/client/src/components/common/Markdown/Markdown.hooks.ts
@@ -62,6 +62,9 @@ export function useActiveHeader(headers: MarkdownHeader[]): string {
     document.addEventListener('scroll', findActiveHeader);
     document.addEventListener('resize', findActiveHeader);
 
+    // Find active header on initial render
+    findActiveHeader();
+
     // Remove event listeners on cleanup.
     return () => {
       document.removeEventListener('scroll', findActiveHeader);

--- a/client/src/components/common/Markdown/Markdown.module.scss
+++ b/client/src/components/common/Markdown/Markdown.module.scss
@@ -1,4 +1,16 @@
 .markdown {
+  h2 {
+    /*
+      The designs requires a 35px margin between the heading and the top of
+      the viewport when scrolling to a heading.
+
+      TODO There's currently no support for this in Safari yet. We'll need to
+      implement a solution in TypeScript.
+      https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-top
+    */
+    scroll-margin-top: 2.1875rem; // 35px when html font-size is 16px
+  }
+
   pre {
     // Show scrollbar along x-axis for really long code
     @apply overflow-x-auto;

--- a/client/src/components/common/Markdown/Markdown.module.scss
+++ b/client/src/components/common/Markdown/Markdown.module.scss
@@ -8,7 +8,7 @@
       implement a solution in TypeScript.
       https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-top
     */
-    scroll-margin-top: 2.1875rem; // 35px when html font-size is 16px
+    scroll-margin-top: #{(35px / 16px)}rem;
   }
 
   pre {

--- a/client/src/components/common/Markdown/Markdown.tsx
+++ b/client/src/components/common/Markdown/Markdown.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import ReactMarkdown, { TransformOptions } from 'react-markdown';
+import slug from 'rehype-slug';
 import gfm from 'remark-gfm';
 import removeComments from 'remark-remove-comments';
 
@@ -14,12 +15,17 @@ interface Props {
   disableHeader?: boolean;
 }
 
-const PLUGINS = [
+const REMARK_PLUGINS = [
   // Add support for GitHub style markdown like checkboxes.
   gfm,
 
   // Remove HTML comments from markdown.
   removeComments,
+];
+
+const REHYPE_PLUGINS = [
+  // Add slug IDs to every heading.
+  slug,
 ];
 
 /**
@@ -50,7 +56,8 @@ export function Markdown({ children, disableHeader }: Props) {
         'max-w-none',
       )}
       components={components}
-      remarkPlugins={PLUGINS}
+      remarkPlugins={REMARK_PLUGINS}
+      rehypePlugins={REHYPE_PLUGINS}
     >
       {children}
     </ReactMarkdown>

--- a/client/src/components/common/Markdown/Markdown.tsx
+++ b/client/src/components/common/Markdown/Markdown.tsx
@@ -6,6 +6,7 @@ import removeComments from 'remark-remove-comments';
 
 import styles from './Markdown.module.scss';
 import { MarkdownCode } from './MarkdownCode';
+import { MarkdownTOC } from './MarkdownTOC';
 
 interface Props {
   // Markdown code.
@@ -63,3 +64,5 @@ export function Markdown({ children, disableHeader }: Props) {
     </ReactMarkdown>
   );
 }
+
+Markdown.TOC = MarkdownTOC;

--- a/client/src/components/common/Markdown/Markdown.types.ts
+++ b/client/src/components/common/Markdown/Markdown.types.ts
@@ -1,0 +1,23 @@
+import { ReactHTML } from 'react';
+import { Node } from 'unist';
+
+export interface MarkdownHeader {
+  id: string;
+  text: string;
+}
+
+export interface MarkdownNode extends Node {
+  children: MarkdownNode[];
+  tagName: keyof ReactHTML;
+}
+
+export interface TextNode extends MarkdownNode {
+  value: string;
+}
+
+export interface HeadingNode extends MarkdownNode {
+  children: [TextNode];
+  properties: {
+    id: string;
+  };
+}

--- a/client/src/components/common/Markdown/Markdown.utils.test.ts
+++ b/client/src/components/common/Markdown/Markdown.utils.test.ts
@@ -1,0 +1,55 @@
+import { MarkdownHeader } from './Markdown.types';
+import { getHeadersFromMarkdown } from './Markdown.utils';
+
+const MARKDOWN_WITHOUT_HEADERS = `
+# Hello World!
+
+This is markdown
+
+### Level 3 header, but not level 2
+
+markdown is cool.
+`;
+
+const MARKDOWN_WITH_HEADERS = `
+# Hello World!
+
+This is markdown
+
+## Foo
+## Bar
+## Foo Bar
+`;
+
+describe('getHeadersFromMarkdown()', () => {
+  it('should return empty array for empty markdown', () => {
+    const headers = getHeadersFromMarkdown('');
+    expect(headers).toHaveLength(0);
+  });
+
+  it('should return empty array when there are no headers', () => {
+    const headers = getHeadersFromMarkdown(MARKDOWN_WITHOUT_HEADERS);
+
+    expect(headers).toHaveLength(0);
+  });
+
+  it('should return array of headers', () => {
+    const headers = getHeadersFromMarkdown(MARKDOWN_WITH_HEADERS);
+    const expected: MarkdownHeader[] = [
+      {
+        id: 'foo',
+        text: 'Foo',
+      },
+      {
+        id: 'bar',
+        text: 'Bar',
+      },
+      {
+        id: 'foo-bar',
+        text: 'Foo Bar',
+      },
+    ];
+
+    expect(headers).toEqual(expected);
+  });
+});

--- a/client/src/components/common/Markdown/Markdown.utils.ts
+++ b/client/src/components/common/Markdown/Markdown.utils.ts
@@ -1,0 +1,66 @@
+import slug from 'rehype-slug';
+import html from 'rehype-stringify';
+import markdownParser from 'remark-parse';
+import remark2rehype from 'remark-rehype';
+import unified from 'unified';
+
+import { HeadingNode, MarkdownHeader, MarkdownNode } from './Markdown.types';
+
+/**
+ * Plugins for transforming markdown to HTML. This also adds slug IDs to each
+ * heading for linking in the TOC.
+ */
+const UNIFIED_PLUGINS = [
+  // Parse markdown
+  markdownParser,
+
+  // Convert markdown to HTML for rehype parsing
+  remark2rehype,
+
+  // Add slug IDs to every heading
+  slug,
+
+  // Compile to HTML
+  html,
+];
+
+/**
+ * Header tag to use for TOC.
+ */
+export const TOC_HEADER_TAG = 'h2';
+
+/**
+ * Function for extracting TOC headers from a markdown string.  This uses
+ * unified, remark, and rehype to parse the markdown string.  The string is
+ * parsed synchronously so that rendering the headers work in SSR.  This is
+ * also the same approach react-markdown uses:
+ *
+ * https://git.io/JObhE
+ *
+ * @param markdown Markdown string.
+ * @returns Array of MarkdownHeader objects.
+ */
+export function getHeadersFromMarkdown(markdown: string): MarkdownHeader[] {
+  if (!markdown) {
+    return [];
+  }
+
+  // Create markdown processor with remark / rehype plugins.
+  const processor = UNIFIED_PLUGINS.reduce(
+    (currentProcessor, plugin) => currentProcessor.use(plugin),
+    unified(),
+  );
+
+  // Create AST from markdown + plugins.
+  const { children } = processor.runSync(
+    processor.parse(markdown),
+  ) as MarkdownNode;
+
+  // Convert all H2 headings into MarkdownHeader objects.
+  return children
+    .filter((node): node is HeadingNode => node.tagName === TOC_HEADER_TAG)
+    .map<MarkdownHeader>((node) => ({
+      id: node.properties.id,
+      text: node.children[0].value,
+    }));
+}

--- a/client/src/components/common/Markdown/MarkdownTOC.tsx
+++ b/client/src/components/common/Markdown/MarkdownTOC.tsx
@@ -1,0 +1,60 @@
+import clsx from 'clsx';
+
+import { useActiveHeader } from './Markdown.hooks';
+import { getHeadersFromMarkdown } from './Markdown.utils';
+
+interface Props {
+  className?: string;
+  markdown: string;
+}
+
+/**
+ * Component for rendering TOC from a markdown string.  The TOC will generate
+ * links to different headings in the markdown.  When clicking on the link, the
+ * page should scroll to the heading and update the current active heading.
+ *
+ * For this to work, there needs to be a corresponding `<Markdown />` component
+ * somewhere with the same markdown content.
+ */
+export function MarkdownTOC({ className, markdown }: Props) {
+  const headers = getHeadersFromMarkdown(markdown);
+  const activeHeader = useActiveHeader(headers);
+
+  return (
+    <ul className={clsx(className, 'flex flex-col', 'border-l border-black')}>
+      {headers.map((header) => {
+        const isActive = header.id === activeHeader;
+
+        return (
+          <li
+            className={clsx(
+              // Layout
+              'flex',
+
+              // Box model
+              'pl-6 h-7 border-l-4',
+
+              // Smooth transition for border color
+              'transition-colors',
+
+              'hover:border-napari-primary',
+              !isActive && 'border-transparent',
+              isActive && 'border-black',
+            )}
+            key={header.id}
+            data-active={isActive}
+            data-testid="tocItem"
+          >
+            {/*
+              Use normal link component instead of Next.js Link because we're
+              not loading another page.
+            */}
+            <a className={clsx(isActive && 'font-bold')} href={`#${header.id}`}>
+              {header.text}
+            </a>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/client/src/components/common/Markdown/MarkdownTOC.tsx
+++ b/client/src/components/common/Markdown/MarkdownTOC.tsx
@@ -30,9 +30,13 @@ export function MarkdownTOC({ className, markdown }: Props) {
             className={clsx(
               // Layout
               'flex',
+              // 'flex items-center',
 
               // Box model
-              'pl-6 h-7 border-l-4',
+              'pl-6 h-6 border-l-4',
+
+              // Apply top/bottom margins except for first/last items
+              'my-2 first:mt-0 last:mb-0',
 
               // Smooth transition for border color
               'transition-colors',

--- a/client/src/components/common/Markdown/__snapshots__/Markdown.test.tsx.snap
+++ b/client/src/components/common/Markdown/__snapshots__/Markdown.test.tsx.snap
@@ -5,7 +5,9 @@ exports[`<Markdown /> should match snapshot 1`] = `
   <div
     class="markdown prose max-w-none"
   >
-    <h1>
+    <h1
+      id="hello-world"
+    >
       Hello World
     </h1>
   </div>

--- a/client/src/global.scss
+++ b/client/src/global.scss
@@ -17,6 +17,15 @@ html {
     https://blog.logrocket.com/the-elements-of-responsive-typography
   */
   font-size: clamp(11px, 3.25vw, 100%);
+
+  /*
+    Use smooth transition when scrolling between different parts of the page.
+
+    TODO This currently has no support in Safari, so we'll probably have to
+    implement a solution in TypeScript.
+    https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior
+  */
+  scroll-behavior: smooth;
 }
 
 body {

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -17,7 +17,7 @@ module.exports = {
     },
 
     extend: {
-      backgroundColor: {
+      colors: {
         'napari-primary': '#80d1ff',
       },
 

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -35,6 +35,15 @@ module.exports = {
         'napari-nav-mobile': 'min-content 1fr',
 
         'napari-2-col': [
+          theme('width.napari-center-col'),
+          theme('width.napari-side-col'),
+        ].join(' '),
+
+        /*
+          App bar 2 column layout is reversed because the logo needs to be
+          smaller than the search container.
+        */
+        'napari-app-bar-2-col': [
           theme('width.napari-side-col'),
           theme('width.napari-center-col'),
         ].join(' '),

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -849,6 +849,18 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@^5.1.2":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-5.1.2.tgz#36e359d992bb652a9885c6fa9aa394639cbe8dd3"
+  integrity sha512-jwhtDYZ5gQUIX8cmVCVdtwNvuF5EiCOWjokRlTV+o/V0GdtRZDykUllL1OXq5PS4+J33wGLNQeeWzEHcWrH7tg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@types/react" ">=16.9.0"
+    "@types/react-dom" ">=16.9.0"
+    "@types/react-test-renderer" ">=16.9.0"
+    filter-console "^0.1.1"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@^11.2.6":
   version "11.2.6"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.6.tgz#586a23adc63615985d85be0c903f374dab19200b"
@@ -988,6 +1000,18 @@
     "@types/interpret" "*"
     "@types/node" "*"
 
+"@types/lodash-es@^4.17.4":
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.4.tgz#b2e440d2bf8a93584a9fd798452ec497986c9b97"
+  integrity sha512-BBz79DCJbD2CVYZH67MBeHZRX++HF+5p8Mo5MzjZi64Wac39S3diedJYHZtScbRVf4DjZyN6LzA0SB0zy+HSSQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.168"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
+  integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
+
 "@types/mdast@^3.0.0":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.3.tgz#2d7d671b1cd1ea3deb306ea75036c2a0407d2deb"
@@ -1035,6 +1059,13 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
+"@types/react-dom@>=16.9.0":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.3.tgz#7fdf37b8af9d6d40127137865bb3fff8871d7ee1"
+  integrity sha512-4NnJbCeWE+8YBzupn/YrJxZ8VnjcJq5iR1laqQ1vkpQgBiA7bwk0Rp24fxsdNinzJY2U+HHS4dJJDPdoMjdJ7w==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-syntax-highlighter@^13.5.0":
   version "13.5.0"
   resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-13.5.0.tgz#b93c05f28844e7c35a5f1d38d3819099ffa82fbd"
@@ -1042,10 +1073,26 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-test-renderer@>=16.9.0":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz#3120f7d1c157fba9df0118dae20cb0297ee0e06b"
+  integrity sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@^17.0.3":
   version "17.0.3"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.3.tgz#ba6e215368501ac3826951eef2904574c262cc79"
   integrity sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@>=16.9.0":
+  version "17.0.4"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.4.tgz#a67c6f7a460d2660e950d9ccc1c2f18525c28220"
+  integrity sha512-onz2BqScSFMoTRdJUZUDD/7xrusM8hBA2Fktk2qgaTYPCgPvWnDEgkrOs8hhPUf2jfcIXkJ5yK6VfYormJS3Jw==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -2090,6 +2137,11 @@ char-regex@^1.0.2:
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
+character-entities-html4@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-1.1.4.tgz#0e64b0a3753ddbf1fdc044c5fd01d0199a02e125"
+  integrity sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g==
+
 character-entities-legacy@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz#94bc1845dce70a5bb9d2ecc748725661293d8fc1"
@@ -2995,6 +3047,11 @@ emittery@^0.7.1:
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.7.2.tgz#25595908e13af0f5674ab419396e2fb394cdfa82"
   integrity sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==
 
+"emoji-regex@>=6.0.0 <=6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.1.1.tgz#c6cd0ec1b0642e2a3c67a1137efc5e796da4f88e"
+  integrity sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4=
+
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
@@ -3667,6 +3724,11 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+filter-console@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/filter-console/-/filter-console-0.1.1.tgz#6242be28982bba7415bcc6db74a79f4a294fa67c"
+  integrity sha512-zrXoV1Uaz52DqPs+qEwNJWJFAWZpYJ47UNmpN9q4j+/EYsz85uV0DC9k8tRND5kYmoVzL0W+Y75q4Rg8sRJCdg==
+
 find-cache-dir@3.3.1, find-cache-dir@^3.2.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.1.tgz#89b33fad4a4670daa94f855f7fbe31d6d84fe880"
@@ -3941,6 +4003,13 @@ getpass@^0.1.1:
   integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
   dependencies:
     assert-plus "^1.0.0"
+
+github-slugger@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.3.0.tgz#9bd0a95c5efdfc46005e82a906ef8e2a059124c9"
+  integrity sha512-gwJScWVNhFYSRDvURk/8yhcFBee6aFjye2a7Lhb2bUyRulpIoek9p0I9Kt7PT67d/nUlZbFu8L9RLiA0woQN8Q==
+  dependencies:
+    emoji-regex ">=6.0.0 <=6.1.1"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -4293,6 +4362,21 @@ hast-util-from-parse5@^6.0.0:
     vfile-location "^3.2.0"
     web-namespaces "^1.0.0"
 
+hast-util-has-property@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/hast-util-has-property/-/hast-util-has-property-1.0.4.tgz#9f137565fad6082524b382c1e7d7d33ca5059f36"
+  integrity sha512-ghHup2voGfgFoHMGnaLHOjbYFACKrRh9KFttdCzMCbFoBMJXiNi2+XTrPP8+q6cDJM/RSqlCfVWrjp1H201rZg==
+
+hast-util-heading-rank@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/hast-util-heading-rank/-/hast-util-heading-rank-1.0.1.tgz#28dfd8b0724cfb0da48308e2a794b1d9f24fd80d"
+  integrity sha512-P6Hq7RCky9syMevlrN90QWpqWDXCxwIVOfQR2rK6P4GpY4bqjKEuCzoWSRORZ7vz+VgRpLnXimh+mkwvVFjbyQ==
+
+hast-util-is-element@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/hast-util-is-element/-/hast-util-is-element-1.1.0.tgz#3b3ed5159a2707c6137b48637fbfe068e175a425"
+  integrity sha512-oUmNua0bFbdrD/ELDSSEadRVtWZOf3iF6Lbv81naqsIV99RnSCieTbWuWCY8BAeEfKJTKl0gRdokv+dELutHGQ==
+
 hast-util-parse-selector@^2.0.0:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz#d57c23f4da16ae3c63b3b6ca4616683313499c3a"
@@ -4314,6 +4398,22 @@ hast-util-raw@6.0.1:
     xtend "^4.0.0"
     zwitch "^1.0.0"
 
+hast-util-to-html@^7.1.1:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/hast-util-to-html/-/hast-util-to-html-7.1.2.tgz#db677f0ee483658cea0eecc9dec30aba42b67111"
+  integrity sha512-pu73bvORzdF6XZgwl9eID/0RjBb/jtRfoGRRSykpR1+o9rCdiAHpgkSukZsQBRlIqMg6ylAcd7F0F7myJUb09Q==
+  dependencies:
+    ccount "^1.0.0"
+    comma-separated-tokens "^1.0.0"
+    hast-util-is-element "^1.0.0"
+    hast-util-whitespace "^1.0.0"
+    html-void-elements "^1.0.0"
+    property-information "^5.0.0"
+    space-separated-tokens "^1.0.0"
+    stringify-entities "^3.0.1"
+    unist-util-is "^4.0.0"
+    xtend "^4.0.0"
+
 hast-util-to-parse5@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/hast-util-to-parse5/-/hast-util-to-parse5-6.0.0.tgz#1ec44650b631d72952066cea9b1445df699f8479"
@@ -4324,6 +4424,16 @@ hast-util-to-parse5@^6.0.0:
     web-namespaces "^1.0.0"
     xtend "^4.0.0"
     zwitch "^1.0.0"
+
+hast-util-to-string@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/hast-util-to-string/-/hast-util-to-string-1.0.4.tgz#9b24c114866bdb9478927d7e9c36a485ac728378"
+  integrity sha512-eK0MxRX47AV2eZ+Lyr18DCpQgodvaS3fAQO2+b9Two9F5HEoRPhiUMNzoXArMJfZi2yieFzUBMRl3HNJ3Jus3w==
+
+hast-util-whitespace@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-1.0.4.tgz#e4fe77c4a9ae1cb2e6c25e02df0043d0164f6e41"
+  integrity sha512-I5GTdSfhYfAPNztx2xJRQpG8cuDSNt599/7YUn7Gx/WxNMsG+a835k97TDkFgk123cwjfwINaZknkKkphx/f2A==
 
 hastscript@^6.0.0:
   version "6.0.0"
@@ -5961,6 +6071,11 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
+
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 lodash.castarray@^4.4.0:
   version "4.4.0"
@@ -8004,6 +8119,13 @@ react-dom@17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
+react-error-boundary@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.1.tgz#932c5ca5cbab8ec4fe37fd7b415aa5c3a47597e7"
+  integrity sha512-W3xCd9zXnanqrTUeViceufD3mIW8Ut29BUD+S2f0eO2XCOU8b6UrJfY46RDGe5lxCJzfe4j0yvIfh0RbTZhKJw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-is@16.13.1, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -8236,6 +8358,24 @@ registry-url@^5.0.0:
   dependencies:
     rc "^1.2.8"
 
+rehype-slug@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/rehype-slug/-/rehype-slug-4.0.1.tgz#313274501cffa997bd52dd57bf2da5851959747a"
+  integrity sha512-KIlJALf9WfHFF21icwTd2yI2IP+RQRweaxH9ChVGQwRYy36+hiomG4ZSe0yQRyCt+D/vE39LbAcOI/h4O4GPhA==
+  dependencies:
+    github-slugger "^1.1.1"
+    hast-util-has-property "^1.0.0"
+    hast-util-heading-rank "^1.0.0"
+    hast-util-to-string "^1.0.0"
+    unist-util-visit "^2.0.0"
+
+rehype-stringify@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/rehype-stringify/-/rehype-stringify-8.0.0.tgz#9b6afb599bcf3165f10f93fc8548f9a03d2ec2ba"
+  integrity sha512-VkIs18G0pj2xklyllrPSvdShAV36Ff3yE5PUO9u36f6+2qJFnn22Z5gKwBOwgXviux4UC7K+/j13AnZfPICi/g==
+  dependencies:
+    hast-util-to-html "^7.1.1"
+
 release-zalgo@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/release-zalgo/-/release-zalgo-1.0.0.tgz#09700b7e5074329739330e535c5a90fb67851730"
@@ -8299,7 +8439,7 @@ remark-parse@^9.0.0:
   dependencies:
     mdast-util-from-markdown "^0.8.0"
 
-remark-rehype@^8.0.0:
+remark-rehype@^8.0.0, remark-rehype@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/remark-rehype/-/remark-rehype-8.1.0.tgz#610509a043484c1e697437fa5eb3fd992617c945"
   integrity sha512-EbCu9kHgAxKmW1yEYjx3QafMyGY3q8noUbNUI5xyKbaFP89wbhDrKxyIQNukNYthzjNHZu6J7hwFg7hRm1svYA==
@@ -9173,6 +9313,15 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
+stringify-entities@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-3.1.0.tgz#b8d3feac256d9ffcc9fa1fefdcf3ca70576ee903"
+  integrity sha512-3FP+jGMmMV/ffZs86MoghGqAoqXAdxLrJP4GUdrDN1aIScYih5tuIO3eF4To5AJZ79KDZ8Fpdy7QJnK8SsL1Vg==
+  dependencies:
+    character-entities-html4 "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    xtend "^4.0.0"
+
 stringify-object@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.3.0.tgz#703065aefca19300d3ce88af4f5b3956d7556629"
@@ -9879,7 +10028,7 @@ unified@9.2.0:
     trough "^1.0.0"
     vfile "^4.0.0"
 
-unified@^9.0.0, unified@^9.1.0:
+unified@^9.0.0, unified@^9.1.0, unified@^9.2.1:
   version "9.2.1"
   resolved "https://registry.yarnpkg.com/unified/-/unified-9.2.1.tgz#ae18d5674c114021bfdbdf73865ca60f410215a3"
   integrity sha512-juWjuI8Z4xFg8pJbnEZ41b5xjGUWGHqXALmBZ3FC3WX0PIx1CZBIIJ6mXbYMcf6Yw4Fi0rFUTA1cdz/BglbOhA==


### PR DESCRIPTION
## Description

Depends on #20

This PR implements a Markdown TOC component. The TOC highlights the active section based on the headings in the browser viewport. The implementation is based on the `useTOCHighlight()` hook used in [Docusaurus](https://github.com/facebook/docusaurus/blob/master/packages/docusaurus-theme-classic/src/theme/hooks/useTOCHighlight.ts).

### Safari `scroll-*` CSS Support

Safari is the only browser without full support for the `scroll-*` CSS properties used in this PR:

- [scroll-behavior](https://caniuse.com/?search=scroll-behavior)
- [scroll-margin-top](https://caniuse.com/?search=scroll-margin-top)

So the highlighting and linking still work as expected, but the smooth scroll and scroll margin do not work. We could look into implementing this in JS, but it's a heavier lift than using CSS.

## Changes

- Disables eslint rule for unbound methods. 
  - Exporting functions is a common pattern, so having this rule on is very limiting. 
- Moved napari primary color from `backgroundColor` to `colors`
  - The `colors` field is more generic and [creates colors for multiple properties](https://tailwindcss.com/docs/customizing-colors#custom-colors) like `backgroundColor`, `borderColor`, etc.
- Markdown TOC component with scroll-to behavior.

## Demos

**Demo Link**: https://napari-hub-toc-demo.vercel.app/plugin/name

### Scrolling / Scrolling on Link Click

https://user-images.githubusercontent.com/2176050/116165614-15cb4f80-a6b1-11eb-88de-d083c7077a23.mp4

### No Scrolling on Link Click in Safari

https://user-images.githubusercontent.com/2176050/116166478-f6352680-a6b2-11eb-8a02-0d7e626f0e5a.mp4

### Responsive TOC

https://user-images.githubusercontent.com/2176050/116168166-ace6d600-a6b6-11eb-8f03-3ad330953dee.mp4
