### PR TITLE
Plugin Search Part 1

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -43,39 +43,6 @@ npm -g install yarn
 yarn install
 ```
 
-## Backend API
-
-The hub communicates with a backend API for plugin data, so you'll need to setup
-either a mock server or connect to an API directly.
-
-### Mock Server
-
-To start the mock server, run:
-
-```sh
-yarn start:mock-server
-```
-
-This starts the server on port `8081`, and by default, the client will connect
-to `http://localhost:8081` for the backend API.
-
-### Actual API
-
-If you want to work with the actual hub API, you'll need to use the `API_URL`
-environment variable to point to the API:
-
-```sh
-API_URL=https://localhost:8081 yarn dev
-```
-
-If you're locally forwarding the API through SSH and if the API checks the host
-header (e.g. AWS API Gateway), you may need to also set `API_URL_HOST` to pass
-the header check:
-
-```sh
-API_URL=https://localhost:8081 API_HOST=<api-id>.execute-api.us-west-2.amazonaws.com yarn dev
-```
-
 ## Development Mode
 
 To run the app in development mode, run the following command:
@@ -84,7 +51,13 @@ To run the app in development mode, run the following command:
 yarn dev
 ```
 
-This will start the Next.js dev server with [fast refresh](https://nextjs.org/docs/basic-features/fast-refresh). Edit some code and watch it update in the browser without having to refresh :heart_eyes:
+This will start the Next.js dev server with
+[fast refresh](https://nextjs.org/docs/basic-features/fast-refresh).
+Edit some code and watch it update in the browser without having to refresh
+:heart_eyes:
+
+This will also start a mock server in the background, but it's also possible to
+[connect to an external API](#backend-api).
 
 ## Plop Generators
 
@@ -102,4 +75,21 @@ argument:
 ```sh
 # Run component generator
 yarn plop component
+```
+
+## Backend API
+
+If you want to connect to an API directly, you'll need to use the `API_URL`
+environment variable to point to the API, and `MOCK_SERVER=false` to disable the
+mock API server.
+
+If you're locally forwarding the API through SSH and if the API checks the host
+header (e.g. AWS API Gateway), you will also need to set `API_URL_HOST` to pass
+the header check:
+
+```sh
+MOCK_SERVER=false \
+API_URL=https://localhost:8081 \
+API_HOST=<api-id>.execute-api.us-west-2.amazonaws.com \
+yarn dev
 ```

--- a/client/jest/e2e.config.js
+++ b/client/jest/e2e.config.js
@@ -45,6 +45,11 @@ const DEVICES = {
   },
 };
 
+/**
+ * Device specific environment variable. Use if you want to test using a specific device.
+ */
+const { DEVICE } = process.env;
+
 module.exports = {
   rootDir: '..',
   preset: 'jest-playwright-preset',
@@ -63,7 +68,7 @@ module.exports = {
     'jest-playwright': {
       browsers: [BROWSER],
       browserContext: 'incognito',
-      devices: Object.values(DEVICES),
+      devices: DEVICE ? [DEVICES[DEVICE]] : Object.values(DEVICES),
       contextOptions: DEFAULT_CONTEXT_CONFIG,
       launchOptions: DEFAULT_LAUNCH_CONFIG,
     },

--- a/client/jest/setupTests.ts
+++ b/client/jest/setupTests.ts
@@ -14,7 +14,3 @@ beforeEach(() => {
     ...originalWindowLocation,
   };
 });
-
-afterEach(() => {
-  window.location = originalWindowLocation;
-});

--- a/client/jest/setupTests.ts
+++ b/client/jest/setupTests.ts
@@ -1,1 +1,20 @@
 import '@testing-library/jest-dom';
+
+// Mock window.location for every test case:
+// https://stackoverflow.com/a/57612279
+const originalWindowLocation = window.location;
+
+beforeEach(() => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  delete window.location;
+
+  // Reassign to regular object so that properties can be reassign
+  window.location = {
+    ...originalWindowLocation,
+  };
+});
+
+afterEach(() => {
+  window.location = originalWindowLocation;
+});

--- a/client/mock-server.js
+++ b/client/mock-server.js
@@ -1,15 +1,25 @@
+if (process.env.MOCK_SERVER === 'false') {
+  console.log('MOCK_SERVER is false, exiting');
+  process.exit();
+}
+
 const express = require('express');
 
 const napariPlugin = require('./src/fixtures/napari.json');
+const pluginIndex = require('./src/fixtures/index.json');
 
 const app = express();
 
-app.get('/plugins', async (req, res) => {
+app.get('/plugins', async (_, res) => {
   res.json({ 'napari-compressed-labels-io': '0.0.0' });
 });
 
-app.get('/plugins/:name', async (req, res) => {
+app.get('/plugins/index', async (_, res) => {
+  res.json(pluginIndex);
+});
+
+app.get('/plugins/:name', async (_, res) => {
   res.json(napariPlugin);
 });
 
-app.listen(8081, () => console.log('Started proxy server'));
+app.listen(8081, () => console.log('Started mock API server'));

--- a/client/package.json
+++ b/client/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "next build",
     "dev": "nodemon -x 'run-p dev:*' -w tailwind.config.js",
+    "dev:api": "node mock-server",
     "dev:next": "next dev -p 8080",
     "dev:tsm": "tsm -w -e default 'src/**/*.module.scss'",
     "lint": "run-p lint:*",
@@ -18,7 +19,6 @@
     "e2e:update": "yarn e2e --updateSnapshot",
     "postinstall": "cd .. && husky install",
     "start": "next start -p 8080",
-    "start:mock-server": "node mock-server",
     "test": "jest -c jest/test.config.js",
     "test:watch": "yarn test --watch",
     "test:update": "yarn test --updateSnapshot"

--- a/client/src/components/PluginDetails/PluginDetails.tsx
+++ b/client/src/components/PluginDetails/PluginDetails.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 
-import { Markdown } from '@/components/common';
+import { ColumnLayout, Markdown } from '@/components/common';
 import { Media, MediaFragment } from '@/components/common/media';
 import { usePluginState } from '@/context/plugin';
 
@@ -97,25 +97,10 @@ function PluginRightColumn() {
  */
 export function PluginDetails() {
   return (
-    <div
-      data-testid="pluginDetails"
-      className={clsx(
-        // Layout
-        'flex 2xl:grid 2xl:justify-center',
-
-        // Padding
-        'p-6 md:p-14 2xl:px-0',
-
-        // Grid gap
-        '2xl:gap-14',
-
-        // Grid columns
-        '2xl:grid-cols-napari-2-col 3xl:grid-cols-napari-3-col',
-      )}
-    >
+    <ColumnLayout data-testid="pluginDetails">
       <PluginLeftColumn />
       <PluginCenterColumn />
       <PluginRightColumn />
-    </div>
+    </ColumnLayout>
   );
 }

--- a/client/src/components/common/ColumnLayout/ColumnLayout.test.tsx
+++ b/client/src/components/common/ColumnLayout/ColumnLayout.test.tsx
@@ -1,0 +1,22 @@
+import { render } from '@testing-library/react';
+
+import { ColumnLayout } from './ColumnLayout';
+
+function renderLayout() {
+  const component = render(
+    <ColumnLayout>
+      <div />
+      <div />
+      <div />
+    </ColumnLayout>,
+  );
+
+  return { component };
+}
+
+describe('<ColumnLayout />', () => {
+  it('should match snapshot', () => {
+    const { component } = renderLayout();
+    expect(component.asFragment()).toMatchSnapshot();
+  });
+});

--- a/client/src/components/common/ColumnLayout/ColumnLayout.test.tsx
+++ b/client/src/components/common/ColumnLayout/ColumnLayout.test.tsx
@@ -3,20 +3,18 @@ import { render } from '@testing-library/react';
 import { ColumnLayout } from './ColumnLayout';
 
 function renderLayout() {
-  const component = render(
+  return render(
     <ColumnLayout>
       <div />
       <div />
       <div />
     </ColumnLayout>,
   );
-
-  return { component };
 }
 
 describe('<ColumnLayout />', () => {
   it('should match snapshot', () => {
-    const { component } = renderLayout();
+    const component = renderLayout();
     expect(component.asFragment()).toMatchSnapshot();
   });
 });

--- a/client/src/components/common/ColumnLayout/ColumnLayout.tsx
+++ b/client/src/components/common/ColumnLayout/ColumnLayout.tsx
@@ -1,0 +1,29 @@
+import clsx from 'clsx';
+import { HTMLAttributes, ReactNode } from 'react';
+
+interface Props extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+export function ColumnLayout({ children, ...props }: Props) {
+  return (
+    <div
+      className={clsx(
+        // Layout
+        'flex 2xl:grid 2xl:justify-center',
+
+        // Padding
+        'p-6 md:p-14 2xl:px-0',
+
+        // Grid gap
+        '2xl:gap-14',
+
+        // Grid columns
+        '2xl:grid-cols-napari-2-col 3xl:grid-cols-napari-3-col',
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}

--- a/client/src/components/common/ColumnLayout/__snapshots__/ColumnLayout.test.tsx.snap
+++ b/client/src/components/common/ColumnLayout/__snapshots__/ColumnLayout.test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ColumnLayout /> should match snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="flex 2xl:grid 2xl:justify-center p-6 md:p-14 2xl:px-0 2xl:gap-14 2xl:grid-cols-napari-2-col 3xl:grid-cols-napari-3-col"
+  >
+    <div />
+    <div />
+    <div />
+  </div>
+</DocumentFragment>
+`;

--- a/client/src/components/common/ColumnLayout/index.ts
+++ b/client/src/components/common/ColumnLayout/index.ts
@@ -1,0 +1,1 @@
+export * from './ColumnLayout';

--- a/client/src/components/common/index.ts
+++ b/client/src/components/common/index.ts
@@ -1,3 +1,4 @@
+export * from './ColumnLayout';
 export * from './Divider';
 export * from './ErrorMessage';
 export * from './Link';

--- a/client/src/fixtures/index.json
+++ b/client/src/fixtures/index.json
@@ -1,0 +1,693 @@
+[
+  {
+    "name": "napari-compressed-labels-io",
+    "summary": "Plugin exploring different options for reading and writing compressed and portable labels layers in napari.",
+    "description": "# napari-compressed-labels-io\n\n[![License](https://img.shields.io/pypi/l/napari-compressed-labels-io.svg?color=green)](https://github.com/DragaDoncila/napari-compressed-labels-io/raw/master/LICENSE)\n[![PyPI](https://img.shields.io/pypi/v/napari-compressed-labels-io.svg?color=green)](https://pypi.org/project/napari-compressed-labels-io)\n[![Python Version](https://img.shields.io/pypi/pyversions/napari-compressed-labels-io.svg?color=green)](https://python.org)\n[![tests](https://github.com/DragaDoncila/napari-compressed-labels-io/workflows/tests/badge.svg)](https://github.com/DragaDoncila/napari-compressed-labels-io/actions)\n[![codecov](https://codecov.io/gh/DragaDoncila/napari-compressed-labels-io/branch/master/graph/badge.svg)](https://codecov.io/gh/DragaDoncila/napari-compressed-labels-io)\n\n\n## Description\n\nThis napari plugin provides readers and writers for labels and their corresponding image layers into zarr format for compression and portability. Each reader/writer pair supports a round trip of saving and loading image and labels layers.\n\n## Writers\nTwo writers are provided by this plugin, each with its own reader.\n\n### `labels_to_zarr`\nThis writer is an alternative to napari's default label writer and will write an entire labels layer, regardless of its dimensions, into a single zarr file. This writer provides the best compression option and its associated reader `get_zarr_labels` will read the layer back into napari.\n\nThis writer will be called when the user tries to save a selected labels layer into a path ending with .zarr\n\n### `label_image_pairs_to_zarr`\nThis writer will save 3-dimensional labels and image layers from the viewer into individual zarrs for portability and convenience. For example, given one labels and one image layer of the shape (10, 200, 200) saved to my_stacks.zarr, 10 subdirectories will be created, each with two zarrs inside of shape (200, 200) corresponding to the labels and image layer.\n\nThis writer allows users to load stacks of associated images, label them, and then quickly save these stacks out into individual slices for easy loading, viewing and interaction. Its associated reader supports the loading into napari of the whole stack, all layers at one slice of the stack, and an individual layer of a given slice of the stack.\n\nThe writer currently supports only 3D layers, with the exception of RGB images of the form (z, y, x, 3), which are also supported.\n\n\n## Readers\n\nTwo readers are provided by this plugin for loading the formats saved by each writer. These are detailed below.\n\n### `get_zarr_labels`\n\nThis reader will open any zarr file with a .zarray at the top level in `path` as a labels layer. This is to be used in conjunction with `labels_to_zarr`.\n\n\n### `get_label_image_stack`\n\nThis reader will open any zarr containing a `.zmeta` file as layers into napari. Depending on what is being opened, the reader will either load a full stack of labels and images, one slice of a stack of images and labels or an individual layer within a slice. This is to be used in conjunction with `label_image_pairs_to_zarr`.\n\n## .zmeta\n\nThis metadata file contains information about the layer types in the stack and in each individual slice, as well as the number of image/label slices. This allows the reader plugin to load the correct layer types with appropriate names both at a stack level and at the individual slice level.\n\n### An example .zmeta specification\n\n```json\n{\n    \"meta\": {\n        \"stack\": 7                               # number of slices in the entire stack (1 for an individual slice, 0 for a layer within a slice)\n    },\n    \"data\": {\n        \"image\" : [                              # all image layers must be listed here\n            {\n                \"name\": \"leaves_example_data\",\n                \"shape\": [790, 790, 3],\n                \"dtype\": \"uint8\",\n                \"rgb\": true                      # where rgb is false the image will be loaded as greyscale (colormap support has not yet been implemented)\n            }\n        ],\n        \"labels\" : [\n            {\n                \"name\": \"oak\",\n                \"shape\": [790, 790],\n                \"dtype\": \"int64\"\n            },\n            {\n                \"name\": \"bg\",\n                \"shape\": [790, 790],\n                \"dtype\": \"int64\"\n            }\n        ]\n    }\n}\n\n```\n\n\n----------------------------------\n\nThis [napari] plugin was generated with [Cookiecutter] using with [@napari]'s [cookiecutter-napari-plugin] template.\n\n<!--\nDon't miss the full getting started guide to set up your new package:\nhttps://github.com/napari/cookiecutter-napari-plugin#getting-started\n\nand review the napari docs for plugin developers:\nhttps://napari.org/docs/plugins/index.html\n-->\n\n## Installation\n\nYou can install `napari-compressed-labels-io` via [pip]:\n\n    pip install napari-compressed-labels-io\n\n## Contributing\n\nContributions are very welcome. Tests can be run with [tox], please ensure\nthe coverage at least stays the same before you submit a pull request.\n\n## License\n\nDistributed under the terms of the [MIT] license,\n\"napari-compressed-labels-io\" is free and open source software\n\n## Issues\n\nIf you encounter any problems, please [file an issue] along with a detailed description.\n\n[napari]: https://github.com/napari/napari\n[Cookiecutter]: https://github.com/audreyr/cookiecutter\n[@napari]: https://github.com/napari\n[MIT]: http://opensource.org/licenses/MIT\n[BSD-3]: http://opensource.org/licenses/BSD-3-Clause\n[GNU GPL v3.0]: http://www.gnu.org/licenses/gpl-3.0.txt\n[GNU LGPL v3.0]: http://www.gnu.org/licenses/lgpl-3.0.txt\n[Apache Software License 2.0]: http://www.apache.org/licenses/LICENSE-2.0\n[Mozilla Public License 2.0]: https://www.mozilla.org/media/MPL/2.0/index.txt\n[cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin\n[file an issue]: https://github.com/DragaDoncila/napari-compressed-labels-io/issues\n[napari]: https://github.com/napari/napari\n[tox]: https://tox.readthedocs.io/en/latest/\n[pip]: https://pypi.org/project/pip/\n[PyPI]: https://pypi.org/\n\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Draga Doncila",
+        "email": "ddoncila@gmail.com"
+      }
+    ],
+    "license": "MIT",
+    "python_version": ">=3.6",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-03-03T20:41:59.257726Z",
+    "version": "0.0.2",
+    "first_released": "2021-02-23T01:34:32.478790Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "affinder",
+    "summary": "Quickly find the affine matrix mapping one image to another using manual correspondence points annotation",
+    "description": "# affinder\n\n[![License](https://img.shields.io/pypi/l/affinder.svg?color=green)](https://github.com/napari/affinder/raw/master/LICENSE)\n[![PyPI](https://img.shields.io/pypi/v/affinder.svg?color=green)](https://pypi.org/project/affinder)\n[![Python Version](https://img.shields.io/pypi/pyversions/affinder.svg?color=green)](https://python.org)\n[![tests](https://github.com/jni/affinder/workflows/tests/badge.svg)](https://github.com/jni/affinder/actions)\n[![codecov](https://codecov.io/gh/jni/affinder/branch/master/graph/badge.svg)](https://codecov.io/gh/jni/affinder)\n\nQuickly find the affine matrix mapping one image to another using manual correspondence points annotation\n\n----------------------------------\n\nThis [napari] plugin was generated with [Cookiecutter] using with [@napari]'s [cookiecutter-napari-plugin] template.\n\n<!--\nDon't miss the full getting started guide to set up your new package:\nhttps://github.com/napari/cookiecutter-napari-plugin#getting-started\n\nand review the napari docs for plugin developers:\nhttps://napari.org/docs/plugins/index.html\n-->\n\n## Installation\n\nYou can install `affinder` via [pip]:\n\n    pip install affinder\n\n## Contributing\n\nContributions are very welcome. Tests can be run with [tox], please ensure\nthe coverage at least stays the same before you submit a pull request.\n\n## License\n\nDistributed under the terms of the [BSD-3] license,\n\"affinder\" is free and open source software\n\n## Issues\n\nIf you encounter any problems, please [file an issue] along with a detailed description.\n\n[napari]: https://github.com/napari/napari\n[Cookiecutter]: https://github.com/audreyr/cookiecutter\n[@napari]: https://github.com/napari\n[MIT]: http://opensource.org/licenses/MIT\n[BSD-3]: http://opensource.org/licenses/BSD-3-Clause\n[GNU GPL v3.0]: http://www.gnu.org/licenses/gpl-3.0.txt\n[GNU LGPL v3.0]: http://www.gnu.org/licenses/lgpl-3.0.txt\n[Apache Software License 2.0]: http://www.apache.org/licenses/LICENSE-2.0\n[Mozilla Public License 2.0]: https://www.mozilla.org/media/MPL/2.0/index.txt\n[cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin\n[file an issue]: https://github.com/jni/affinder/issues\n[napari]: https://github.com/napari/napari\n[tox]: https://tox.readthedocs.io/en/latest/\n[pip]: https://pypi.org/project/pip/\n[PyPI]: https://pypi.org/\n\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Juan Nunez-Iglesias",
+        "email": "juan.nunez-iglesias@monash.edu"
+      }
+    ],
+    "license": "BSD-3",
+    "python_version": ">=3.7",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-03-25T00:53:48.475737Z",
+    "version": "0.2.0",
+    "first_released": "2021-02-04T10:12:07.298699Z",
+    "development_status": ["Development Status :: 3 - Alpha"]
+  },
+  {
+    "name": "napping",
+    "summary": "Control point mapping and coordination transformation using napari",
+    "description": "# napping\n\n![PyPI](https://img.shields.io/pypi/v/napping)\n![PyPI - Python Version](https://img.shields.io/pypi/pyversions/napping)\n![PyPI - License](https://img.shields.io/pypi/l/napping)\n![GitHub issues](https://img.shields.io/github/issues/BodenmillerGroup/napping)\n![GitHub pull requests](https://img.shields.io/github/issues-pr/BodenmillerGroup/napping)\n\nControl point mapping and coordination transformation using napari\n\n## Requirements\n\nThis package requires Python 3.7 or newer.\n\nPython package dependencies are listed in [requirements.txt](https://github.com/BodenmillerGroup/napping/blob/main/requirements.txt).\n\nUsing virtual environments is strongly recommended.\n\n## Installation\n\nInstall napping and its dependencies with:\n\n    pip install napping\n\n### Environment setup example: mapping IMC and slidescanner images\n\nAs napari is under active development, the use of virtual environments is strongly encouraged. For example, to set up an environment for aligning Imaging Mass Cytometry (IMC, .mcd/.txt) and bright-field/immunofluorescence slidescanner (.czi) images:\n\n    conda create -n napping python\n    conda activate napping\n    pip install napping napari-imc napari-czifile2\n\nAfterwards, napping can be started from inside the environment:\n\n    napping\n\n## Usage\n\nUse `napping` for control point mapping and coordinate transformation\n\n## Authors\n\nCreated and maintained by Jonas Windhager [jonas.windhager@uzh.ch](mailto:jonas.windhager@uzh.ch)\n\n## Contributing\n\n[Contributing](https://github.com/BodenmillerGroup/napping/blob/main/CONTRIBUTING.md)\n\n## Changelog\n\n[Changelog](https://github.com/BodenmillerGroup/napping/blob/main/CHANGELOG.md)\n\n## License\n\n[MIT](https://github.com/BodenmillerGroup/napping/blob/main/LICENSE.md)\n\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Jonas Windhager",
+        "email": "jonas.windhager@uzh.ch"
+      }
+    ],
+    "license": "MIT",
+    "python_version": ">=3.7",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-03-15T23:01:07.633925Z",
+    "version": "0.1.7",
+    "first_released": "2021-02-02T20:57:19.679669Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "napari-console",
+    "summary": "A plugin that adds a console to napari",
+    "description": "# napari-console (WIP, under active development)\n\n[![License](https://img.shields.io/pypi/l/napari-console.svg?color=green)](https://github.com/napari/napari-console/raw/master/LICENSE)\n[![PyPI](https://img.shields.io/pypi/v/napari-console.svg?color=green)](https://pypi.org/project/napari-console)\n[![Python Version](https://img.shields.io/pypi/pyversions/napari-console.svg?color=green)](https://python.org)\n[![tests](https://github.com/sofroniewn/napari-console/workflows/tests/badge.svg)](https://github.com/sofroniewn/napari-console/actions)\n[![codecov](https://codecov.io/gh/sofroniewn/napari-console/branch/master/graph/badge.svg)](https://codecov.io/gh/sofroniewn/napari-console)\n\nA plugin that adds a console to napari\n\n----------------------------------\n\nThis [napari] plugin was generated with [Cookiecutter] using with [@napari]'s [cookiecutter-napari-plugin] template.\n\n<!--\nDon't miss the full getting started guide to set up your new package:\nhttps://github.com/napari/cookiecutter-napari-plugin#getting-started\n\nand review the napari docs for plugin developers:\nhttps://napari.org/docs/plugins/index.html\n-->\n\n## Installation\n\nYou can install `napari-console` via [pip]:\n\n    pip install napari-console\n\n## Contributing\n\nContributions are very welcome. Tests can be run with [tox], please ensure\nthe coverage at least stays the same before you submit a pull request.\n\n## License\n\nDistributed under the terms of the [BSD-3] license,\n\"napari-console\" is free and open source software\n\n## Issues\n\nIf you encounter any problems, please [file an issue] along with a detailed description.\n\n[napari]: https://github.com/napari/napari\n[Cookiecutter]: https://github.com/audreyr/cookiecutter\n[@napari]: https://github.com/napari\n[MIT]: http://opensource.org/licenses/MIT\n[BSD-3]: http://opensource.org/licenses/BSD-3-Clause\n[GNU GPL v3.0]: http://www.gnu.org/licenses/gpl-3.0.txt\n[GNU LGPL v3.0]: http://www.gnu.org/licenses/lgpl-3.0.txt\n[Apache Software License 2.0]: http://www.apache.org/licenses/LICENSE-2.0\n[Mozilla Public License 2.0]: https://www.mozilla.org/media/MPL/2.0/index.txt\n[cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin\n[file an issue]: https://github.com/sofroniewn/napari-console/issues\n[napari]: https://github.com/napari/napari\n[tox]: https://tox.readthedocs.io/en/latest/\n[pip]: https://pypi.org/project/pip/\n[PyPI]: https://pypi.org/\n\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Nicholas Sofroniew",
+        "email": "sofroniewn@gmail.com"
+      }
+    ],
+    "license": "BSD-3",
+    "python_version": ">=3.7",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-02-14T17:53:30.374963Z",
+    "version": "0.0.3",
+    "first_released": "2021-01-21T04:42:40.342150Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "napari-hdf5-labels-io",
+    "summary": "Napari plugin to store set of layers in a .h5 file. Label layer are stored in a sparse representation",
+    "description": "# napari-hdf5-labels-io\n\n[![License](https://img.shields.io/pypi/l/napari-hdf5-labels-io.svg?color=green)](https://github.com/yapic/napari-hdf5-labels-io/raw/master/LICENSE)\n[![PyPI](https://img.shields.io/pypi/v/napari-hdf5-labels-io.svg?color=green)](https://pypi.org/project/napari-hdf5-labels-io)\n[![Python Version](https://img.shields.io/pypi/pyversions/napari-hdf5-labels-io.svg?color=green)](https://python.org)\n[![tests](https://github.com/yapic/napari-hdf5-labels-io/workflows/tests/badge.svg)](https://github.com/yapic/napari-hdf5-labels-io/actions)\n[![codecov](https://codecov.io/gh/yapic/napari-hdf5-labels-io/branch/master/graph/badge.svg)](https://codecov.io/gh/yapic/napari-hdf5-labels-io)\n\nNapari plugin to store Napari projects in a .h5 file. Label layer are stored in a sparse representation (COO list).\n\n----------------------------------\n\nThis [napari] plugin was generated with [Cookiecutter] using with [@napari]'s [cookiecutter-napari-plugin] template.\n\n<!--\nDon't miss the full getting started guide to set up your new package:\nhttps://github.com/napari/cookiecutter-napari-plugin#getting-started\n\nand review the napari docs for plugin developers:\nhttps://napari.org/docs/plugins/index.html\n-->\n\n## Description\n\nThis Napari plugin provides a writer and reader to store existing layers in the current Napari window, all the metadata is stored as well in a HDF5 file. All the stored preferences are included when a project file is opened.\n\nLabel layers are stored in a coordinate list sparse representation with the [Sparse module](https://sparse.pydata.org/) to keep the project file size minimum (aiming to implement this in other layers in the future).\n\n## HDF5 file architecture\n\nThe project file is a HDF5 generated with the [h5py module](https://docs.h5py.org). The file groups correspond to the different Napari layer types and the layer metadata is stored as attributes of each layer.\n\nIn the case of the meta dictionary which is nested in the LayerData meta dictionary (Napari IO), new keys are generated in the outer dictionary to use them as h5 dataset attributes. This nested dictionary architecture is reconstructed by the reader to ensure format compatibility.\n\n## Installation\n\nYou can install `napari-hdf5-labels-io` via [pip]:\n\n    pip install napari-hdf5-labels-io\n\n## Contributing\n\nContributions are very welcome. Tests can be run with [tox], please ensure\nthe coverage at least stays the same before you submit a pull request.\n\n## License\n\nDistributed under the terms of the [GNU GPL v3.0] license,\n\"napari-hdf5-labels-io\" is free and open source software.\n\n## Issues\n\nIf you encounter any problems, please [file an issue] along with a detailed description.\n\n[napari]: https://github.com/napari/napari\n[Cookiecutter]: https://github.com/audreyr/cookiecutter\n[@napari]: https://github.com/napari\n[MIT]: http://opensource.org/licenses/MIT\n[BSD-3]: http://opensource.org/licenses/BSD-3-Clause\n[GNU GPL v3.0]: http://www.gnu.org/licenses/gpl-3.0.txt\n[GNU LGPL v3.0]: http://www.gnu.org/licenses/lgpl-3.0.txt\n[Apache Software License 2.0]: http://www.apache.org/licenses/LICENSE-2.0\n[Mozilla Public License 2.0]: https://www.mozilla.org/media/MPL/2.0/index.txt\n[cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin\n[file an issue]: https://github.com/yapic/napari-hdf5-labels-io/issues\n[napari]: https://github.com/napari/napari\n[tox]: https://tox.readthedocs.io/en/latest/\n[pip]: https://pypi.org/project/pip/\n[PyPI]: https://pypi.org/\n\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Duway Nicolas Lesmes Leon",
+        "email": "dlesmesleon@hotmail.com"
+      }
+    ],
+    "license": "GNU GPL v3.0",
+    "python_version": "<3.9",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-04-07T12:15:01.683207Z",
+    "version": "0.2.dev13",
+    "first_released": "2021-03-04T09:44:01.947204Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "PlatyMatch",
+    "summary": "`PlatyMatch` allows registration of volumetric images of embryos by establishing correspondences between cells",
+    "description": "# PlatyMatch\n\n[![License](https://img.shields.io/pypi/l/PlatyMatch.svg?color=green)](https://github.com/mlbyml/PlatyMatch/raw/master/LICENSE)\n[![PyPI](https://img.shields.io/pypi/v/PlatyMatch.svg?color=green)](https://pypi.org/project/PlatyMatch)\n[![Python Version](https://img.shields.io/pypi/pyversions/PlatyMatch.svg?color=green)](https://python.org)\n[![tests](https://github.com/mlbyml/PlatyMatch/workflows/tests/badge.svg)](https://github.com/mlbyml/PlatyMatch/actions)\n[![codecov](https://codecov.io/gh/mlbyml/PlatyMatch/branch/master/graph/badge.svg)](https://codecov.io/gh/mlbyml/PlatyMatch)\n\n`PlatyMatch` allows registration of volumetric images of embryos by establishing correspondences between cells\n\n----------------------------------\n\nThis [napari] plugin was generated with [Cookiecutter] using with [@napari]'s [cookiecutter-napari-plugin] template.\n\n<!--\nDon't miss the full getting started guide to set up your new package:\nhttps://github.com/napari/cookiecutter-napari-plugin#getting-started\n\nand review the napari docs for plugin developers:\nhttps://napari.org/docs/plugins/index.html\n-->\n\n## Installation\n\nYou can install `PlatyMatch` via [pip]:\n\n    pip install PlatyMatch\n\n## Contributing\n\nContributions are very welcome. Tests can be run with [tox], please ensure\nthe coverage at least stays the same before you submit a pull request.\n\n## License\n\nDistributed under the terms of the [BSD-3] license,\n\"PlatyMatch\" is free and open source software\n\n## Issues\n\nIf you encounter any problems, please [file an issue] along with a detailed description.\n\n[napari]: https://github.com/napari/napari\n[Cookiecutter]: https://github.com/audreyr/cookiecutter\n[@napari]: https://github.com/napari\n[MIT]: http://opensource.org/licenses/MIT\n[BSD-3]: http://opensource.org/licenses/BSD-3-Clause\n[GNU GPL v3.0]: http://www.gnu.org/licenses/gpl-3.0.txt\n[GNU LGPL v3.0]: http://www.gnu.org/licenses/lgpl-3.0.txt\n[Apache Software License 2.0]: http://www.apache.org/licenses/LICENSE-2.0\n[Mozilla Public License 2.0]: https://www.mozilla.org/media/MPL/2.0/index.txt\n[cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin\n[file an issue]: https://github.com/mlbyml/PlatyMatch/issues\n[napari]: https://github.com/napari/napari\n[tox]: https://tox.readthedocs.io/en/latest/\n[pip]: https://pypi.org/project/pip/\n[PyPI]: https://pypi.org/\n\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Manan Lalit",
+        "email": "lalit@mpi-cbg.de"
+      }
+    ],
+    "license": "BSD-3",
+    "python_version": ">=3.6",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-05-03T23:28:19.818975Z",
+    "version": "0.0.2",
+    "first_released": "2021-05-03T23:28:19.818975Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "napari_video",
+    "summary": "napari plugin for reading videos.",
+    "description": "# napari-video\nNapari plugin for working with videos.\n\nRelies on [pyvideoreader](https://pypi.org/project/pyvideoreader/) as a backend which itself uses [opencv](https://opencv.org) for reading videos.\n\n## Installation\n```shell\npip install napari[all] napari_video\n```\n\n## Usage\nFrom a terminal:\n```shell\nnapari video.avi\n```\n\nOr from within python:\n```shell\nimport napari\nfrom napari_video.napari_video import VideoReaderNP\n\npath='video.mp4'\nvr = VideoReaderNP(path)\nwith napari.gui_qt():\n    viewer = napari.view_image(vr, name=path)\n```\n\n## Internals\n`napari_video.napari_video.VideoReaderNP` exposes a video with a numpy-like interface, using opencv as a backend.\n\nFor instance, open a video:\n```python\nvr = VideoReaderNP('video.avi')\nprint(vr)\n```\n```\nvideo.avi with 60932 frames of size (920, 912, 3) at 100.00 fps\n```\nThen\n\n- `vr[100]` will return the 100th frame as a numpy array with shape `(902, 912, 3)`.\n- `vr[100:200:10]` will return 10 frames evenly spaced between frame number 100 and 200 (shape `(10, 902, 912, 3)`).\n- Note that by default, single-frame and slice indexing return 3D and 4D arrays, respectively. To consistently return 4D arrays, open the video with `remove_leading_singleton=True`. `vr[100]` will then return a `(1, 902, 912, 3)` array.\n- We can also request specific ROIs and channels. For instance, `vr[100:200:10,100:400,800:850,1]` will return an array with shape `(10, 300, 50, 1)`.\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Jan Clemens",
+        "email": "clemensjan@googlemail.com"
+      }
+    ],
+    "license": "",
+    "python_version": ">=3.6",
+    "operating_system": [],
+    "release_date": "2021-03-16T11:36:22.298000Z",
+    "version": "0.2.6",
+    "first_released": "2021-02-27T15:40:14.736684Z",
+    "development_status": []
+  },
+  {
+    "name": "cellfinder-napari",
+    "summary": "Efficient cell detection in large images",
+    "description": "# cellfinder-napari\n\n[![License](https://img.shields.io/pypi/l/cellfinder-napari.svg?color=green)](https://github.com/napari/cellfinder-napari/raw/master/LICENSE)\n[![PyPI](https://img.shields.io/pypi/v/cellfinder-napari.svg?color=green)](https://pypi.org/project/cellfinder-napari)\n[![Python Version](https://img.shields.io/pypi/pyversions/cellfinder-napari.svg?color=green)](https://python.org)\n[![tests](https://github.com/brainglobe/cellfinder-napari/workflows/tests/badge.svg)](https://github.com/brainglobe/cellfinder-napari/actions)\n[![codecov](https://codecov.io/gh/brainglobe/cellfinder-napari/branch/master/graph/badge.svg)](https://codecov.io/gh/brainglobe/cellfinder-napari)\n[![Downloads](https://pepy.tech/badge/cellfinder-napari)](https://pepy.tech/project/cellfinder-napari)\n[![Wheel](https://img.shields.io/pypi/wheel/cellfinder.svg)](https://pypi.org/project/cellfinder)\n[![Development Status](https://img.shields.io/pypi/status/cellfinder-napari.svg)](https://github.com/brainglobe/cellfinder-napari)\n[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)\n[![Gitter](https://badges.gitter.im/brainglobe.svg)](https://gitter.im/BrainGlobe/cellfinder/?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)\n[![Contributions](https://img.shields.io/badge/Contributions-Welcome-brightgreen.svg)](https://docs.brainglobe.info/cellfinder/contributing)\n[![Website](https://img.shields.io/website?up_message=online&url=https%3A%2F%2Fcellfinder.info)](https://cellfinder.info)\n[![Twitter](https://img.shields.io/twitter/follow/findingcells?style=social)](https://twitter.com/findingcells)\n\n\n\n### Efficient cell detection in large images (e.g. whole mouse brain images)\n\nThis package implements the cell detection algorithm from \n[Tyson, Rousseau & Niedworok et al. (2021)](https://www.biorxiv.org/content/10.1101/2020.10.21.348771v2) \nfor [napari](https://napari.org/index.html), based on the \n[cellfinder-core](https://github.com/brainglobe/cellfinder-core) package.\n\nThis algorithm can also be used within the original \n[cellfinder](https://github.com/brainglobe/cellfinder) software for \nwhole-brain microscopy analysis.\n\n----\n![raw](https://raw.githubusercontent.com/brainglobe/cellfinder-napari/master/resources/cellfinder-napari.gif)\n\n**Visualising detected cells in the cellfinder napari plugin**\n\n----\n## Instructions\n\n### Installation\nOnce you have [installed napari](https://napari.org/index.html#installation). \nYou can install napari either through the napari plugin installation tool, or \ndirectly from PyPI with:\n```bash\npip install cellfinder-napari\n```\n\n### Usage\nFull documentation can be \nfound [here](https://docs.brainglobe.info/cellfinder-napari). \n\nThis software is at a very early stage, and was written with our data in mind. \nOver time we hope to support other data types/formats. If you have any \nquestions or issues, please get in touch by \n[email](mailto:code@adamltyson.com?subject=cellfinder-napari), \n[gitter](https://gitter.im/BrainGlobe/cellfinder) or by \n[raising an issue](https://github.com/brainglobe/cellfinder-napari/issues).\n\n\n---\n## Illustration\n\n### Introduction\ncellfinder takes a stitched, but otherwise raw whole-brain dataset with at least \ntwo channels:\n * Background channel (i.e. autofluorescence)\n * Signal channel, the one with the cells to be detected:\n\n![raw](https://raw.githubusercontent.com/brainglobe/cellfinder/master/resources/raw.png)\n**Raw coronal serial two-photon mouse brain image showing labelled cells**\n\n\n### Cell candidate detection\nClassical image analysis (e.g. filters, thresholding) is used to find \ncell-like objects (with false positives):\n\n![raw](https://raw.githubusercontent.com/brainglobe/cellfinder/master/resources/detect.png)\n**Candidate cells (including many artefacts)**\n\n\n### Cell candidate classification\nA deep-learning network (ResNet) is used to classify cell candidates as true \ncells or artefacts:\n\n![raw](https://raw.githubusercontent.com/brainglobe/cellfinder/master/resources/classify.png)\n**Cassified cell candidates. Yellow - cells, Blue - artefacts**\n\n## Citing cellfinder\n\nIf you find this plugin useful, and use it in your research, please cite the preprint outlining the cell detection algorithm:\n> Tyson, A. L., Rousseau, C. V., Niedworok, C. J., Keshavarzi, S., Tsitoura, C., Cossell, L., Strom, M. and Margrie, T. W. (2021) “A deep learning algorithm for 3D cell detection in whole mouse brain image datasets’ bioRxiv, [doi.org/10.1101/2020.10.21.348771](https://doi.org/10.1101/2020.10.21.348771)\n\n\n**If you use this, or any other tools in the brainglobe suite, please\n [let us know](mailto:code@adamltyson.com?subject=cellfinder-napari), and \n we'd be happy to promote your paper/talk etc.**\n\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Adam Tyson",
+        "email": "code@adamltyson.com"
+      }
+    ],
+    "license": "GPL-3.0",
+    "python_version": ">=3.6",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-04-27T16:58:33.081813Z",
+    "version": "0.0.9",
+    "first_released": "2021-01-25T16:40:18.651958Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "napari-svg",
+    "summary": "A plugin for reading and writing svg files with napari",
+    "description": "# napari-svg\n\n[![License](https://img.shields.io/pypi/l/napari-svg.svg?color=green)](https://github.com/napari/napari-svg/raw/master/LICENSE)\n[![PyPI](https://img.shields.io/pypi/v/napari-svg.svg?color=green)](https://pypi.org/project/napari-svg)\n[![Python Version](https://img.shields.io/pypi/pyversions/napari-svg.svg?color=green)](https://python.org)\n[![tests](https://github.com/napari/napari-svg/workflows/tests/badge.svg)](https://github.com/napari/napari-svg/actions)\n[![codecov](https://codecov.io/gh/napari/napari-svg/branch/master/graph/badge.svg)](https://codecov.io/gh/napari/napari-svg)\n\nA plugin for reading and writing svg files with napari\n\n----------------------------------\n\nThis [napari] plugin was generated with [Cookiecutter] using with [@napari]'s [cookiecutter-napari-plugin] template.\n\n<!--\nDon't miss the full getting started guide to set up your new package:\nhttps://github.com/napari/cookiecutter-napari-plugin#getting-started\n\nand review the napari docs for plugin developers:\nhttps://napari.org/docs/plugins/index.html\n-->\n\n## Installation\n\nYou can install `napari-svg` via [pip]:\n\n    pip install napari-svg\n\n## Contributing\n\nContributions are very welcome. Tests can be run with [tox], please ensure\nthe coverage at least stays the same before you submit a pull request.\n\n## License\n\nDistributed under the terms of the [BSD-3] license,\n\"napari-svg\" is free and open source software\n\n## Issues\n\nIf you encounter any problems, please [file an issue] along with a detailed description.\n\n[napari]: https://github.com/napari/napari\n[Cookiecutter]: https://github.com/audreyr/cookiecutter\n[@napari]: https://github.com/napari\n[MIT]: http://opensource.org/licenses/MIT\n[BSD-3]: http://opensource.org/licenses/BSD-3-Clause\n[GNU GPL v3.0]: http://www.gnu.org/licenses/gpl-3.0.txt\n[GNU LGPL v3.0]: http://www.gnu.org/licenses/lgpl-3.0.txt\n[Apache Software License 2.0]: http://www.apache.org/licenses/LICENSE-2.0\n[Mozilla Public License 2.0]: https://www.mozilla.org/media/MPL/2.0/index.txt\n[cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin\n[file an issue]: https://github.com/napari/napari-svg/issues\n[napari]: https://github.com/napari/napari\n[tox]: https://tox.readthedocs.io/en/latest/\n[pip]: https://pypi.org/project/pip/\n[PyPI]: https://pypi.org/\n\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Nicholas Sofroniew",
+        "email": "sofroniewn@gmail.com"
+      }
+    ],
+    "license": "BSD-3",
+    "python_version": ">=3.7",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-05-01T17:44:08.372420Z",
+    "version": "0.1.5",
+    "first_released": "2020-04-13T03:37:20.169990Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "napari-yapic-prediction",
+    "summary": "Napari widget plugin to perform yapic model segmentation prediction in the napari window",
+    "description": "# napari-yapic-prediction\n\n[![License](https://img.shields.io/pypi/l/napari-yapic-prediction.svg?color=green)](https://github.com/yapic/napari-yapic-prediction/raw/master/LICENSE)\n[![PyPI](https://img.shields.io/pypi/v/napari-yapic-prediction.svg?color=green)](https://pypi.org/project/napari-yapic-prediction)\n[![Python Version](https://img.shields.io/pypi/pyversions/napari-yapic-prediction.svg?color=green)](https://python.org)\n[![tests](https://github.com/yapic/napari-yapic-prediction/workflows/tests/badge.svg)](https://github.com/yapic/napari-yapic-prediction/actions)\n[![codecov](https://codecov.io/gh/yapic/napari-yapic-prediction/branch/master/graph/badge.svg?token=amah2YwOpx)](https://codecov.io/gh/yapic/napari-yapic-prediction)\n\nnapari widget plugin to perform YAPiC model segmentation prediction in the napari window.\n\n----------------------------------\n\nThis [napari] plugin was generated with [Cookiecutter] using with [@napari]'s [cookiecutter-napari-plugin] template.\n\n<!--\nDon't miss the full getting started guide to set up your new package:\nhttps://github.com/napari/cookiecutter-napari-plugin#getting-started\n\nand review the napari docs for plugin developers:\nhttps://napari.org/docs/plugins/index.html\n-->\n\n## Description\n\nThis napari plugin provides a widget to upload a [YAPiC] trained model and perform segmentation over all the present images in the napari window. The segmentation results are uploaded as napari layers into the viewer automatically with the name structure of *imgename_prediction*.\n\n## Installation\n\n1. Please install either GPU or CPU version of tensorflow before installing the plugin depending on your system.\nOne of the plugin dependency is `yapic` that currently has sensitivity to tensorflow versions.\nThis behaviour will be removed in future.\n\n2. You can install `napari-yapic-prediction` via [pip]:\n\n    pip install napari-yapic-prediction\n\n## Contributing\n\nContributions are very welcome. Tests can be run with [tox], please ensure\nthe coverage at least stays the same before you submit a pull request.\n\n## License\n\nDistributed under the terms of the [GNU GPL v3.0] license,\n\"napari-yapic-prediction\" is free and open source software\n\n## Issues\n\nIf you encounter any problems, please [file an issue] along with a detailed description.\n\n[napari]: https://github.com/napari/napari\n[Cookiecutter]: https://github.com/audreyr/cookiecutter\n[@napari]: https://github.com/napari\n[MIT]: http://opensource.org/licenses/MIT\n[BSD-3]: http://opensource.org/licenses/BSD-3-Clause\n[GNU GPL v3.0]: http://www.gnu.org/licenses/gpl-3.0.txt\n[GNU LGPL v3.0]: http://www.gnu.org/licenses/lgpl-3.0.txt\n[Apache Software License 2.0]: http://www.apache.org/licenses/LICENSE-2.0\n[Mozilla Public License 2.0]: https://www.mozilla.org/media/MPL/2.0/index.txt\n[cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin\n[file an issue]: https://github.com/yapic/napari-yapic-prediction/issues\n[napari]: https://github.com/napari/napari\n[tox]: https://tox.readthedocs.io/en/latest/\n[pip]: https://pypi.org/project/pip/\n[PyPI]: https://pypi.org/\n[YAPiC]: https://yapic.github.io/yapic/\n\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Duway Nicolas Lesmes Leon",
+        "email": "dlesmesleon@hotmail.com"
+      }
+    ],
+    "license": "GNU GPL v3.0",
+    "python_version": ">=3.6",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-04-21T14:05:54.980081Z",
+    "version": "0.1.dev78",
+    "first_released": "2021-04-19T08:42:54.339457Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "napari-demo",
+    "summary": "demo plugin",
+    "description": "Hi there,\nThis is a demo Description\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Ziyang Liu",
+        "email": "zliu@chanzuckerberg.com"
+      },
+      {
+        "name": "Justin T. Kiggins",
+        "orcid": "0000-0002-4638-7015"
+      }
+    ],
+    "license": "BSD-3",
+    "python_version": ">=3.6",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-04-27T00:06:41.696334Z",
+    "version": "0.0.2",
+    "first_released": "2021-01-27T19:22:41.381119Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "ome-zarr",
+    "summary": "Implementation of images in Zarr files.",
+    "description": "===========\nome-zarr-py\n===========\n\nExperimental support for multi-resolution images stored in Zarr filesets, according to the `OME zarr spec`_.\n\n\nFeatures\n--------\n\n- Use as a image reader plugin for `napari`_. The `napari`_ plugin was generated with `Cookiecutter`_ along with `@napari`_'s `cookiecutter-napari-plugin`_ template.\n- Simple command-line to read and download conforming Zarr filesets.\n- Helper methods for parsing related metadata.\n\n\nInstallation\n------------\n\nInstall the latest release of `ome-zarr`_ from PyPI::\n\n    pip install ome-zarr\n\n\nInstall developer mode to run from your current branch::\n\n    git clone git@github.com:ome/ome-zarr-py.git\n    cd ome-zarr-py\n    pip install -e .\n\n\nUsage\n-----\n\nOpen Zarr filesets containing images with associated OME metadata.\nThe examples below use the image at http://idr.openmicroscopy.org/webclient/?show=image-6001240.\n\nAll examples can be made more or less verbose by passing `-v` or `-q` one or more times::\n\n    # ome_zarr -vvv ...\n\n\ninfo\n====\n\nUse the `ome_zarr` command to interrogate Zarr datasets::\n\n    # Remote data\n    $ ome_zarr info https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr/\n\n    # Local data (after downloading as below)\n    $ ome_zarr info 6001240.zarr/\n\ndownload\n========\n\nTo download all the resolutions and metadata for an image::\n\n    # creates local 6001240.zarr/\n    $ ome_zarr download https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr/\n\n    # Specify output directory\n    $ ome_zarr download https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr/ --output image_dir\n\nnapari plugin\n=============\n\nNapari will use `ome-zarr` to open images that the plugin recognises as ome-zarr.\nThe image metadata from OMERO will be used to set channel names and rendering settings\nin napari::\n\n    $ napari 'https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr/'\n\n    # Also works with local files\n    $ napari 6001240.zarr\n\nOR in python::\n\n    import napari\n    with napari.gui_qt():\n        viewer = napari.Viewer()\n        viewer.open('https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr/')\n\nIf single zarray is passed to the plugin, it will be opened without the use of\nthe metadata::\n\n    $ napari '/tmp/6001240.zarr/0'\n\ncsv to labels\n=============\n\nThe `csv_to_labels` command uses a CSV file to add key:value properties to labels\nunder an OME-Zarr Image or Plate.\n\nThe OME-Zarr labels metadata must already contain a `properties`\nlist of `{key:value}` objects, each with a unique key:ID. This key is `omero:shapeId`\nin the example below.\n\nThis ID can be used to identify a single row of the CSV table by specifying the name of\na column with unique values, e.g. `shape_id` below.\nThis row is used to add additional column_name:value data to the label properties.\n\nYou also need to specify which columns from the CSV to use, e.g. `\"area,X,Y,Width,Height\"`.\nYou can also specify the column types (as in https://github.com/ome/omero-metadata/)\nto specify the data-type for each column (string by default).\n\n - `d`: `DoubleColumn`, for floating point numbers\n - `l`: `LongColumn`, for integer numbers\n - `s`: `StringColumn`, for text\n - `b`: `BoolColumn`, for true/false\n\nUse e.g. `#d` as a suffix in the column name to denote a `float` column, no spaces etc:\n```\n\"area#d,label_text#s,Width#l,Height#l\"\n```\n\nFor example, to take values from columns named `area`, `label_text`, `Width` and `Height`\nwithin a CSV file named `labels_data.csv` with an ID column named `shape_id` and add these\nvalues to label properties with an ID key of `omero:shapeId` in an Image or Plate named `123.zarr`::\n\n    ome_zarr csv_to_labels labels_data.csv shape_id \"area#d,label_text#s,Width#l,Height#l\" 123.zarr omero:shapeId```\n\n\nRelease process\n---------------\n\nThis repository uses `bump2version <https://pypi.org/project/bump2version/>`_ to manage version numbers.\nTo tag a release run::\n\n    $ bumpversion release\n\nThis will remove the ``.dev0`` suffix from the current version, commit, and tag the release.\n\nTo switch back to a development version run::\n\n    $ bumpversion --no-tag [major|minor|patch]\n\nspecifying ``major``, ``minor`` or ``patch`` depending on whether the development branch will be a `major, minor or patch release <https://semver.org/>`_. This will also add the ``.dev0`` suffix.\n\nRemember to ``git push`` all commits and tags.\n\n\nLicense\n-------\n\nDistributed under the terms of the `BSD`_ license,\n\"ome-zarr-py\" is free and open source software\n\n.. _`OME zarr spec`: https://github.com/ome/omero-ms-zarr/blob/master/spec.md\n.. _`Cookiecutter`: https://github.com/audreyr/cookiecutter\n.. _`@napari`: https://github.com/napari\n.. _`BSD`: https://opensource.org/licenses/BSD-2-Clause\n.. _`Apache Software License 2.0`: http://www.apache.org/licenses/LICENSE-2.0\n.. _`Mozilla Public License 2.0`: https://www.mozilla.org/media/MPL/2.0/index.txt\n.. _`cookiecutter-napari-plugin`: https://github.com/napari/cookiecutter-napari-plugin\n.. _`napari`: https://github.com/napari/napari\n.. _`ome-zarr`: https://pypi.org/project/ome-zarr/\n\n\n",
+    "description_content_type": "",
+    "authors": [
+      {
+        "name": "The Open Microscopy Team",
+        "email": ""
+      }
+    ],
+    "license": "",
+    "python_version": ">=3.6",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-04-24T09:52:11.611073Z",
+    "version": "0.0.18",
+    "first_released": "2020-05-06T15:58:47.352058Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "napari-brainreg",
+    "summary": "Visualise brainreg registration output",
+    "description": "# napari-brainreg\n\n[![License](https://img.shields.io/pypi/l/napari-brainreg.svg?color=green)](https://github.com/brainglobe/napari-brainreg/raw/master/LICENSE)\n[![PyPI](https://img.shields.io/pypi/v/napari-brainreg.svg?color=green)](https://pypi.org/project/napari-brainreg)\n[![Python Version](https://img.shields.io/pypi/pyversions/napari-brainreg.svg?color=green)](https://python.org)\n[![tests](https://github.com/brainglobe/napari-brainreg/workflows/tests/badge.svg)](https://github.com/brainglobe/napari-brainreg/actions)\n[![Development Status](https://img.shields.io/pypi/status/napari-brainreg.svg)](https://github.com/brainglobe/napari-brainreg)\n[![codecov](https://codecov.io/gh/brainglobe/napari-brainreg/branch/master/graph/badge.svg)](https://codecov.io/gh/brainglobe/napari-brainreg)\n[![Gitter](https://badges.gitter.im/cellfinder/brainreg.svg)](https://gitter.im/cellfinder/brainreg?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)\n\nVisualise [brainreg](https://github.com/brainglobe/brainreg) registration output in [napari](https://github.com/napari/napari)\n\nBased on the [napari cookiecutter plugin template](https://github.com/napari/cookiecutter-napari-plugin) and [napari-ndtiffs](https://github.com/tlambert03/napari-ndtiffs) by [@tlambert03](https://github.com/tlambert03)\n\n----------------------------------\n\n## Installation\nAssuming you already have [napari](https://github.com/napari/napari) installed, you can install `napari-brainreg` via pip:\n\n    pip install napari-brainreg\n\n## Usage\n#### Sample space\nOpen napari and drag your [brainreg](https://github.com/brainglobe/brainreg) output directory (the one with the log file) onto the napari window.\n\nVarious images should then open, including:\n* `Registered image` - the image used for registration, downsampled to atlas resolution\n* `atlas_name` - e.g. `allen_mouse_25um` the atlas labels, warped to your sample brain\n* `Boundaries` - the boundaries of the atlas regions\n\nIf you downsampled additional channels, these will also be loaded.\n\nMost of these images will not be visible by default. Click the little eye icon to toggle visibility.\n\n_N.B. If you use a high resolution atlas (such as `allen_mouse_10um`), then the files can take a little while to load._\n\n![sample_space](https://raw.githubusercontent.com/brainglobe/napari-brainreg/master/resources/sample_space.gif)\n\n\n#### Atlas space\n`napari-brainreg` also comes with an additional plugin, for visualising your data \nin atlas space. \n\nThis is typically only used in other software, but you can enable it yourself:\n* Open napari\n* Navigate to `Plugins` -> `Plugin Call Order`\n* In the `Plugin Sorter` window, select `napari_get_reader` from the `select hook...` dropdown box\n* Drag `brainreg_standard` (the atlas space viewer plugin) above `brainreg` (the normal plugin) to ensure that the atlas space plugin is used preferentially.\n\n![atlas_space](https://raw.githubusercontent.com/brainglobe/napari-brainreg/master/resources/atlas_space.gif)\n\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Adam Tyson",
+        "email": "adam.tyson@ucl.ac.uk"
+      }
+    ],
+    "license": "MIT",
+    "python_version": ">=3.6",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2020-11-13T13:48:23.695512Z",
+    "version": "0.2.3",
+    "first_released": "2020-08-12T16:20:36.226724Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "napari-itk-io",
+    "summary": "File IO with itk for napari",
+    "description": "# napari-itk-io\n\n[![License](https://img.shields.io/pypi/l/napari-itk-io.svg?color=green)](https://github.com/InsightSoftwareConsortium/napari-itk-io/raw/master/LICENSE)\n[![PyPI](https://img.shields.io/pypi/v/napari-itk-io.svg?color=green)](https://pypi.org/project/napari-itk-io)\n[![Python Version](https://img.shields.io/pypi/pyversions/napari-itk-io.svg?color=green)](https://python.org)\n[![tests](https://github.com/InsightSoftwareConsortium/napari-itk-io/workflows/tests/badge.svg)](https://github.com/InsightSoftwareConsortium/napari-itk-io/actions)\n[![codecov](https://codecov.io/gh/InsightSoftwareConsortium/napari-itk-io/branch/master/graph/badge.svg)](https://codecov.io/gh/InsightSoftwareConsortium/napari-itk-io)\n\nFile IO with itk for napari.\n\nSupported image file formats:\n\n- [BioRad](http://www.bio-rad.com/)\n- [BMP](https://en.wikipedia.org/wiki/BMP_file_format)\n- [DICOM](http://dicom.nema.org/)\n- [DICOM Series](http://dicom.nema.org/)\n- [ITK HDF5](https://support.hdfgroup.org/HDF5/)\n- [JPEG](https://en.wikipedia.org/wiki/JPEG_File_Interchange_Format)\n- [GE4,GE5,GEAdw](http://www3.gehealthcare.com)\n- [Gipl (Guys Image Processing Lab)](https://www.ncbi.nlm.nih.gov/pubmed/12956259)\n- [LSM](http://www.openwetware.org/wiki/Dissecting_LSM_files)\n- [MetaImage](https://itk.org/Wiki/ITK/MetaIO/Documentation)\n- [MINC 2.0](https://en.wikibooks.org/wiki/MINC/SoftwareDevelopment/MINC2.0_File_Format_Reference)\n- [MGH](https://surfer.nmr.mgh.harvard.edu/fswiki/FsTutorial/MghFormat)\n- [MRC](http://www.ccpem.ac.uk/mrc_format/mrc_format.php)\n- [NifTi](https://nifti.nimh.nih.gov/nifti-1)\n- [NRRD](http://teem.sourceforge.net/nrrd/format.html)\n- [Portable Network Graphics (PNG)](https://en.wikipedia.org/wiki/Portable_Network_Graphics)\n- [Tagged Image File Format (TIFF)](https://en.wikipedia.org/wiki/TIFF)\n- [VTK legacy file format for images](http://www.vtk.org/VTK/img/file-formats.pdf)\n\nFor DICOM Series, select the folder containing the series with *File -> Open\nFolder...*. The first series will be selected and sorted spatially.\n\n## Installation\n\nYou can install `napari-itk-io` via [pip]:\n\n    pip install napari-itk-io\n\n## Contributing\n\nContributions are very welcome. Tests can be run with [tox], please ensure\nthe coverage at least stays the same before you submit a pull request.\n\nFollow the [itk contributing\nguidelines](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CONTRIBUTING.md)\nand the [itk code of\nconduct](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CODE_OF_CONDUCT.md).\n\n## License\n\nDistributed under the terms of the [Apache Software License 2.0] license,\n\"napari-itk-io\" is free and open source software.\n\n## Issues\n\nIf you encounter any problems, please [file an issue] along with a detailed description.\n\n[napari]: https://github.com/napari/napari\n[Cookiecutter]: https://github.com/audreyr/cookiecutter\n[@napari]: https://github.com/napari\n[MIT]: http://opensource.org/licenses/MIT\n[BSD-3]: http://opensource.org/licenses/BSD-3-Clause\n[GNU GPL v3.0]: http://www.gnu.org/licenses/gpl-3.0.txt\n[GNU LGPL v3.0]: http://www.gnu.org/licenses/lgpl-3.0.txt\n[Apache Software License 2.0]: http://www.apache.org/licenses/LICENSE-2.0\n[Mozilla Public License 2.0]: https://www.mozilla.org/media/MPL/2.0/index.txt\n[cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin\n[file an issue]: https://github.com/InsightSoftwareConsortium/napari-itk-io/issues\n[napari]: https://github.com/napari/napari\n[tox]: https://tox.readthedocs.io/en/latest/\n[pip]: https://pypi.org/project/pip/\n[PyPI]: https://pypi.org/\n\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Matt McCormick",
+        "email": "matt.mccormick@kitware.com"
+      }
+    ],
+    "license": "Apache Software License 2.0",
+    "python_version": ">=3.6",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-04-29T04:38:13.802370Z",
+    "version": "0.1.0",
+    "first_released": "2021-04-28T22:49:15.780944Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "napari-imc",
+    "summary": "Imaging Mass Cytometry (IMC) file type support for napari",
+    "description": "# napari-imc\n\n![PyPI](https://img.shields.io/pypi/v/napari-imc)\n![PyPI - Python Version](https://img.shields.io/pypi/pyversions/napari-imc)\n![PyPI - License](https://img.shields.io/pypi/l/napari-imc)\n![GitHub issues](https://img.shields.io/github/issues/BodenmillerGroup/napari-imc)\n![GitHub pull requests](https://img.shields.io/github/issues-pr/BodenmillerGroup/napari-imc)\n\nImaging Mass Cytometry (IMC) file type support for napari\n\nOpen .mcd/.txt files and interactively view panoramas and multi-channel acquisitions using napari\n\n## Requirements\n\nThis package requires Python 3.7 or newer.\n\nPython package dependencies are listed in [requirements.txt](https://github.com/BodenmillerGroup/napari-imc/blob/main/requirements.txt).\n\nPlease note that napari is under active development. Currently, this package supports napari 0.4.5 and newer. \n\nUsing virtual environments is strongly recommended.\n\n## Installation\n\nEnsure that `napari[all]` is installed.\n\nInstall napari-imc and its dependencies with:\n\n    pip install napari-imc\n\n## Usage\n\nUse `napari` to open Imaging Mass Cytometry (IMC) .mcd/.txt files\n\n## Authors\n\nCreated and maintained by Jonas Windhager [jonas.windhager@uzh.ch](mailto:jonas.windhager@uzh.ch)\n\n## Contributing\n\n[Contributing](https://github.com/BodenmillerGroup/napari-imc/blob/main/CONTRIBUTING.md)\n\n## Changelog\n\n[Changelog](https://github.com/BodenmillerGroup/napari-imc/blob/main/CHANGELOG.md)\n\n## License\n\n[MIT](https://github.com/BodenmillerGroup/napari-imc/blob/main/LICENSE.md)\n\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Jonas Windhager",
+        "email": "jonas.windhager@uzh.ch"
+      }
+    ],
+    "license": "MIT",
+    "python_version": ">=3.7",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-03-15T22:07:59.411993Z",
+    "version": "0.5.3",
+    "first_released": "2021-01-19T00:32:41.040698Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "napari-mri",
+    "summary": "A simple plugin to use with napari for 3D-viewing of                  Magnetic Resonance Imaging file formats",
+    "description": "# napari-mri\n\n[![License](https://img.shields.io/pypi/l/napari-mri.svg?color=green)](https://github.com/sahas111/napari-mri/raw/master/LICENSE)\n[![PyPI](https://img.shields.io/pypi/v/napari-mri.svg?color=green)](https://pypi.org/project/napari-mri)\n[![Python Version](https://img.shields.io/pypi/pyversions/napari-mri.svg?color=green)](https://python.org)\n[![tests](https://github.com/sahas111/napari-mri/workflows/tests/badge.svg)](https://github.com/sahas111/napari-mri/actions)\n[![codecov](https://codecov.io/gh/sahas111/napari-mri/branch/master/graph/badge.svg)](https://codecov.io/gh/sahas111/napari-mri)\n\nA simple plugin to use with napari for 3D-viewing of Magnetic Resonance Imaging file formats\n\n----------------------------------\n\nThis [napari] plugin was generated with [Cookiecutter] using with [@napari]'s [cookiecutter-napari-plugin] template.\n\n<!--\nDon't miss the full getting started guide to set up your new package:\nhttps://github.com/napari/cookiecutter-napari-plugin#getting-started\n\nand review the napari docs for plugin developers:\nhttps://napari.org/docs/plugins/index.html\n-->\n\n## Installation\n\nYou can install `napari-mri` via [pip]:\n\n    pip install napari-mri\n\n## Contributing\n\nContributions are very welcome. Tests can be run with [tox], please ensure\nthe coverage at least stays the same before you submit a pull request.\n\n## License\n\nDistributed under the terms of the [BSD-3] license,\n\"napari-mri\" is free and open source software\n\n## Issues\n\nIf you encounter any problems, please [file an issue] along with a detailed description.\n\n[napari]: https://github.com/napari/napari\n[Cookiecutter]: https://github.com/audreyr/cookiecutter\n[@napari]: https://github.com/napari\n[MIT]: http://opensource.org/licenses/MIT\n[BSD-3]: http://opensource.org/licenses/BSD-3-Clause\n[GNU GPL v3.0]: http://www.gnu.org/licenses/gpl-3.0.txt\n[GNU LGPL v3.0]: http://www.gnu.org/licenses/lgpl-3.0.txt\n[Apache Software License 2.0]: http://www.apache.org/licenses/LICENSE-2.0\n[Mozilla Public License 2.0]: https://www.mozilla.org/media/MPL/2.0/index.txt\n[cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin\n[file an issue]: https://github.com/sahas111/napari-mri/issues\n[napari]: https://github.com/napari/napari\n[tox]: https://tox.readthedocs.io/en/latest/\n[pip]: https://pypi.org/project/pip/\n[PyPI]: https://pypi.org/\n\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "SUSMITA SAHA",
+        "email": "susmi06@yahoo.com"
+      }
+    ],
+    "license": "",
+    "python_version": ">=3.7",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-03-21T06:12:30.232144Z",
+    "version": "0.1.0",
+    "first_released": "2021-03-21T06:12:30.232144Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "napari-properties-viewer",
+    "summary": "A viewer for napari layer properties",
+    "description": "# napari-properties-viewer\n\n[![License](https://img.shields.io/pypi/l/napari-properties-viewer.svg?color=green)](https://github.com/napari/napari-properties-viewer/raw/master/LICENSE)\n[![PyPI](https://img.shields.io/pypi/v/napari-properties-viewer.svg?color=green)](https://pypi.org/project/napari-properties-viewer)\n[![Python Version](https://img.shields.io/pypi/pyversions/napari-properties-viewer.svg?color=green)](https://python.org)\n[![tests](https://github.com/kevinyamauchi/napari-properties-viewer/workflows/tests/badge.svg)](https://github.com/kevinyamauchi/napari-properties-viewer/actions)\n[![codecov](https://codecov.io/gh/kevinyamauchi/napari-properties-viewer/branch/master/graph/badge.svg)](https://codecov.io/gh/kevinyamauchi/napari-properties-viewer)\n\nA viewer for napari layer properties\n\n![image](resources/properties_viewer.gif)\n----------------------------------\n\nThis [napari] plugin was generated with [Cookiecutter] using with [@napari]'s [cookiecutter-napari-plugin] template.\n\n<!--\nDon't miss the full getting started guide to set up your new package:\nhttps://github.com/napari/cookiecutter-napari-plugin#getting-started\n\nand review the napari docs for plugin developers:\nhttps://napari.org/docs/plugins/index.html\n-->\n\n## Installation\n\nYou can install `napari-properties-viewer` via [pip]:\n\n    pip install napari-properties-viewer\n\n## Contributing\n\nContributions are very welcome. Tests can be run with [tox], please ensure\nthe coverage at least stays the same before you submit a pull request.\n\n## License\n\nDistributed under the terms of the [BSD-3] license,\n\"napari-properties-viewer\" is free and open source software\n\n## Issues\n\nIf you encounter any problems, please [file an issue] along with a detailed description.\n\n[napari]: https://github.com/napari/napari\n[Cookiecutter]: https://github.com/audreyr/cookiecutter\n[@napari]: https://github.com/napari\n[MIT]: http://opensource.org/licenses/MIT\n[BSD-3]: http://opensource.org/licenses/BSD-3-Clause\n[GNU GPL v3.0]: http://www.gnu.org/licenses/gpl-3.0.txt\n[GNU LGPL v3.0]: http://www.gnu.org/licenses/lgpl-3.0.txt\n[Apache Software License 2.0]: http://www.apache.org/licenses/LICENSE-2.0\n[Mozilla Public License 2.0]: https://www.mozilla.org/media/MPL/2.0/index.txt\n[cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin\n[file an issue]: https://github.com/kevinyamauchi/napari-properties-viewer/issues\n[napari]: https://github.com/napari/napari\n[tox]: https://tox.readthedocs.io/en/latest/\n[pip]: https://pypi.org/project/pip/\n[PyPI]: https://pypi.org/\n\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Kevin Yamauchi",
+        "email": "kevin.yamauchi@gmail.com"
+      }
+    ],
+    "license": "BSD-3",
+    "python_version": ">=3.6",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-04-28T13:47:44.032297Z",
+    "version": "0.0.1",
+    "first_released": "2021-04-28T13:47:44.032297Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "napari-medical-image-formats",
+    "summary": "A Plugin in order to read medical image formats such as DICOM and NIfTI",
+    "description": "# napari-medical-image-formats\n\n[![License](https://img.shields.io/pypi/l/napari-medical-image-formats.svg?color=green)](https://github.com/MBPhys/napari-medical-image-formats/raw/master/LICENSE)\n[![PyPI](https://img.shields.io/pypi/v/napari-medical-image-formats.svg?color=green)](https://pypi.org/project/napari-medical-image-formats)\n[![Python Version](https://img.shields.io/pypi/pyversions/napari-medical-image-formats.svg?color=green)](https://python.org)\n\n\nA Plugin in order to read medical image formats such as DICOM and NIfTI without any meta informations. This will be updated soon.\n\n----------------------------------\n\n## Installation\n\nYou can install `napari-medical-image-formats` via [pip]:\n\n    pip install napari-medical-image-formats\n\n## Contributing\n\nContributions are very welcome. Tests can be run with [tox], please ensure\nthe coverage at least stays the same before you submit a pull request.\n\n## License\n\nDistributed under the terms of the [BSD-3] license,\n\"napari-medical-image-formats\" is free and open source software\n\n## Issues\n\nIf you encounter any problems, please [file an issue] along with a detailed description.\n\n[napari]: https://github.com/napari/napari\n[Cookiecutter]: https://github.com/audreyr/cookiecutter\n[@napari]: https://github.com/napari\n[MIT]: http://opensource.org/licenses/MIT\n[BSD-3]: http://opensource.org/licenses/BSD-3-Clause\n[GNU GPL v3.0]: http://www.gnu.org/licenses/gpl-3.0.txt\n[GNU LGPL v3.0]: http://www.gnu.org/licenses/lgpl-3.0.txt\n[Apache Software License 2.0]: http://www.apache.org/licenses/LICENSE-2.0\n[Mozilla Public License 2.0]: https://www.mozilla.org/media/MPL/2.0/index.txt\n[cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin\n[file an issue]: https://github.com/MBPhys/napari-medical-image-formats/issues\n[napari]: https://github.com/napari/napari\n[tox]: https://tox.readthedocs.io/en/latest/\n[pip]: https://pypi.org/project/pip/\n[PyPI]: https://pypi.org/\n\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Marc Boucsein, Marc Buckmakowski",
+        "email": ""
+      }
+    ],
+    "license": "BSD-3",
+    "python_version": ">=3.7",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-04-24T14:22:51.473417Z",
+    "version": "0.3.6",
+    "first_released": "2021-04-24T14:22:51.473417Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "misic-napari-plugin",
+    "summary": "segmentation of bacteria",
+    "description": "# misic-napari-plugin\n\n[![License](https://img.shields.io/pypi/l/misic-napari-plugin.svg?color=green)](https://github.com/pswap/misic-napari-plugin/raw/master/LICENSE)\n[![PyPI](https://img.shields.io/pypi/v/misic-napari-plugin.svg?color=green)](https://pypi.org/project/misic-napari-plugin)\n[![Python Version](https://img.shields.io/pypi/pyversions/misic-napari-plugin.svg?color=green)](https://python.org)\n[![tests](https://github.com/pswap/misic-napari-plugin/workflows/tests/badge.svg)](https://github.com/pswap/misic-napari-plugin/actions)\n[![codecov](https://codecov.io/gh/pswap/misic-napari-plugin/branch/master/graph/badge.svg)](https://codecov.io/gh/pswap/misic-napari-plugin)\n\nsegmentation of bacteria\n\n----------------------------------\n\nThis [napari] plugin was generated with [Cookiecutter] using with [@napari]'s [cookiecutter-napari-plugin] template.\n\n<!--\nDon't miss the full getting started guide to set up your new package:\nhttps://github.com/napari/cookiecutter-napari-plugin#getting-started\n\nand review the napari docs for plugin developers:\nhttps://napari.org/docs/plugins/index.html\n-->\n\n## Installation\n\nYou can install `misic-napari-plugin` via [pip]:\n\n    pip install misic-napari-plugin\n\n## License\n\nDistributed under the terms of the [MIT] license,\n\"misic-napari-plugin\" is free and open source software\n\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "lcb-iam-pswap-le",
+        "email": "spanigrahi@imm.cnrs.fr"
+      }
+    ],
+    "license": "MIT",
+    "python_version": ">=3.6",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-04-09T08:21:41.349840Z",
+    "version": "0.1.1",
+    "first_released": "2021-04-07T18:17:11.487049Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "napari-dv",
+    "summary": "Deltavision/MRC file reader for napari",
+    "description": "=========\nnapari-dv\n=========\n\n.. image:: https://img.shields.io/pypi/v/napari-dv.svg\n    :target: https://pypi.org/project/napari-dv\n    :alt: PyPI version\n\n.. image:: https://img.shields.io/pypi/pyversions/napari-dv.svg\n    :target: https://pypi.org/project/napari-dv\n    :alt: Python versions\n\n.. image:: https://travis-ci.org/tlambert03/napari-dv.svg?branch=master\n    :target: https://travis-ci.org/tlambert03/napari-dv\n    :alt: See Build Status on Travis CI\n\n.. image:: https://ci.appveyor.com/api/projects/status/github/tlambert03/napari-dv?branch=master\n    :target: https://ci.appveyor.com/project/tlambert03/napari-dv/branch/master\n    :alt: See Build Status on AppVeyor\n\nDeltavision/MRC file reader plugin for napari\n\n----\n\nThis `napari`_ plugin was generated with `Cookiecutter`_ along with\n`@napari`_'s `cookiecutter-napari-plugin`_ template.\n\n\nInstallation\n------------\n\nYou can install \"napari-dv\" via `pip`_ from `PyPI`_::\n\n    $ pip install napari-dv\n\n\nLicense\n-------\n\nDistributed under the terms of the `MIT`_ license,\n\"napari-dv\" is free and open source software\n\n\nIssues\n------\n\nIf you encounter any problems, please `file an issue`_ along with a detailed description.\n\n.. _`Cookiecutter`: https://github.com/audreyr/cookiecutter\n.. _`@napari`: https://github.com/napari\n.. _`MIT`: http://opensource.org/licenses/MIT\n.. _`BSD-3`: http://opensource.org/licenses/BSD-3-Clause\n.. _`GNU GPL v3.0`: http://www.gnu.org/licenses/gpl-3.0.txt\n.. _`Apache Software License 2.0`: http://www.apache.org/licenses/LICENSE-2.0\n.. _`cookiecutter-napari-plugin`: https://github.com/napari/cookiecutter-napari-plugin\n.. _`file an issue`: https://github.com/tlambert03/napari-dv/issues\n.. _`napari`: https://github.com/napari/napari\n.. _`tox`: https://tox.readthedocs.io/en/latest/\n.. _`pip`: https://pypi.org/project/pip/\n.. _`PyPI`: https://pypi.org/project\n\n\n",
+    "description_content_type": "",
+    "authors": [
+      {
+        "name": "Talley Lambert",
+        "email": "talley.lambert@gmail.com"
+      }
+    ],
+    "license": "MIT",
+    "python_version": ">=3.6",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-01-27T23:48:58.142381Z",
+    "version": "0.2.5",
+    "first_released": "2020-02-02T21:12:45.927865Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "nd2-dask",
+    "summary": "Plugin to load nd2 data into napari",
+    "description": "# nd2-dask\n\n[![License](https://img.shields.io/pypi/l/nd2-dask.svg?color=green)](https://github.com/napari/nd2-dask/raw/master/LICENSE)\n[![PyPI](https://img.shields.io/pypi/v/nd2-dask.svg?color=green)](https://pypi.org/project/nd2-dask)\n[![Python Version](https://img.shields.io/pypi/pyversions/nd2-dask.svg?color=green)](https://python.org)\n[![tests](https://github.com/DragaDoncila/nd2-dask/workflows/tests/badge.svg)](https://github.com/DragaDoncila/nd2-dask/actions)\n[![codecov](https://codecov.io/gh/DragaDoncila/nd2-dask/branch/master/graph/badge.svg)](https://codecov.io/gh/DragaDoncila/nd2-dask)\n\nPlugin to load nd2 data into napari\n\n----------------------------------\n\nThis [napari] plugin was generated with [Cookiecutter] using with [@napari]'s [cookiecutter-napari-plugin] template.\n\n<!--\nDon't miss the full getting started guide to set up your new package:\nhttps://github.com/napari/cookiecutter-napari-plugin#getting-started\n\nand review the napari docs for plugin developers:\nhttps://napari.org/docs/plugins/index.html\n-->\n\n## Installation\n\nYou can install `nd2-dask` via [pip]:\n\n    pip install nd2-dask\n\n## Contributing\n\nContributions are very welcome. Tests can be run with [tox], please ensure\nthe coverage at least stays the same before you submit a pull request.\n\n## License\n\nDistributed under the terms of the [BSD-3] license,\n\"nd2-dask\" is free and open source software\n\n## Issues\n\nIf you encounter any problems, please [file an issue] along with a detailed description.\n\n[napari]: https://github.com/napari/napari\n[Cookiecutter]: https://github.com/audreyr/cookiecutter\n[@napari]: https://github.com/napari\n[MIT]: http://opensource.org/licenses/MIT\n[BSD-3]: http://opensource.org/licenses/BSD-3-Clause\n[GNU GPL v3.0]: http://www.gnu.org/licenses/gpl-3.0.txt\n[GNU LGPL v3.0]: http://www.gnu.org/licenses/lgpl-3.0.txt\n[Apache Software License 2.0]: http://www.apache.org/licenses/LICENSE-2.0\n[Mozilla Public License 2.0]: https://www.mozilla.org/media/MPL/2.0/index.txt\n[cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin\n[file an issue]: https://github.com/DragaDoncila/nd2-dask/issues\n[napari]: https://github.com/napari/napari\n[tox]: https://tox.readthedocs.io/en/latest/\n[pip]: https://pypi.org/project/pip/\n[PyPI]: https://pypi.org/\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Draga Doncila Pop",
+        "email": "ddon0001@student.monash.edu"
+      }
+    ],
+    "license": "BSD-3",
+    "python_version": ">=3.6",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-02-04T05:18:13.029326Z",
+    "version": "0.0.5",
+    "first_released": "2020-11-08T01:29:33.641028Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "napari-czifile2",
+    "summary": "Carl Zeiss Image (.czi) file support for napari",
+    "description": "# napari-czifile2\n\n![PyPI](https://img.shields.io/pypi/v/napari-czifile2)\n![PyPI - Python Version](https://img.shields.io/pypi/pyversions/napari-czifile2)\n![PyPI - License](https://img.shields.io/pypi/l/napari-czifile2)\n![GitHub issues](https://img.shields.io/github/issues/BodenmillerGroup/napari-czifile2)\n![GitHub pull requests](https://img.shields.io/github/issues-pr/BodenmillerGroup/napari-czifile2)\n\nCarl Zeiss Image (.czi) file type support for napari\n\nOpen .czi files and interactively view scenes co-registered in the machine's coordinate system using napari\n\n## Requirements\n\nThis package requires Python 3.7 or newer.\n\nPython package dependencies are listed in [requirements.txt](https://github.com/BodenmillerGroup/napari-czifile2/blob/master/requirements.txt).\n\nPlease note that napari is under active development. Using virtual environments is strongly encouraged.\n\n## Installation\n\nEnsure that `napari[all]` is installed.\n\nInstall napari-czifile2 and its dependencies with:\n\n    pip install napari-czifile2\n\n## Usage\n\nUse `napari` to open Carl Zeiss Image (.czi) files\n\n## Authors\n\nCreated and maintained by Jonas Windhager [jonas.windhager@uzh.ch](mailto:jonas.windhager@uzh.ch)\n\n## Contributing\n\n[Contributing](https://github.com/BodenmillerGroup/napari-czifile2/blob/master/CONTRIBUTING.md)\n\n## Changelog\n\n[Changelog](https://github.com/BodenmillerGroup/napari-czifile2/blob/master/CHANGELOG.md)\n\n## License\n\n[MIT](https://github.com/BodenmillerGroup/napari-czifile2/blob/master/LICENSE.md)\n\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Jonas Windhager",
+        "email": "jonas.windhager@uzh.ch"
+      }
+    ],
+    "license": "MIT",
+    "python_version": ">=3.7",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-04-17T21:09:43.930836Z",
+    "version": "0.2.1",
+    "first_released": "2021-02-02T03:07:14.849183Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "napari-dzi-zarr",
+    "summary": "An experimental plugin for viewing Deep Zoom Images (DZI) with napari and zarr.",
+    "description": "# napari-dzi-zarr\n\n[![License](https://img.shields.io/pypi/l/napari-dzi-zarr.svg?color=green)](https://github.com/napari/napari-dzi-zarr/raw/master/LICENSE)\n[![PyPI](https://img.shields.io/pypi/v/napari-dzi-zarr.svg?color=green)](https://pypi.org/project/napari-dzi-zarr)\n[![Python Version](https://img.shields.io/pypi/pyversions/napari-dzi-zarr.svg?color=green)](https://python.org)\n[![tests](https://github.com/manzt/napari-dzi-zarr/workflows/tests/badge.svg)](https://github.com/manzt/napari-dzi-zarr/actions)\n\nAn experimental plugin for viewing Deep Zoom Images (DZI) with napari + zarr + dask.\n\n----------------------------------\n\nThis [napari] plugin was generated with [Cookiecutter] using with [@napari]'s [cookiecutter-napari-plugin] template.\n\n## Description \n\nThe [DZI File Format](https://github.com/openseadragon/openseadragon/wiki/The-DZI-File-Format) \nis a pyramidal tile source specification where individual tiles are RGB/RGBA JPEG/PNG images. \nDZI is a very popular tile source for zoomable web-viewers like \n[OpenSeadragon](https://openseadragon.github.io/), and as a result many tile sources are available over \nHTTP. This plugin wraps a DZI tile source (local or remote) as a multiscale Zarr, where each pyramidal level is a `zarr.Array` of shape `(level_height, level_width, 3/4)`, allowing the same images to be viewed \nin `napari` + `dask`.\n\n## Installation\n\nYou can install `napari-dzi-zarr` via [pip]:\n\n    pip install napari-dzi-zarr\n\n\n## Usage\n\nThis high-resolution scan of Rembrandt's Night Watch is available thanks to [R.G Erdmann](https://twitter.com/erdmann). More examples can be found on [boschproject.org](http://boschproject.org).\n\n    $ napari http://hyper-resolution.org/dzi/Rijksmuseum/SK-C-5/SK-C-5_VIS_20-um_2019-12-21.dzi\n\n![Rembrandt's Night Watch in napari](./night_watch_napari.png)\n\n## Contributing\n\nContributions are very welcome. Tests can be run with [tox].\n\n## License\n\nDistributed under the terms of the [BSD-3] license,\n\"napari-dzi-zarr\" is free and open source software\n\n## Issues\n\nIf you encounter any problems, please [file an issue] along with a detailed description.\n\n[napari]: https://github.com/napari/napari\n[Cookiecutter]: https://github.com/audreyr/cookiecutter\n[@napari]: https://github.com/napari\n[MIT]: http://opensource.org/licenses/MIT\n[BSD-3]: http://opensource.org/licenses/BSD-3-Clause\n[GNU GPL v3.0]: http://www.gnu.org/licenses/gpl-3.0.txt\n[GNU LGPL v3.0]: http://www.gnu.org/licenses/lgpl-3.0.txt\n[Apache Software License 2.0]: http://www.apache.org/licenses/LICENSE-2.0\n[Mozilla Public License 2.0]: https://www.mozilla.org/media/MPL/2.0/index.txt\n[cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin\n[file an issue]: https://github.com/manzt/napari-dzi-zarr/issues\n[napari]: https://github.com/napari/napari\n[tox]: https://tox.readthedocs.io/en/latest/\n[pip]: https://pypi.org/project/pip/\n[PyPI]: https://pypi.org/\n\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Trevor Manz",
+        "email": "trevor.j.manz@gmail.com"
+      }
+    ],
+    "license": "BSD-3",
+    "python_version": ">=3.6",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-04-06T14:13:16.654713Z",
+    "version": "0.1.2",
+    "first_released": "2020-08-20T17:18:30.022784Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "napari-animation",
+    "summary": "A plugin to make animations with napari",
+    "description": "# napari-animation (WIP under active development)\n\n[![License](https://img.shields.io/pypi/l/napari-animation.svg?color=green)](https://github.com/napari/napari-animation/raw/master/LICENSE)\n[![PyPI](https://img.shields.io/pypi/v/napari-animation.svg?color=green)](https://pypi.org/project/napari-animation)\n[![Python Version](https://img.shields.io/pypi/pyversions/napari-animation.svg?color=green)](https://python.org)\n[![tests](https://github.com/sofroniewn/napari-animation/workflows/tests/badge.svg)](https://github.com/sofroniewn/napari-animation/actions)\n[![codecov](https://codecov.io/gh/sofroniewn/napari-animation/branch/master/graph/badge.svg)](https://codecov.io/gh/sofroniewn/napari-animation)\n\n**napari-animation** is a plugin for making animations in [napari].\n\n----------------------------------\n\nThis [napari] plugin was generated with [Cookiecutter] using with [@napari]'s [cookiecutter-napari-plugin] template.\n\nIt is built off of great work from @guiwitz in [naparimovie](https://github.com/guiwitz/naparimovie) which was initially submitted to napari in [PR#851](https://github.com/napari/napari/pull/780).\n\n----------------------------------\n## Overview\n\n**napari-animation** provides a framework for the creation of animations in napari and features:\n- an easy to use GUI for interactive creation of animations\n- Python tools for programmatic creation of animations\n\nThis plugin is currently pre-release and under active development. APIs are likely to change before it's first 0.0.1 release,\nbut feedback and contributions are welcome.\n\n## Installation\n\nYou can clone this repository with install locally with\n\n    pip install -e .\n\n## Examples\nExamples can be found in our [examples](examples) folder. Simple examples for both interactive and headless \nuse of the plugin follow.\n\n### Interactive\n**napari-animation** can be used interactively by creating an `AnimationWidget` from a napari `Viewer` and adding it to\nthe viewer as a dock widget.\n\n```python\nfrom napari_animation import AnimationWidget\n\nanimation_widget = AnimationWidget(viewer)\nviewer.window.add_dock_widget(animation_widget, area='right')\n```\n\n![AnimationWidget image](resources/screenshot-animation-widget.png)\n\n### Headless\n**napari-animation** can also be run headless, allowing for reproducible, scripted creation of animations.\n\n```python\nfrom napari_animation import Animation\n\nanimation = Animation(viewer)\n\nviewer.dims.ndisplay = 3\nviewer.camera.angles = (0.0, 0.0, 90.0)\nanimation.capture_keyframe()\nviewer.camera.zoom = 2.4\nanimation.capture_keyframe()\nviewer.camera.angles = (-7.0, 15.7, 62.4)\nanimation.capture_keyframe(steps=60)\nviewer.camera.angles = (2.0, -24.4, -36.7)\nanimation.capture_keyframe(steps=60)\nviewer.reset_view()\nviewer.camera.angles = (0.0, 0.0, 90.0)\nanimation.capture_keyframe()\nanimation.animate('demo.mov', canvas_only=False)\n```\n\n## Is everything animate-able?\n\nUnfortunately, not yet! Currently differences in the following objects are tracked by the `Animation` class\n\n- `Viewer.camera`\n- `Viewer.dims`\n- `Layer.scale`\n- `Layer.translate`\n- `Layer.rotate`\n- `Layer.shear`\n- `layer.opacity`\n- `Layer.blending`\n- `Layer.visible`\n\nSupport for more layer attributes will be added in future releases.\n\n## Contributing\n\nContributions are very welcome. Tests and additional infrastructure are being setup.\n\n## License\n\nDistributed under the terms of the [BSD-3] license,\n\"napari-animation\" is free and open source software\n\n## Issues\n\nIf you encounter any problems, please [file an issue] along with a detailed description.\n\n[napari]: https://github.com/napari/napari\n[Cookiecutter]: https://github.com/audreyr/cookiecutter\n[@napari]: https://github.com/napari\n[BSD-3]: http://opensource.org/licenses/BSD-3-Clause\n[cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin\n[file an issue]: https://github.com/sofroniewn/napari-animation/issues\n[napari]: https://github.com/napari/napari\n[tox]: https://tox.readthedocs.io/en/latest/\n[pip]: https://pypi.org/project/pip/\n[PyPI]: https://pypi.org/\n\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Nicholas Sofroniew, Alister Burt, Guillaume Witz, Faris Abouakil, Talley Lambert",
+        "email": ""
+      }
+    ],
+    "license": "BSD 3-Clause",
+    "python_version": ">=3.7",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-05-03T23:57:13.685794Z",
+    "version": "0.0.1rc5",
+    "first_released": "2021-04-23T16:11:20.051462Z",
+    "development_status": ["Development Status :: 3 - Alpha"]
+  },
+  {
+    "name": "napari-minimal-plugin",
+    "summary": "A minimal plugin",
+    "description": "# napari-minimal-plugin\n\n[![License](https://img.shields.io/pypi/l/napari-minimal-plugin.svg?color=green)](https://github.com/mlbyml/napari-minimal-plugin/raw/master/LICENSE)\n[![PyPI](https://img.shields.io/pypi/v/napari-minimal-plugin.svg?color=green)](https://pypi.org/project/napari-minimal-plugin)\n[![Python Version](https://img.shields.io/pypi/pyversions/napari-minimal-plugin.svg?color=green)](https://python.org)\n[![tests](https://github.com/mlbyml/napari-minimal-plugin/workflows/tests/badge.svg)](https://github.com/mlbyml/napari-minimal-plugin/actions)\n[![codecov](https://codecov.io/gh/mlbyml/napari-minimal-plugin/branch/master/graph/badge.svg)](https://codecov.io/gh/mlbyml/napari-minimal-plugin)\n\nA minimal plugin\n\n----------------------------------\n\nThis [napari] plugin was generated with [Cookiecutter] using with [@napari]'s [cookiecutter-napari-plugin] template.\n\n<!--\nDon't miss the full getting started guide to set up your new package:\nhttps://github.com/napari/cookiecutter-napari-plugin#getting-started\n\nand review the napari docs for plugin developers:\nhttps://napari.org/docs/plugins/index.html\n-->\n\n## Installation\n\nYou can install `napari-minimal-plugin` via [pip]:\n\n    pip install napari-minimal-plugin\n\n## Contributing\n\nContributions are very welcome. Tests can be run with [tox], please ensure\nthe coverage at least stays the same before you submit a pull request.\n\n## License\n\nDistributed under the terms of the [BSD-3] license,\n\"napari-minimal-plugin\" is free and open source software\n\n## Issues\n\nIf you encounter any problems, please [file an issue] along with a detailed description.\n\n[napari]: https://github.com/napari/napari\n[Cookiecutter]: https://github.com/audreyr/cookiecutter\n[@napari]: https://github.com/napari\n[MIT]: http://opensource.org/licenses/MIT\n[BSD-3]: http://opensource.org/licenses/BSD-3-Clause\n[GNU GPL v3.0]: http://www.gnu.org/licenses/gpl-3.0.txt\n[GNU LGPL v3.0]: http://www.gnu.org/licenses/lgpl-3.0.txt\n[Apache Software License 2.0]: http://www.apache.org/licenses/LICENSE-2.0\n[Mozilla Public License 2.0]: https://www.mozilla.org/media/MPL/2.0/index.txt\n[cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin\n[file an issue]: https://github.com/mlbyml/napari-minimal-plugin/issues\n[napari]: https://github.com/napari/napari\n[tox]: https://tox.readthedocs.io/en/latest/\n[pip]: https://pypi.org/project/pip/\n[PyPI]: https://pypi.org/\n\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Manan Lalit",
+        "email": "lalit@mpi-cbg.de"
+      }
+    ],
+    "license": "BSD-3",
+    "python_version": ">=3.6",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-05-02T16:09:10.827132Z",
+    "version": "0.0.1",
+    "first_released": "2021-05-02T16:09:10.827132Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "napari-cellfinder",
+    "summary": "Visualise cellfinder results with napari",
+    "description": "# napari-cellfinder\n\n[![License](https://img.shields.io/pypi/l/napari-cellfinder.svg?color=green)](https://github.com/napari/napari-cellfinder/raw/master/LICENSE)\n[![PyPI](https://img.shields.io/pypi/v/napari-cellfinder.svg?color=green)](https://pypi.org/project/napari-cellfinder)\n[![Python Version](https://img.shields.io/pypi/pyversions/napari-cellfinder.svg?color=green)](https://python.org)\n[![tests](https://github.com/adamltyson/napari-cellfinder/workflows/tests/badge.svg)](https://github.com/adamltyson/napari-cellfinder/actions)\n[![codecov](https://codecov.io/gh/adamltyson/napari-cellfinder/branch/master/graph/badge.svg)](https://codecov.io/gh/adamltyson/napari-cellfinder)\n\nVisualise cellfinder results with napari\n\n\n----------------------------------\n\n\n## Installation\n\nYou can install `napari-cellfinder` via [pip]:\n\n    pip install napari-cellfinder\n\n## Usage\n* Open napari (however you normally do it, but typically just type `napari` into your terminal)\n* Load your raw data (drag and drop the data directories into napari, one at a time)\n* Drag and drop your cellfinder output directory into napari.\n\nThe plugin will then load your detected cells (in yellow) and the rejected cell \ncandidates (in blue). If you carried out registration, then these results will be \noverlaid (similarly to the [napari-brainreg] plugin, but transformed to the \ncoordinate space of your raw data).\n\n![load_data](https://raw.githubusercontent.com/brainglobe/napari-cellfinder/master/resources/load_data.gif)\n**Loading raw data**\n\n![load_data](https://raw.githubusercontent.com/brainglobe/napari-cellfinder/master/resources/load_results.gif)\n**Loading cellfinder results**\n\n## Contributing\n\nContributions are very welcome. Tests can be run with [tox], please ensure\nthe coverage at least stays the same before you submit a pull request.\n\n## License\n\nDistributed under the terms of the [MIT] license,\n\"napari-cellfinder\" is free and open source software\n\n## Issues\n\nIf you encounter any problems, please [file an issue] along with a detailed description.\n\n[napari-brainreg]: https://github.com/brainglobe/napari-brainreg\n[napari]: https://github.com/napari/napari\n[Cookiecutter]: https://github.com/audreyr/cookiecutter\n[@napari]: https://github.com/napari\n[MIT]: http://opensource.org/licenses/MIT\n[BSD-3]: http://opensource.org/licenses/BSD-3-Clause\n[GNU GPL v3.0]: http://www.gnu.org/licenses/gpl-3.0.txt\n[GNU LGPL v3.0]: http://www.gnu.org/licenses/lgpl-3.0.txt\n[Apache Software License 2.0]: http://www.apache.org/licenses/LICENSE-2.0\n[Mozilla Public License 2.0]: https://www.mozilla.org/media/MPL/2.0/index.txt\n[cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin\n[file an issue]: https://github.com/adamltyson/napari-cellfinder/issues\n[napari]: https://github.com/napari/napari\n[tox]: https://tox.readthedocs.io/en/latest/\n[pip]: https://pypi.org/project/pip/\n[PyPI]: https://pypi.org/\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Adam Tyson",
+        "email": "adam.tyson@ucl.ac.uk"
+      }
+    ],
+    "license": "MIT",
+    "python_version": ">=3.6",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-01-14T15:41:12.438954Z",
+    "version": "0.2.1",
+    "first_released": "2020-08-14T09:07:02.660802Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "napari-nikon-nd2",
+    "summary": "Opens Nikon ND2 files into napari.",
+    "description": "# napari-nikon-nd2\n\n[![License](https://img.shields.io/pypi/l/napari-nikon-nd2.svg?color=green)](https://github.com/cwood1967/napari-nikon-nd2/blob/main/LICENSE)\n[![PyPI](https://img.shields.io/pypi/v/napari-nikon-nd2.svg?color=green)](https://pypi.org/project/napari-nikon-nd2)\n[![Python Version](https://img.shields.io/pypi/pyversions/napari-nikon-nd2.svg?color=green)](https://python.org)\n[![tests](https://github.com/cwood1967/napari-nikon-nd2/workflows/tests/badge.svg)](https://github.com/cwood1967/napari-nikon-nd2/actions)\n[![codecov](https://codecov.io/gh/cwood1967/napari-nikon-nd2/branch/main/graph/badge.svg)](https://codecov.io/gh/cwood1967/napari-nikon-nd2)\n\nOpens Nikon ND2 files into napari. This plugin uses the [nd2reader] and [pims] python packages. \n\n----------------------------------\n\nThis [napari] plugin was generated with [Cookiecutter] using with [@napari]'s [cookiecutter-napari-plugin] template.\n\n<!--\nDon't miss the full getting started guide to set up your new package:\nhttps://github.com/napari/cookiecutter-napari-plugin#getting-started\n\nand review the napari docs for plugin developers:\nhttps://napari.org/docs/plugins/index.html\n-->\n\n## Installation\n\nYou can install `napari-nikon-nd2` via [pip]:\n\n    pip install napari-nikon-nd2\n\n## Contributing\n\nContributions are very welcome. Tests can be run with [tox], please ensure\nthe coverage at least stays the same before you submit a pull request.\n\n## License\n\nDistributed under the terms of the [Apache Software License 2.0] license,\n\"napari-nikon-nd2\" is free and open source software\n\n## Issues\n\nIf you encounter any problems, please [file an issue] along with a detailed description.\n\n## Credits\n\nThis [napari] plugin was created using [Napari Delta Vision Reader] and\nthe [Allen Institute IO] plugin as examples.\n\n\n[napari]: https://github.com/napari/napari\n[Cookiecutter]: https://github.com/audreyr/cookiecutter\n[@napari]: https://github.com/napari\n[MIT]: http://opensource.org/licenses/MIT\n[BSD-3]: http://opensource.org/licenses/BSD-3-Clause\n[GNU GPL v3.0]: http://www.gnu.org/licenses/gpl-3.0.txt\n[GNU LGPL v3.0]: http://www.gnu.org/licenses/lgpl-3.0.txt\n[Apache Software License 2.0]: http://www.apache.org/licenses/LICENSE-2.0\n[Mozilla Public License 2.0]: https://www.mozilla.org/media/MPL/2.0/index.txt\n[cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin\n[file an issue]: https://github.com/cwood1967/napari-nikon-nd2/issues\n[napari]: https://github.com/napari/napari\n[tox]: https://tox.readthedocs.io/en/latest/\n[pip]: https://pypi.org/project/pip/\n[PyPI]: https://pypi.org/\n[nd2reader]: https://github.com/rbnvrw/nd2reader\n[pims]: https://github.com/soft-matter/pims\n[Allen Institute IO]: https://github.com/AllenCellModeling/napari-aicsimageio\n[Napari Delta Vision Reader]: https://github.com/tlambert03/napari-dv\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Chris Wood",
+        "email": "cwood1967@gmail.com"
+      }
+    ],
+    "license": "Apache Software License 2.0",
+    "python_version": ">=3.6",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-02-03T21:55:34.674256Z",
+    "version": "0.1.3",
+    "first_released": "2021-02-03T21:21:34.976957Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "napari-em-reader",
+    "summary": "A napari plugin to read .em files",
+    "description": "# napari-em-reader\n\n[![License](https://img.shields.io/pypi/l/napari-em-reader.svg?color=green)](https://github.com/brisvag/napari-em-reader/raw/master/LICENSE)\n[![PyPI](https://img.shields.io/pypi/v/napari-em-reader.svg?color=green)](https://pypi.org/project/napari-em-reader)\n[![Python Version](https://img.shields.io/pypi/pyversions/napari-em-reader.svg?color=green)](https://python.org)\n[![tests](https://github.com/brisvag/napari-em-reader/workflows/tests/badge.svg)](https://github.com/brisvag/napari-em-reader/actions)\n[![codecov](https://codecov.io/gh/brisvag/napari-em-reader/branch/master/graph/badge.svg)](https://codecov.io/gh/brisvag/napari-em-reader)\n\nA napari plugin to read .em files\n\n----------------------------------\n\nThis [napari] plugin was generated with [Cookiecutter] using with [@napari]'s [cookiecutter-napari-plugin] template.\n\n<!--\nDon't miss the full getting started guide to set up your new package:\nhttps://github.com/napari/cookiecutter-napari-plugin#getting-started\n\nand review the napari docs for plugin developers:\nhttps://napari.org/docs/plugins/index.html\n-->\n\n## Installation\n\nYou can install `napari-em-reader` via [pip]:\n\n    pip install napari-em-reader\n\n## Contributing\n\nContributions are very welcome. Tests can be run with [tox], please ensure\nthe coverage at least stays the same before you submit a pull request.\n\n## License\n\nDistributed under the terms of the [BSD-3] license,\n\"napari-em-reader\" is free and open source software\n\n## Issues\n\nIf you encounter any problems, please [file an issue] along with a detailed description.\n\n[napari]: https://github.com/napari/napari\n[Cookiecutter]: https://github.com/audreyr/cookiecutter\n[@napari]: https://github.com/napari\n[MIT]: http://opensource.org/licenses/MIT\n[BSD-3]: http://opensource.org/licenses/BSD-3-Clause\n[GNU GPL v3.0]: http://www.gnu.org/licenses/gpl-3.0.txt\n[GNU LGPL v3.0]: http://www.gnu.org/licenses/lgpl-3.0.txt\n[Apache Software License 2.0]: http://www.apache.org/licenses/LICENSE-2.0\n[Mozilla Public License 2.0]: https://www.mozilla.org/media/MPL/2.0/index.txt\n[cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin\n[file an issue]: https://github.com/brisvag/napari-em-reader/issues\n[napari]: https://github.com/napari/napari\n[tox]: https://tox.readthedocs.io/en/latest/\n[pip]: https://pypi.org/project/pip/\n[PyPI]: https://pypi.org/\n\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Lorenzo Gaifas",
+        "email": "brisvag@gmail.com"
+      }
+    ],
+    "license": "BSD-3",
+    "python_version": ">=3.6",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-02-23T14:51:15.118105Z",
+    "version": "0.1.0",
+    "first_released": "2021-02-23T14:51:15.118105Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "elastix-napari",
+    "summary": "A toolbox for rigid and nonrigid registration of images.",
+    "description": "# elastix_napari\n\n[![License](https://img.shields.io/pypi/l/elastix_napari.svg?color=green)](https://github.com/SuperElastix/elastix_napari/raw/main/LICENSE)\n[![PyPI](https://img.shields.io/pypi/v/elastix_napari.svg?color=green)](https://pypi.org/project/elastix_napari)\n[![Python Version](https://img.shields.io/pypi/pyversions/elastix_napari.svg?color=green)](https://python.org)\n[![tests](https://github.com/SuperElastix/elastix_napari/workflows/tests/badge.svg)](https://github.com/SuperElastix/elastix_napari/actions)\n[![codecov](https://codecov.io/gh/SuperElastix/elastix_napari/branch/main/graph/badge.svg)](https://codecov.io/gh/SuperElastix/elastix_napari)\n\nThe napari plugin for elastix, a toolbox for rigid and nonrigid registration of images.\n\n----------------------------------\n\nThis [napari] plugin was generated with [Cookiecutter] using with [@napari]'s [cookiecutter-napari-plugin] template.\n\n<!--\nDon't miss the full getting started guide to set up your new package:\nhttps://github.com/napari/cookiecutter-napari-plugin#getting-started\n\nand review the napari docs for plugin developers:\nhttps://napari.org/docs/plugins/index.html\n-->\n\n## Installation\n\nYou can install `elastix_napari` via [pip]:\n\n    pip install elastix_napari\n\n## Contributing\n\nContributions are very welcome. Tests can be run with [tox], please ensure\nthe coverage at least stays the same before you submit a pull request.\n\n## License\n\nDistributed under the terms of the [Apache Software License 2.0] license,\n\"elastix_napari\" is free and open source software\n\n## Issues\n\nIf you encounter any problems, please [file an issue] along with a detailed description.\n\n[napari]: https://github.com/napari/napari\n[Cookiecutter]: https://github.com/audreyr/cookiecutter\n[@napari]: https://github.com/napari\n[MIT]: http://opensource.org/licenses/MIT\n[BSD-3]: http://opensource.org/licenses/BSD-3-Clause\n[GNU GPL v3.0]: http://www.gnu.org/licenses/gpl-3.0.txt\n[GNU LGPL v3.0]: http://www.gnu.org/licenses/lgpl-3.0.txt\n[Apache Software License 2.0]: http://www.apache.org/licenses/LICENSE-2.0\n[Mozilla Public License 2.0]: https://www.mozilla.org/media/MPL/2.0/index.txt\n[cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin\n[file an issue]: https://github.com/SuperElastix/elastix_napari/issues\n[napari]: https://github.com/napari/napari\n[tox]: https://tox.readthedocs.io/en/latest/\n[pip]: https://pypi.org/project/pip/\n[PyPI]: https://pypi.org/\n\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Viktor van der Valk",
+        "email": "v.o.van_der_valk@lumc.nl"
+      }
+    ],
+    "license": "Apache Software License 2.0",
+    "python_version": ">=3.6",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-04-16T07:17:16.646899Z",
+    "version": "0.1.3",
+    "first_released": "2021-03-24T08:31:46.514582Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "PartSeg",
+    "summary": "PartSeg is python GUI for bio imaging analysis especially nucleus analysis,",
+    "description": "# PartSeg\n\n![Tests](https://github.com/4DNucleome/PartSeg/workflows/Tests/badge.svg?branch=master)\n[![PyPI version](https://badge.fury.io/py/PartSeg.svg)](https://badge.fury.io/py/PartSeg)\n[![Documentation Status](https://readthedocs.org/projects/partseg/badge/?version=latest)](https://partseg.readthedocs.io/en/latest/?badge=latest)\n[![Azure Pipelines Build Status](https://dev.azure.com/PartSeg/PartSeg/_apis/build/status/4DNucleome.PartSeg?branchName=master)](https://dev.azure.com/PartSeg/PartSeg/_build/latest?definitionId=1&branchName=master)\n[![DOI](https://zenodo.org/badge/166421141.svg)](https://zenodo.org/badge/latestdoi/166421141)\n[![Total alerts](https://img.shields.io/lgtm/alerts/g/4DNucleome/PartSeg.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/4DNucleome/PartSeg/alerts/)\n[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/4DNucleome/PartSeg.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/4DNucleome/PartSeg/context:python)\n[![Codacy Badge](https://api.codacy.com/project/badge/Grade/6c6bef8ebb6a4785a7a1a2da88524661)](https://www.codacy.com/manual/Czaki/PartSeg?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=4DNucleome/PartSeg&amp;utm_campaign=Badge_Grade)\n[![Requirements Status](https://requires.io/github/4DNucleome/PartSeg/requirements.svg?branch=develop)](https://requires.io/github/4DNucleome/PartSeg/requirements/?branch=master)\n[![Code Style](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)\n[![codecov](https://codecov.io/gh/4DNucleome/PartSeg/branch/master/graph/badge.svg?token=nbAbkOAe1C)](https://codecov.io/gh/4DNucleome/PartSeg)\n\nPartSeg is a GUI and a library for segmentation algorithms.\n\nThis application is designed to help biologist with segmentation based on threshold and connected components.\n\n![interface](https://raw.githubusercontent.com/4DNucleome/PartSeg/master/images/roi_analysis.png)\n\n## Tutorials\n\n-   Tutorial: **Chromosome 1 (as gui)** [link](https://github.com/4DNucleome/PartSeg/blob/master/tutorials/tutorial-chromosome-1/tutorial-chromosome1_16.md)\n-   Data for chromosome 1 tutorial [link](https://4dnucleome.cent.uw.edu.pl/PartSeg/Downloads/PartSeg_samples.zip)\n-   Tutorial: **Different neuron types (as library)** [link](https://github.com/4DNucleome/PartSeg/blob/master/tutorials/tutorial_neuron_types/Neuron_types_example.ipynb)\n\n## Installing\n\n-   From binaries:\n    -   [Windows](https://4dnucleome.cent.uw.edu.pl/PartSeg/Downloads/PartSeg-lastest-windows.zip) (build on Windows 10)\n    -   [Linux](https://4dnucleome.cent.uw.edu.pl/PartSeg/Downloads/PartSeg-lastest-linux.zip) (build on Ubuntu 18.04)\n    -   [MacOS](https://4dnucleome.cent.uw.edu.pl/PartSeg/Downloads/PartSeg-lastest-macos.zip) (build on MacOS Mojave)\n\n-   With pip:\n    -   From pypi: `pip install PartSeg[pyqt]`\n    -   From repository: `pip install git+https://github.com/4DNucleome/PartSeg.git`\n\n## Running\n\nIf you downloaded binaries, run the `PartSeg` (or `PartSeg.exe` for Windows) file inside the `PartSeg` folder\n\nIf you installed from repository or from pip, you can run it with `PartSeg` command or `python -m PartSeg`.\nFirst option does not work on Windows.\n\nPartSeg export few commandline options:\n\n-   `--no_report` - disable error reporting\n-   `--no_dialog` - disable error reporting and error dialog. Use only when running from terminal.\n-   `segmentation_analysis` - skip launcher and start analysis gui\n-   `segmentation` - skip launcher and start segmentation gui\n\n## napari plugin\n\nPartSeg provides napari plugins for io to allow reading projects format in napari viewer.\n\n## Save Format\n\nSaved projects are tar files compressed with gzip or bz2.\n\nMetadata is saved in data.json file (in json format).\nImages/masks are saved as *.npy (numpy array format).\n\n## Interface\n\nLauncher. Choose the program that you will launch:\n\n![launcher](https://raw.githubusercontent.com/4DNucleome/PartSeg/master/images/launcher.png)\n\nMain window of Segmentation Analysis:\n\n![interface](https://raw.githubusercontent.com/4DNucleome/PartSeg/master/images/roi_analysis.png)\n\nMain window of Segmentation Analysis with view on measurement result:\n\n![interface](https://raw.githubusercontent.com/4DNucleome/PartSeg/master/images/roi_analysis2.png)\n\nWindow for creating a set of measurements:\n\n![statistics](https://raw.githubusercontent.com/4DNucleome/PartSeg/master/images/measurement.png)\n\nMain window of Mask Segmentation:\n\n![mask interface](https://raw.githubusercontent.com/4DNucleome/PartSeg/master/images/roi_mask.png)\n\n## Laboratory\n\nLaboratory of Functional and Structural Genomics\n[http://4dnucleome.cent.uw.edu.pl/](http://4dnucleome.cent.uw.edu.pl/)\n\n## Cite as\n\nBokota, G., Sroka, J., Basu, S. et al. PartSeg: a tool for quantitative feature extraction\nfrom 3D microscopy images for dummies. BMC Bioinformatics 22, 72 (2021).\n[https://doi.org/10.1186/s12859-021-03984-1](https://doi.org/10.1186/s12859-021-03984-1)\n\n\n## Changelog\n\n### 0.13.4\n\n-   Bugfix for outdated profile/pipeline preview\n\n### 0.13.3\n\n-   Fix saving roi_info in multiple files and history\n\n### 0.13.2\n\n-   Fix showing label in select label tab\n\n### 0.13.1\n\n-   Add Haralick measurements\n-   Add obsep file support\n\n### 0.13.0\n\n-   Add possibility of custom input widgets for algorithms\n-   Switch to napari Colormaps instead of custom one\n-   Add points visualization\n-   Synchronization widget for builtin (View menu) napari viewer\n-   Drop Python 3.6\n\n### 0.12.7\n\n-   Fixes for napari 0.4.6\n\n### 0.12.6\n\n-   Fix prev_mask_get\n-   Fix cache mechanism on mask change\n-   Update PyInstaller build\n\n### 0.12.5\n\n-   Fix bug in pipeline execute\n\n### 0.12.4\n\n-   Fix ROI Mask windows related build (signal not properly connected)\n\n### 0.12.3\n\n-   Fix ROI Mask\n\n### 0.12.2\n\n-   Fix windows bundle\n\n### 0.12.1\n\n-   History of last opened files\n-   Add ROI annotation and ROI alternatives\n-   Minor bugfix\n\n### 0.12.0\n\n-   Toggle multiple files widget in View menu\n-   Toggle Left panel in ROI Analysis in View Menu\n-   Rename Mask Segmentation to ROI Mask\n-   Add documentation for interface\n-   Add Batch processing tutorial\n-   Add information about errors to batch processing output file\n-   Load image from the batch prepare window\n-   Add search option in part of list and combo boxes\n-   Add drag and drop mechanism to load list of files to batch window.\n\n### 0.11.5\n\n-   add side view to viewer\n-   fix horizontal view for Measurements result table\n\n### 0.11.4\n\n-   bump to napari 0.3.8 in bundle\n-   fix bug with not presented segmentation loaded from project\n-   add frame (1 pix) to image cat from base one based on segmentation\n-   pin to Qt version to 5.14\n\n### 0.11.3\n\n-   prepare for napari 0.3.7\n-   split napari io plugin on multiple part\n-   better reporting for numpy array via sentry\n-   fix setting color for mask marking\n\n### 0.11.2\n\n-   Speedup image set in viewer using async calls\n-   Fix bug in long name of sheet with parameters\n\n### 0.11.1\n\n-   Add screenshot option in View menu\n-   Add Voxels measurements\n\n### 0.11.0\n\n-   Make sprawl algorithm name shorter\n-   Unify capitalisation of measurement names\n-   Add simple measurements to mask segmentation\n-   Use napari as viewer\n-   Add possibility to preview additional output of algorithms (In View menu)\n-   Update names of available Algorithm and Measurement to be more descriptive.\n\n### 0.10.8\n\n-   fix synchronisation between viewers in Segmentation Analysis\n-   fix batch crash on error during batch run, add information about file on which calculation fails\n-   add changelog preview in Help > About\n\n### 0.10.7\n\n-   in measurements, on empty list of components mean will return 0\n\n### 0.10.6\n\n-   fix border rim preview\n-   fix problem with size of image preview\n-   zoom with scroll and moving if rectangle zoom is not marked\n\n### 0.10.5\n\n-   make PartSeg PEP517 compatible.\n-   fix multiple files widget on Windows (path normalisation)\n\n### 0.10.4\n\n-   fix slow zoom\n\n### 0.10.3\n\n-   deterministic order of elements in batch processing.\n\n### 0.10.2\n\n-   bugfixes\n\n### 0.10.1\n\n-   bugfixes\n\n### 0.10.0\n\n-   Add creating custom label coloring.\n-   Change execs interpreter to python 3.7.\n-   Add masking operation in Segmentation Mask.\n-   Change license to BSD.\n-   Allow select root type in batch processing.\n-   Add median filter in preview.\n\n### 0.9.7\n\n-   fix bug in compare mask\n\n### 0.9.6\n\n-   fix bug in loading project with mask\n-   upgrade PyInstaller version (bug  GHSA-7fcj-pq9j-wh2r)\n\n### 0.9.5\n\n-   fix bug in loading project in \"Segmentation analysis\"\n\n### 0.9.4\n\n-   read mask segmentation projects\n-   choose source type in batch\n-   add initial support to OIF and CZI file format\n-   extract utils to PartSegCore module\n-   add automated tests of example notebook\n-   reversed mask\n-   load segmentation parameters in mask segmentation\n-   allow use sprawl in segmentation tool\n-   add radial split of mask for measurement\n-   add all measurement results in batch, per component sheet\n\n### 0.9.3\n\n-   start automated build documentation\n-   change color map backend and allow for user to create custom color map.\n-   segmentation compare\n-   update test engines\n-   support of PySide2\n\n### 0.9.2.3\n\n-   refactor code to make easier create plugin for mask segmentation\n-   create class base updater for update outdated algorithm description\n-   fix save functions\n-   fix different bugs\n\n### 0.9.2.2\n\n-   extract static data to separated package\n-   update marker of fix range and add mark of gauss in channel control\n\n### 0.9.2.1\n\n-   add VoteSmooth and add choosing of smooth algorithm\n\n### 0.9.2\n\n-   add pypi base check for update\n\n-   remove resetting image state when change state in same image\n\n-   in stack segmentation add options to picking components from segmentation's\n\n-   in mask segmentation add:\n\n    -   preview of segmentation parameters per component,\n    -   save segmentation parameters in save file\n    -   new implementation of batch mode.\n\n### 0.9.1\n\n-   Add multiple files widget\n\n-   Add Calculating distances between segmented object and mask\n\n-   Batch processing plan fixes:\n\n    -   Fix adding pipelines to plan\n    -   Redesign mask widget\n\n-   modify measurement backend to allow calculate multi channel measurements.\n\n### 0.9\n\nBegin of changelog\n\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Grzegorz Bokota",
+        "email": "g.bokota@cent.uw.edu.pl"
+      }
+    ],
+    "license": "BSD-3-Clause",
+    "python_version": ">=3.7",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-04-17T15:28:42.348986Z",
+    "version": "0.13.4",
+    "first_released": "2019-01-14T23:29:35.670697Z",
+    "development_status": ["Development Status :: 3 - Alpha"]
+  },
+  {
+    "name": "brainglobe-napari-io",
+    "summary": "Read and write files from the BrainGlobe neuroanatomy suite",
+    "description": "# napari-cellfinder\n\n[![License](https://img.shields.io/pypi/l/brainglobe-napari-io.svg?color=green)](https://github.com/napari/brainglobe-napari-io/raw/master/LICENSE)\n[![PyPI](https://img.shields.io/pypi/v/brainglobe-napari-io.svg?color=green)](https://pypi.org/project/brainglobe-napari-io)\n[![Python Version](https://img.shields.io/pypi/pyversions/brainglobe-napari-io.svg?color=green)](https://python.org)\n[![tests](https://github.com/brainglobe/brainglobe-napari-io/workflows/tests/badge.svg)](https://github.com/brainglobe/brainglobe-napari-io/actions)\n[![codecov](https://codecov.io/gh/brainglobe/brainglobe-napari-io/branch/master/graph/badge.svg)](https://codecov.io/gh/brainglobe/brainglobe-napari-io)\n\nVisualise cellfinder and brainreg results with napari\n\n\n----------------------------------\n\n\n## Installation\nThis package is likely already installed \n(e.g. with cellfinder, brainreg or another napari plugin), but if you want to \ninstall it again, either use the napari plugin install GUI or you can \ninstall `brainglobe-napari-io` via [pip]:\n\n    pip install brainglobe-napari-io\n\n## Usage\n* Open napari (however you normally do it, but typically just type `napari` into your terminal, or click on your desktop icon)\n\n### brainreg\n#### Sample space\nOpen napari and drag your [brainreg](https://github.com/brainglobe/brainreg) output directory (the one with the log file) onto the napari window.\n\nVarious images should then open, including:\n* `Registered image` - the image used for registration, downsampled to atlas resolution\n* `atlas_name` - e.g. `allen_mouse_25um` the atlas labels, warped to your sample brain\n* `Boundaries` - the boundaries of the atlas regions\n\nIf you downsampled additional channels, these will also be loaded.\n\nMost of these images will not be visible by default. Click the little eye icon to toggle visibility.\n\n_N.B. If you use a high resolution atlas (such as `allen_mouse_10um`), then the files can take a little while to load._\n\n![sample_space](https://raw.githubusercontent.com/brainglobe/brainglobe-napari-io/master/resources/sample_space.gif)\n\n\n#### Atlas space\n`napari-brainreg` also comes with an additional plugin, for visualising your data \nin atlas space. \n\nThis is typically only used in other software, but you can enable it yourself:\n* Open napari\n* Navigate to `Plugins` -> `Plugin Call Order`\n* In the `Plugin Sorter` window, select `napari_get_reader` from the `select hook...` dropdown box\n* Drag `brainreg_read_dir_standard_space` (the atlas space viewer plugin) above `brainreg_read_dir` (the normal plugin) to ensure that the atlas space plugin is used preferentially.\n\n![atlas_space](https://raw.githubusercontent.com/brainglobe/brainglobe-napari-io/master/resources/atlas_space.gif)\n\n\n### cellfinder\n#### Load cellfinder XML file\n* Load your raw data (drag and drop the data directories into napari, one at a time)\n* Drag and drop your cellfinder XML file (e.g. `cell_classification.xml`) into napari.\n\n#### Load cellfinder directory\n* Load your raw data (drag and drop the data directories into napari, one at a time)\n* Drag and drop your cellfinder output directory into napari.\n\nThe plugin will then load your detected cells (in yellow) and the rejected cell \ncandidates (in blue). If you carried out registration, then these results will be \noverlaid (similarly to the loading brainreg data, but transformed to the \ncoordinate space of your raw data).\n\n![load_data](https://raw.githubusercontent.com/brainglobe/brainglobe-napari-io/master/resources/load_data.gif)\n**Loading raw data**\n\n![load_data](https://raw.githubusercontent.com/brainglobe/brainglobe-napari-io/master/resources/load_results.gif)\n**Loading cellfinder results**\n\n\n\n## Contributing\n\nContributions are very welcome. Tests can be run with [tox], please ensure\nthe coverage at least stays the same before you submit a pull request.\n\n## License\n\nDistributed under the terms of the [MIT] license,\n\"brainglobe-napari-io\" is free and open source software\n\n## Issues\n\nIf you encounter any problems, please [file an issue] along with a detailed description.\n\n[napari]: https://github.com/napari/napari\n[Cookiecutter]: https://github.com/audreyr/cookiecutter\n[@napari]: https://github.com/napari\n[MIT]: http://opensource.org/licenses/MIT\n[BSD-3]: http://opensource.org/licenses/BSD-3-Clause\n[GNU GPL v3.0]: http://www.gnu.org/licenses/gpl-3.0.txt\n[GNU LGPL v3.0]: http://www.gnu.org/licenses/lgpl-3.0.txt\n[Apache Software License 2.0]: http://www.apache.org/licenses/LICENSE-2.0\n[Mozilla Public License 2.0]: https://www.mozilla.org/media/MPL/2.0/index.txt\n[cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin\n[file an issue]: https://github.com/brainglobe/brainglobe-napari-io/issues\n[napari]: https://github.com/napari/napari\n[tox]: https://tox.readthedocs.io/en/latest/\n[pip]: https://pypi.org/project/pip/\n[PyPI]: https://pypi.org/\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Adam Tyson",
+        "email": "adam.tyson@ucl.ac.uk"
+      }
+    ],
+    "license": "GPL-3.0",
+    "python_version": ">=3.6",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-03-12T17:35:22.014796Z",
+    "version": "0.0.2",
+    "first_released": "2021-03-12T12:52:23.068881Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "napari-aicsimageio",
+    "summary": "AICSImageIO bindings for napari",
+    "description": "# napari-aicsimageio\n\n[![Build Status](https://github.com/AllenCellModeling/napari-aicsimageio/workflows/Build%20Master/badge.svg)](https://github.com/AllenCellModeling/napari-aicsimageio/actions)\n[![Code Coverage](https://codecov.io/gh/AllenCellModeling/napari-aicsimageio/branch/master/graph/badge.svg)](https://codecov.io/gh/AllenCellModeling/napari-aicsimageio)\n\nAICSImageIO bindings for napari\n\n---\n\n## Features\n* Supports reading metadata and imaging data for:\n    * `CZI`\n    * `OME-TIFF`\n    * `TIFF`\n    * Any formats supported by [aicsimageio](https://github.com/AllenCellModeling/aicsimageio)\n    * Any additional format supported by [imageio](https://github.com/imageio/imageio)\n* Two variants of the AICSImageIO bindings:\n    * `aicsimageio`, which reads the image fully into memory\n    * `aicsimageio-delayed`, which delays reading YX planes until requested for large file support\n\n## Installation\n**Stable Release:** `pip install napari-aicsimageio`<br>\n**Development Head:** `pip install git+https://github.com/AllenCellModeling/napari-aicsimageio.git`\n\n## Development\nSee [CONTRIBUTING.md](CONTRIBUTING.md) for information related to developing the code.\n\n***Free software: BSD-3-Clause***\n\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Jackson Maxfield Brown",
+        "email": "jmaxfieldbrown@gmail.com"
+      }
+    ],
+    "license": "BSD-3-Clause",
+    "python_version": ">=3.7",
+    "operating_system": [],
+    "release_date": "2020-12-14T07:30:26.366917Z",
+    "version": "0.2.0",
+    "first_released": "2020-03-26T20:10:54.889461Z",
+    "development_status": ["Development Status :: 5 - Production/Stable"]
+  },
+  {
+    "name": "napari-lazy-openslide",
+    "summary": "A plugin to lazily load multiscale whole-slide images with openslide and dask.",
+    "description": "# napari-lazy-openslide\n\n[![License](https://img.shields.io/pypi/l/napari-lazy-openslide.svg?color=green)](https://github.com/manzt/napari-lazy-openslide/raw/master/LICENSE)\n[![PyPI](https://img.shields.io/pypi/v/napari-lazy-openslide.svg?color=green)](https://pypi.org/project/napari-lazy-openslide)\n[![Python Version](https://img.shields.io/pypi/pyversions/napari-lazy-openslide.svg?color=green)](https://python.org)\n[![tests](https://github.com/manzt/napari-lazy-openslide/workflows/tests/badge.svg)](https://github.com/manzt/napari-lazy-openslide/actions)\n\nAn experimental plugin to lazily load multiscale whole-slide tiff images with openslide and dask.\n\n----------------------------------\n\nThis [napari] plugin was generated with [Cookiecutter] using with [@napari]'s [cookiecutter-napari-plugin] template.\n\n<!--\nDon't miss the full getting started guide to set up your new package:\nhttps://github.com/napari/cookiecutter-napari-plugin#getting-started\n\nand review the napari docs for plugin developers:\nhttps://napari.org/docs/plugins/index.html\n-->\n\n## Installation\n\n**Step 1.)** Make sure you have OpenSlide installed. Download instructions [here](https://openslide.org/download/).\n\n> NOTE: Installation on macOS is easiest via Homebrew: `brew install openslide`. Up-to-date and multiplatform \n> binaries for `openslide` are also avaiable via `conda`: `conda install -c sdvillal openslide-python`\n\n**Step 2.)** Install `napari-lazy-openslide` via [pip]:\n\n    pip install napari-lazy-openslide\n\n## Usage\n\nThis plugin tries to be conservative with what files it will attempt to provide a reader.\nIt will only attempt to read `.tif` and `.tiff` files that `openslide` will open and are \ndetected as multiscale (`openslide.OpenSlide.level_count > 1`). Under the hood, \n`napari-lazy-openslide` wraps the `openslide` reader with a valid `zarr.Store` where each \neach pyramidal level is exposed as a separate `zarr.Array` with shape `(y,x,4)`.\n\nThe plugin is experimental and has only been tested with `CAMELYON16` and `CAMELYON17` datasets, \nwhich can be downloaded [here](https://camelyon17.grand-challenge.org/Data/).\n\n```bash\n$ napari tumor_004.tif\n```\n\n![Interactive deep zoom of whole-slide image](tumor_004.gif)\n\n## Contributing\n\nContributions are very welcome. Tests can be run with [tox], please ensure\nthe coverage at least stays the same before you submit a pull request.\n\n## License\n\nDistributed under the terms of the [BSD-3] license,\n\"napari-lazy-openslide\" is free and open source software\n\n## Issues\n\nIf you encounter any problems, please [file an issue] along with a detailed description.\n\n[napari]: https://github.com/napari/napari\n[Cookiecutter]: https://github.com/audreyr/cookiecutter\n[@napari]: https://github.com/napari\n[MIT]: http://opensource.org/licenses/MIT\n[BSD-3]: http://opensource.org/licenses/BSD-3-Clause\n[GNU GPL v3.0]: http://www.gnu.org/licenses/gpl-3.0.txt\n[GNU LGPL v3.0]: http://www.gnu.org/licenses/lgpl-3.0.txt\n[Apache Software License 2.0]: http://www.apache.org/licenses/LICENSE-2.0\n[Mozilla Public License 2.0]: https://www.mozilla.org/media/MPL/2.0/index.txt\n[cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin\n[file an issue]: https://github.com/manzt/napari-lazy-openslide/issues\n[napari]: https://github.com/napari/napari\n[tox]: https://tox.readthedocs.io/en/latest/\n[pip]: https://pypi.org/project/pip/\n[PyPI]: https://pypi.org/\n\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Trevor Manz",
+        "email": "trevor.j.manz@gmail.com"
+      }
+    ],
+    "license": "BSD-3",
+    "python_version": ">=3.6",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-01-30T19:48:17.848849Z",
+    "version": "0.2.0",
+    "first_released": "2020-07-14T17:50:55.269908Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "napari-btrack-reader",
+    "summary": "A plugin to load btrack files",
+    "description": "# napari-btrack-reader\n\n[![License](https://img.shields.io/pypi/l/napari-btrack-reader.svg?color=green)](https://github.com/napari/napari-btrack-reader/raw/master/LICENSE)\n[![PyPI](https://img.shields.io/pypi/v/napari-btrack-reader.svg?color=green)](https://pypi.org/project/napari-btrack-reader)\n[![Python Version](https://img.shields.io/pypi/pyversions/napari-btrack-reader.svg?color=green)](https://python.org)\n[![tests](https://github.com/quantumjot/napari-btrack-reader/workflows/tests/badge.svg)](https://github.com/quantumjot/napari-btrack-reader/actions)\n[![codecov](https://codecov.io/gh/quantumjot/napari-btrack-reader/branch/master/graph/badge.svg)](https://codecov.io/gh/quantumjot/napari-btrack-reader)\n\nA plugin to load btrack files\n\n----------------------------------\n\nThis plugin reads tracking data generated by BayesianTracker (btrack).\n\nThis [napari] plugin was generated with [Cookiecutter] using with [@napari]'s [cookiecutter-napari-plugin] template.\n\n<!--\nDon't miss the full getting started guide to set up your new package:\nhttps://github.com/napari/cookiecutter-napari-plugin#getting-started\n\nand review the napari docs for plugin developers:\nhttps://napari.org/docs/plugins/index.html\n-->\n\n## Installation\n\nYou can install `napari-btrack-reader` via [pip]:\n\n    pip install napari-btrack-reader\n\n## Contributing\n\nContributions are very welcome. Tests can be run with [tox], please ensure\nthe coverage at least stays the same before you submit a pull request.\n\n## License\n\nDistributed under the terms of the [BSD-3] license,\n\"napari-btrack-reader\" is free and open source software\n\n## Issues\n\nIf you encounter any problems, please [file an issue] along with a detailed description.\n\n[napari]: https://github.com/napari/napari\n[Cookiecutter]: https://github.com/audreyr/cookiecutter\n[@napari]: https://github.com/napari\n[MIT]: http://opensource.org/licenses/MIT\n[BSD-3]: http://opensource.org/licenses/BSD-3-Clause\n[GNU GPL v3.0]: http://www.gnu.org/licenses/gpl-3.0.txt\n[GNU LGPL v3.0]: http://www.gnu.org/licenses/lgpl-3.0.txt\n[Apache Software License 2.0]: http://www.apache.org/licenses/LICENSE-2.0\n[Mozilla Public License 2.0]: https://www.mozilla.org/media/MPL/2.0/index.txt\n[cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin\n[file an issue]: https://github.com/quantumjot/napari-btrack-reader/issues\n[napari]: https://github.com/napari/napari\n[tox]: https://tox.readthedocs.io/en/latest/\n[pip]: https://pypi.org/project/pip/\n[PyPI]: https://pypi.org/\n\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Alan R. Lowe",
+        "email": "code@arlowe.co.uk"
+      }
+    ],
+    "license": "BSD-3",
+    "python_version": ">=3.6",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2020-11-05T10:23:48.064223Z",
+    "version": "0.1.0",
+    "first_released": "2020-11-05T10:23:48.064223Z",
+    "development_status": ["Development Status :: 4 - Beta"]
+  },
+  {
+    "name": "cellpose-napari",
+    "summary": "a generalist algorithm for anatomical segmentation",
+    "description": "# cellpose-napari <img src=\"docs/_static/favicon.ico\" width=\"50\" title=\"cellpose\" alt=\"cellpose\" align=\"right\" vspace = \"50\">\n\n[![Documentation Status](https://readthedocs.org/projects/cellpose-napari/badge/?version=latest)](https://cellpose-napari.readthedocs.io/en/latest/?badge=latest)\n[![tests](https://github.com/mouseland/cellpose-napari/workflows/tests/badge.svg)](https://github.com/mouseland/cellpose-napari/actions)\n[![codecov](https://codecov.io/gh/Mouseland/cellpose-napari/branch/main/graph/badge.svg)](https://codecov.io/gh/MouseLand/cellpose-napari)\n[![PyPI version](https://badge.fury.io/py/cellpose-napari.svg)](https://badge.fury.io/py/cellpose-napari)\n[![PyPI - Downloads](https://img.shields.io/pypi/dm/cellpose-napari)](https://pypistats.org/packages/cellpose-napari)\n[![Python version](https://img.shields.io/pypi/pyversions/cellpose-napari)](https://pypistats.org/packages/cellpose-napari)\n[![License](https://img.shields.io/pypi/l/cellpose-napari.svg?color=green)](https://github.com/mouseland/cellpose-napari/raw/master/LICENSE)\n[![Contributors](https://img.shields.io/github/contributors-anon/MouseLand/cellpose-napari)](https://github.com/MouseLand/cellpose-napari/graphs/contributors)\n[![website](https://img.shields.io/website?url=https%3A%2F%2Fwww.cellpose.org)](https://www.cellpose.org)\n[![GitHub stars](https://img.shields.io/github/stars/MouseLand/cellpose-napari?style=social)](https://github.com/MouseLand/cellpose-napari/)\n[![GitHub forks](https://img.shields.io/github/forks/MouseLand/cellpose-napari?style=social)](https://github.com/MouseLand/cellpose-napari/)\n\na napari plugin for anatomical segmentation of general cellular images\n\n----------------------------------\n\nThis [napari] plugin was generated with [Cookiecutter] using with [@napari]'s [cookiecutter-napari-plugin] template.\n\nThe plugin code was written by Carsen Stringer, and the cellpose code was written by Carsen Stringer and Marius Pachitariu. To learn about Cellpose, read the [**paper**](https://t.co/kBMXmPp3Yn?amp=1) or watch this [**talk**](https://t.co/JChCsTD0SK?amp=1). \n\nFor support with the plugin, please open an [issue](https://github.com/MouseLand/cellpose-napari/issues). For support with cellpose, please open an [issue](https://github.com/MouseLand/cellpose/issues) on the cellpose repo. \n\n\nIf you use this plugin please cite the [paper](https://www.nature.com/articles/s41592-020-01018-x):\n::\n\n      @article{stringer2021cellpose,\n      title={Cellpose: a generalist algorithm for cellular segmentation},\n      author={Stringer, Carsen and Wang, Tim and Michaelos, Michalis and Pachitariu, Marius},\n      journal={Nature Methods},\n      volume={18},\n      number={1},\n      pages={100--106},\n      year={2021},\n      publisher={Nature Publishing Group}\n      }\n\n\n![cellpose-napari_plugin](docs/_static/napari_main_demo_fast_small.gif?raw=true \"cellpose-napari\")\n\n## Installation\n\nInstall an [Anaconda](https://www.anaconda.com/download/) distribution of Python -- Choose **Python 3** and your operating system. Note you might need to use an anaconda prompt if you did not add anaconda to the path. \n\nYou can install `cellpose-napari` via [pip]:\n\n    pip install cellpose-napari\n\nIf install fails in your base environment, create a new environment:\n1. Download the [`environment.yml`](https://github.com/MouseLand/cellpose-napari/blob/master/environment.yml?raw=true) file from the repository. You can do this by cloning the repository, or copy-pasting the text from the file into a text document on your local computer.\n2. Open an anaconda prompt / command prompt with `conda` for **python 3** in the path\n3. Change directories to where the `environment.yml` is and run `conda env create -f environment.yml`\n4. To activate this new environment, run `conda activate cellpose-napari`\n5. You should see `(cellpose-napari)` on the left side of the terminal line. \n\nIf you have **issues** with cellpose installation, see the [cellpose docs](https://cellpose.readthedocs.io/en/latest/installation.html) for more details, and then if the suggestions fail, open an issue.\n\n### Upgrading software\n\nYou can upgrade the plugin with\n~~~\npip install cellpose-napari --upgrade\n~~~\n\nand you can upgrade cellpose with\n~~~\npip install cellpose --upgrade\n~~~\n\n### GPU version (CUDA) on Windows or Linux\n\nIf you plan on running many images, you may want to install a GPU version of *torch* (if it isn't already installed).\n\nBefore installing the GPU version, remove the CPU version:\n~~~\npip uninstall torch\n~~~\n\nFollow the instructions [here](https://pytorch.org/get-started/locally/) to determine what version to install. The Anaconda install is recommended along with CUDA version 10.2. For instance this command will install the 10.2 version on Linux and Windows (note the `torchvision` and `torchaudio` commands are removed because cellpose doesn't require them):\n\n~~~\nconda install pytorch cudatoolkit=10.2 -c pytorch\n~~~~\n\nWhen upgrading GPU Cellpose in the future, you will want to ignore dependencies (to ensure that the pip version of torch does not install):\n~~~\npip install --no-deps cellpose --upgrade\n~~~\n\n### Installation of github version\n\nFollow steps from above to install the dependencies. In the github repository, run `pip install -e .` and the github version will be installed. If you want to go back to the pip version of cellpose-napari, then say `pip install cellpose-napari`.\n\n\n## Running the software\n\n\nOpen napari with the cellpose-napari dock widget open\n```\nnapari -w cellpose-napari\n```\n\nThere is sample data in the File menu, or get started with your own images!\n\n### Detailed usage [documentation](https://cellpose-napari.readthedocs.io/).\n\n## Contributing\n\nContributions are very welcome. Tests are run with pytest.\n\n## License\n\nDistributed under the terms of the [BSD-3] license,\n\"cellpose-napari\" is free and open source software.\n\n## Dependencies\ncellpose-napari relies on the following excellent packages (which are automatically installed with conda/pip if missing):\n- [napari](https://napari.org)\n- [magicgui](https://napari.org/magicgui/)\n\ncellpose relies on the following excellent packages (which are automatically installed with conda/pip if missing):\n- [torch](https://pytorch.org/)\n- [numpy](http://www.numpy.org/) (>=1.16.0)\n- [numba](http://numba.pydata.org/numba-doc/latest/user/5minguide.html)\n- [scipy](https://www.scipy.org/)\n- [natsort](https://natsort.readthedocs.io/en/master/)\n- [tifffile](https://pypi.org/project/tifffile/)\n- [opencv](https://opencv.org/)\n\n\n[napari]: https://github.com/napari/napari\n[Cookiecutter]: https://github.com/audreyr/cookiecutter\n[@napari]: https://github.com/napari\n[BSD-3]: http://opensource.org/licenses/BSD-3-Clause\n[cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin\n\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Carsen Stringer",
+        "email": "stringerc@janelia.hhmi.org"
+      }
+    ],
+    "license": "BSD-3",
+    "python_version": ">=3.6",
+    "operating_system": ["Operating System :: OS Independent"],
+    "release_date": "2021-05-03T01:51:03.086320Z",
+    "version": "0.1.3",
+    "first_released": "2021-04-26T03:13:32.237206Z",
+    "development_status": []
+  },
+  {
+    "name": "brainreg-segment",
+    "summary": "Manual segmentation of 3D brain structures in a common anatomical space",
+    "description": "[![Python Version](https://img.shields.io/pypi/pyversions/brainreg-segment.svg)](https://pypi.org/project/brainreg-segment)\n[![PyPI](https://img.shields.io/pypi/v/brainreg-segment.svg)](https://pypi.org/project/brainreg-segment)\n[![Wheel](https://img.shields.io/pypi/wheel/brainreg-segment.svg)](https://pypi.org/project/brainreg-segment)\n[![Development Status](https://img.shields.io/pypi/status/brainreg-segment.svg)](https://github.com/brainglobe/brainreg-segment)\n[![Tests](https://img.shields.io/github/workflow/status/brainglobe/brainreg-segment/tests)](\n    https://github.com/brainglobe/brainreg-segment/actions)\n[![Coverage Status](https://coveralls.io/repos/github/brainglobe/brainreg-segment/badge.svg?branch=master)](https://coveralls.io/github/brainglobe/brainreg-segment?branch=master)\n[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)\n[![Gitter](https://badges.gitter.im/brainglobe/brainreg-segment.svg)](https://gitter.im/brainglobe/brainreg-segment?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)\n\n# brainreg-segment\nSegmentation of 1/2/3D brain structures in a common anatomical space\n\n`brainreg-segment` is a companion to [`brainreg`](https://github.com/brainglobe/brainreg) allowing manual segmentation of regions/objects within the brain (e.g. injection sites, probes etc.) allowing for automated analysis of brain region distribution, and visualisation (e.g. in [brainrender](https://github.com/BrancoLab/brainrender)).\n\n## Installation\n\nbrainreg-segment comes bundled with [`brainreg`](https://github.com/brainglobe/brainreg), so see the [brainreg installation instructions](https://docs.brainglobe.info/brainreg/installation). \n\nbrainreg-segment can be installed on it's own (`pip install brainreg-segment`), but you will need to register your data with brainreg first. \n\n## Usage\n\nSee [user guide](https://docs.brainglobe.info/brainreg-segment/user-guide)\n\n",
+    "description_content_type": "text/markdown",
+    "authors": [
+      {
+        "name": "Adam Tyson, Horst Obenhaus",
+        "email": "code@adamltyson.com"
+      }
+    ],
+    "license": "",
+    "python_version": ">=3.7",
+    "operating_system": [
+      "Operating System :: Microsoft :: Windows :: Windows 10",
+      "Operating System :: POSIX :: Linux"
+    ],
+    "release_date": "2021-04-26T13:17:17.068145Z",
+    "version": "0.2.7",
+    "first_released": "2020-08-26T09:04:27.878441Z",
+    "development_status": ["Development Status :: 3 - Alpha"]
+  }
+]

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -18,6 +18,10 @@ import { Hydrate } from 'react-query/hydration';
 import { Layout } from '@/components';
 import { MediaContextProvider } from '@/components/common/media';
 
+interface GetLayoutComponent {
+  getLayout?(page: ReactNode): ReactNode;
+}
+
 interface QueryProviderProps {
   children: ReactNode;
   dehydratedState: unknown;
@@ -40,6 +44,12 @@ function ReactQueryProvider({ children, dehydratedState }: QueryProviderProps) {
 }
 
 export default function App({ Component, pageProps }: AppProps) {
+  // Render using custom layout if component exports one:
+  // https://adamwathan.me/2019/10/17/persistent-layout-patterns-in-nextjs/
+  const { getLayout } = Component as GetLayoutComponent;
+  let page: ReactNode = <Component {...pageProps} />;
+  page = getLayout?.(page) ?? <Layout>{page}</Layout>;
+
   return (
     <>
       <Head>
@@ -47,11 +57,7 @@ export default function App({ Component, pageProps }: AppProps) {
       </Head>
 
       <ReactQueryProvider dehydratedState={pageProps.dehydratedState}>
-        <MediaContextProvider>
-          <Layout>
-            <Component {...pageProps} />
-          </Layout>
-        </MediaContextProvider>
+        <MediaContextProvider>{page}</MediaContextProvider>
       </ReactQueryProvider>
     </>
   );

--- a/client/src/utils/logger.ts
+++ b/client/src/utils/logger.ts
@@ -1,0 +1,57 @@
+/*
+  eslint-disable
+    @typescript-eslint/no-explicit-any,
+    no-console,
+*/
+
+/**
+ * Class for logging messages at different levels. This allows us to format log
+ * messages in a standardized way and also opens up the possibility of adding
+ * different transports like logging to a file on the server or logging to the
+ * cloud.
+ */
+export class Logger {
+  /**
+   * Creates a new logger instance. Named loggers can be created using the
+   * `name` option and can be used for showing a unique name for all log
+   * messages. This is similar to `logging.getLogger(__name__)` in python.
+   *
+   * @param name The name for the logger
+   */
+  constructor(private name: string = '') {}
+
+  log(...messages: any[]): void {
+    if (process.env.NODE_ENV !== 'production') {
+      console.log(...this.formatMessages(messages));
+    }
+  }
+
+  debug(...messages: any[]): void {
+    if (process.env.NODE_ENV !== 'production') {
+      console.debug(...this.formatMessages(messages));
+    }
+  }
+
+  error(...messages: any[]): void {
+    console.error(...this.formatMessages(messages));
+  }
+
+  info(...messages: any[]): void {
+    console.info(...this.formatMessages(messages));
+  }
+
+  warn(...messages: any[]): void {
+    console.warn(...this.formatMessages(messages));
+  }
+
+  trace(...messages: any[]): void {
+    console.trace(...this.formatMessages(messages));
+  }
+
+  private formatMessages(messages: any[]): any[] {
+    const date = new Date();
+    return [`[${date.toISOString()}]`, this.name && `[${this.name}]`]
+      .filter(Boolean)
+      .concat(messages);
+  }
+}

--- a/client/src/utils/performance.ts
+++ b/client/src/utils/performance.ts
@@ -1,0 +1,23 @@
+interface MeasureExecutionResult {
+  duration: string;
+}
+
+/**
+ * Utility for measuring the execution duration of a function.
+ *
+ * @param fn Function to measure.
+ * @returns The result of the function, if any.
+ */
+export function measureExecution<R>(
+  fn: () => R,
+): MeasureExecutionResult & { result: R } {
+  const now = window.performance.now();
+  const result = fn();
+  const end = window.performance.now();
+  const duration = `${(end - now).toFixed(2)} ms`;
+
+  return {
+    duration,
+    result,
+  };
+}


### PR DESCRIPTION
## Description

This PR is part 1 of 2 PRs for adding plugin search. This PR includes minor refactors and additions accumulated while working on the search engine.

## Changes

- Running `yarn dev` will now run the mock server automatically
- It's now possible to run E2E tests using a specific screen size: `DEVICE=2xl yarn e2e`
- Index fixture data for testing
- Utilities:
  - `measureExecution()` for measuring runtime of a function using [window.performance.now()](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now)
  - `Logger` for logging messages in a standardized way. Right now it's a glorified `console.log` wrapper, but it can be extended to other transports in the future
- Mock `window.location` in jest tests for router related tests
- `ColumnLayout` component for reusing the napari 3-column layout
- Allow support for custom page layouts using `getLayout()`

## Demos

Demos can be found in #35