### PR TITLE
Improve Dockerfile for production

### DIFF
--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,3 +1,5 @@
+.dockerignore
 .next
 .vercel
+Dockerfile
 node_modules

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,6 +1,28 @@
-FROM node:15
-COPY . /app
+# Build image
+FROM node:16-alpine AS builder
+
 WORKDIR /app
-RUN yarn install && yarn build
+
+# Install dependencies
+COPY package.json yarn.lock postinstall.js /app/
+RUN yarn install
+
+# Build for production
+COPY . /app
+RUN yarn build
+
+# Application image
+FROM node:16-alpine
+
+WORKDIR /app
+
+# Install dependencies for production
+COPY package.json yarn.lock postinstall.js /app/
+ENV NODE_ENV=production
+RUN yarn install
+
+# Copy application build to image
+COPY --from=builder /app/.next /app/.next
+
 EXPOSE 8080
 ENTRYPOINT [ "yarn", "start" ]

--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,7 @@
     "e2e": "jest -c jest/e2e.config.js",
     "e2e:watch": "yarn e2e --watch",
     "e2e:update": "yarn e2e --updateSnapshot",
-    "postinstall": "cd .. && husky install",
+    "postinstall": "node postinstall",
     "start": "next start -p 8080",
     "start:mock-server": "node mock-server",
     "test": "jest -c jest/test.config.js",

--- a/client/postinstall.js
+++ b/client/postinstall.js
@@ -1,0 +1,9 @@
+const { execSync } = require('child_process');
+const { resolve } = require('path');
+
+if (process.env.NODE_ENV !== 'production') {
+  execSync('husky install', {
+    cwd: resolve(__dirname, '..'),
+    stdio: 'inherit',
+  });
+}


### PR DESCRIPTION
## Description

This PR improves the frontend Dockerfile. It splits the image into two using [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/) so that build dependencies and source code aren't included in the final production image. It also switches the base image to an alpine based runtime.

This ultimately reduces the image size from 2.51 GB to 600 MB.