### PR TITLE
Minor client refactors

### DIFF
--- a/client/src/components/AppBar/AppBar.module.scss
+++ b/client/src/components/AppBar/AppBar.module.scss
@@ -1,5 +1,0 @@
-.links {
-  :not(:first-child) {
-    @apply ml-6;
-  }
-}

--- a/client/src/components/AppBar/AppBar.module.scss.d.ts
+++ b/client/src/components/AppBar/AppBar.module.scss.d.ts
@@ -1,9 +1,0 @@
-export type Styles = {
-  links: string;
-};
-
-export type ClassNames = keyof Styles;
-
-declare const styles: Styles;
-
-export default styles;

--- a/client/src/components/AppBar/AppBar.tsx
+++ b/client/src/components/AppBar/AppBar.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image';
 import { useState } from 'react';
 
 import { MenuDrawer, SearchBar } from '@/components';
-import { Link } from '@/components/common';
+import { ColumnLayout, Link } from '@/components/common';
 import { MenuDrawerItem } from '@/components/MenuDrawer/types';
 import { useSearchState } from '@/context/search';
 
@@ -87,27 +87,21 @@ export function AppBar() {
         visible={visible}
       />
 
-      <nav
+      <ColumnLayout
         className={clsx(
           // Color and height
           'bg-napari-primary h-napari-app-bar',
 
+          // Centering
+          'justify-center items-center',
+
           // Padding
           'px-6 md:px-12 2xl:p-0',
 
-          // Grid layout
-          'grid grid-cols-napari-nav-mobile',
-          'justify-center items-center',
-
-          // Grid gap
-          'gap-6 md:gap-12',
-
-          // Change to 2 column grid layout when 2xl+ screens
-          '2xl:grid 2xl:grid-cols-napari-app-bar-2-col',
-
-          // Use 3 column layout when 3xl+ screens
-          '3xl:grid 3xl:grid-cols-napari-3-col',
+          // Grid layout for smaller screens
+          'grid-cols-[min-content,1fr]',
         )}
+        component="nav"
       >
         <AppBarHeader />
 
@@ -141,7 +135,7 @@ export function AppBar() {
             />
           </button>
         </div>
-      </nav>
+      </ColumnLayout>
     </>
   );
 }

--- a/client/src/components/AppBar/AppBar.tsx
+++ b/client/src/components/AppBar/AppBar.tsx
@@ -4,10 +4,9 @@ import { useState } from 'react';
 
 import { MenuDrawer, SearchBar } from '@/components';
 import { ColumnLayout, Link } from '@/components/common';
+import { MediaFragment } from '@/components/common/media';
 import { MenuDrawerItem } from '@/components/MenuDrawer/types';
 import { useSearchState } from '@/context/search';
-
-import styles from './AppBar.module.scss';
 
 const IMAGE_SIZE = 16;
 
@@ -21,6 +20,21 @@ const MENU_ITEMS: MenuDrawerItem[] = [
     link: '/help',
   },
 ];
+
+/**
+ * Link bar for rendering menu links. This only shows up on lg+ screens.
+ */
+function AppBarLinks() {
+  return (
+    <>
+      {MENU_ITEMS.map((item) => (
+        <Link className="ml-6" key={item.link} href={item.link}>
+          {item.title}
+        </Link>
+      ))}
+    </>
+  );
+}
 
 /**
  * Header that links back to the home page.
@@ -43,33 +57,11 @@ function AppBarHeader() {
           napari <strong>hub</strong>
         </Link>
       </h1>
+
+      <MediaFragment greaterThanOrEqual="lg">
+        <AppBarLinks />
+      </MediaFragment>
     </header>
-  );
-}
-
-/**
- * Link bar for rendering menu links. This only shows up on lg+ screens.
- */
-function AppBarLinks() {
-  return (
-    <ul
-      className={clsx(
-        // Hide links on smaller layouts
-        'hidden lg:flex',
-
-        // Margins
-        'ml-12',
-
-        // Custom link styling
-        styles.links,
-      )}
-    >
-      {MENU_ITEMS.map((item) => (
-        <li className="list-none" key={item.link}>
-          <Link href={item.link}>{item.title}</Link>
-        </li>
-      ))}
-    </ul>
   );
 }
 
@@ -118,7 +110,6 @@ export function AppBar() {
           )}
         >
           <SearchBar />
-          <AppBarLinks />
 
           {/* Menu button */}
           <button

--- a/client/src/components/AppBar/AppBar.tsx
+++ b/client/src/components/AppBar/AppBar.tsx
@@ -16,8 +16,8 @@ const MENU_ITEMS: MenuDrawerItem[] = [
     link: '/about',
   },
   {
-    title: 'Help',
-    link: '/help',
+    title: 'FAQ',
+    link: '/faq',
   },
 ];
 

--- a/client/src/components/AppBar/__snapshots__/AppBar.test.tsx.snap
+++ b/client/src/components/AppBar/__snapshots__/AppBar.test.tsx.snap
@@ -25,9 +25,9 @@ exports[`<AppBar /> should match snapshot 1`] = `
         data-testid="drawerItem"
       >
         <a
-          href="/help"
+          href="/faq"
         >
-          Help
+          FAQ
         </a>
       </li>
     </ul>
@@ -57,7 +57,7 @@ exports[`<AppBar /> should match snapshot 1`] = `
     </button>
   </div>
   <nav
-    class="bg-napari-primary h-napari-app-bar px-6 md:px-12 2xl:p-0 grid grid-cols-napari-nav-mobile justify-center items-center gap-6 md:gap-12 2xl:grid 2xl:grid-cols-napari-app-bar-2-col 3xl:grid 3xl:grid-cols-napari-3-col"
+    class="bg-napari-primary h-napari-app-bar justify-center items-center px-6 md:px-12 2xl:p-0 grid-cols-[min-content,1fr] grid grid-cols-1 justify-center gap-6 md:gap-12 2xl:grid-cols-napari-2-col 3xl:grid-cols-napari-3-col"
   >
     <header
       class="flex"
@@ -75,6 +75,18 @@ exports[`<AppBar /> should match snapshot 1`] = `
           </strong>
         </a>
       </h1>
+      <a
+        class="ml-6"
+        href="/about"
+      >
+        About
+      </a>
+      <a
+        class="ml-6"
+        href="/faq"
+      >
+        FAQ
+      </a>
     </header>
     <div
       class="flex items-center w-full max-w-napari-center-col justify-self-end"
@@ -100,28 +112,6 @@ exports[`<AppBar /> should match snapshot 1`] = `
           />
         </div>
       </form>
-      <ul
-        class="hidden lg:flex ml-12 links"
-      >
-        <li
-          class="list-none"
-        >
-          <a
-            href="/about"
-          >
-            About
-          </a>
-        </li>
-        <li
-          class="list-none"
-        >
-          <a
-            href="/help"
-          >
-            Help
-          </a>
-        </li>
-      </ul>
       <button
         class="ml-6 flex lg:hidden"
         type="button"

--- a/client/src/components/Layout/__snapshots__/Layout.test.tsx.snap
+++ b/client/src/components/Layout/__snapshots__/Layout.test.tsx.snap
@@ -25,9 +25,9 @@ exports[`<Layout /> should match snapshot 1`] = `
         data-testid="drawerItem"
       >
         <a
-          href="/help"
+          href="/faq"
         >
-          Help
+          FAQ
         </a>
       </li>
     </ul>
@@ -57,7 +57,7 @@ exports[`<Layout /> should match snapshot 1`] = `
     </button>
   </div>
   <nav
-    class="bg-napari-primary h-napari-app-bar px-6 md:px-12 2xl:p-0 grid grid-cols-napari-nav-mobile justify-center items-center gap-6 md:gap-12 2xl:grid 2xl:grid-cols-napari-app-bar-2-col 3xl:grid 3xl:grid-cols-napari-3-col"
+    class="bg-napari-primary h-napari-app-bar justify-center items-center px-6 md:px-12 2xl:p-0 grid-cols-[min-content,1fr] grid grid-cols-1 justify-center gap-6 md:gap-12 2xl:grid-cols-napari-2-col 3xl:grid-cols-napari-3-col"
   >
     <header
       class="flex"
@@ -75,6 +75,18 @@ exports[`<Layout /> should match snapshot 1`] = `
           </strong>
         </a>
       </h1>
+      <a
+        class="ml-6"
+        href="/about"
+      >
+        About
+      </a>
+      <a
+        class="ml-6"
+        href="/faq"
+      >
+        FAQ
+      </a>
     </header>
     <div
       class="flex items-center w-full max-w-napari-center-col justify-self-end"
@@ -100,28 +112,6 @@ exports[`<Layout /> should match snapshot 1`] = `
           />
         </div>
       </form>
-      <ul
-        class="hidden lg:flex ml-12 links"
-      >
-        <li
-          class="list-none"
-        >
-          <a
-            href="/about"
-          >
-            About
-          </a>
-        </li>
-        <li
-          class="list-none"
-        >
-          <a
-            href="/help"
-          >
-            Help
-          </a>
-        </li>
-      </ul>
       <button
         class="ml-6 flex lg:hidden"
         type="button"

--- a/client/src/components/PluginDetails/CallToActionButton.tsx
+++ b/client/src/components/PluginDetails/CallToActionButton.tsx
@@ -25,9 +25,6 @@ export function CallToActionButton({ className }: Props) {
           // Button color
           'bg-napari-primary',
 
-          // Keep button on screen when scrolling on 2xl.
-          '2xl:fixed',
-
           // Dimensions
           'h-12 w-full lg:max-w-napari-side-col',
         )}

--- a/client/src/components/PluginDetails/MetadataList.tsx
+++ b/client/src/components/PluginDetails/MetadataList.tsx
@@ -143,11 +143,7 @@ export function MetadataList({
 }: MetadataListProps) {
   return (
     <ul
-      className={clsx(
-        'list-none',
-        className,
-        horizontal && 'grid grid-cols-napari-3-col-fr',
-      )}
+      className={clsx(className, 'list-none', horizontal && 'grid grid-cols-3')}
     >
       {items.map((item) => {
         const values = item.value instanceof Array ? item.value : [item.value];

--- a/client/src/components/PluginDetails/PluginDetails.tsx
+++ b/client/src/components/PluginDetails/PluginDetails.tsx
@@ -97,7 +97,12 @@ function PluginRightColumn() {
  */
 export function PluginDetails() {
   return (
-    <ColumnLayout data-testid="pluginDetails">
+    <ColumnLayout
+      className="p-6 md:p-12 2xl:px-0"
+      data-testid="pluginDetails"
+      // Use reverse 2-column layout to render 225px TOC on the right side.
+      reverseTwoColumn
+    >
       <PluginLeftColumn />
       <PluginCenterColumn />
       <PluginRightColumn />

--- a/client/src/components/PluginDetails/PluginDetails.tsx
+++ b/client/src/components/PluginDetails/PluginDetails.tsx
@@ -71,6 +71,8 @@ function PluginCenterColumn() {
         {plugin.description}
       </Markdown>
 
+      <CallToActionButton className="mb-6 md:mb-12 2xl:mb-20" />
+
       <MediaFragment lessThan="3xl">
         <PluginMetadata />
       </MediaFragment>
@@ -83,7 +85,9 @@ function PluginRightColumn() {
 
   return (
     <Media greaterThanOrEqual="2xl">
-      <CallToActionButton />
+      {/*  Keep button on screen when scrolling on 2xl. */}
+      <CallToActionButton className="fixed" />
+
       <Markdown.TOC
         className="fixed flex mt-24"
         markdown={plugin.description}

--- a/client/src/components/PluginDetails/PluginMetadata.tsx
+++ b/client/src/components/PluginDetails/PluginMetadata.tsx
@@ -136,18 +136,19 @@ function PluginMetadataBase({
 
   return (
     <div
+      // ID is used to navigate to metadata using `View project data` link
       id="pluginMetadata"
       className={clsx(
         className,
 
-        // Vertical layout for < xl
-        'flex flex-col',
+        // Vertical 1-column grid layout for < xl
+        'grid',
 
-        // Horizontal layout with 3 column grid for xl+
-        'xl:grid xl:grid-cols-napari-3-col-fr',
+        // Horizontal layout with 3-column grid for xl+
+        'xl:grid-cols-3',
 
-        // Back to vertical layout for 3xl+
-        '3xl:flex',
+        // Back to 1-column vertical layout for 3xl+
+        '3xl:grid-cols-1',
       )}
     >
       <MetadataList inline={inline} items={projectItems} />

--- a/client/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
+++ b/client/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
@@ -2,14 +2,14 @@
 
 exports[`<PluginDetails /> should match snapshot 1`] = `
 <div
-  class="flex 2xl:grid 2xl:justify-center p-6 md:p-14 2xl:px-0 2xl:gap-14 2xl:grid-cols-napari-2-col 3xl:grid-cols-napari-3-col"
+  class="p-6 md:p-12 2xl:px-0 grid grid-cols-1 justify-center gap-6 md:gap-12 2xl:grid-cols-napari-2-col-reverse 3xl:grid-cols-napari-3-col"
   data-testid="pluginDetails"
 >
   <div
     class="fresnel-container fresnel-greaterThanOrEqual-3xl "
   >
     <div
-      class="fresnel-greaterThanOrEqual-3xl flex flex-col xl:grid xl:grid-cols-napari-3-col-fr 3xl:flex"
+      class="fresnel-greaterThanOrEqual-3xl grid xl:grid-cols-3 3xl:grid-cols-1"
       id="pluginMetadata"
     >
       <ul
@@ -261,7 +261,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
         class="absolute min-w-napari-xs"
       />
       <button
-        class="fresnel-lessThan-2xl bg-napari-primary 2xl:fixed h-12 w-full lg:max-w-napari-side-col"
+        class="fresnel-lessThan-2xl bg-napari-primary h-12 w-full lg:max-w-napari-side-col"
         type="button"
       >
         Install
@@ -274,7 +274,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       </a>
     </div>
     <ul
-      class="list-none text-black bg-gray-100 p-5 fresnel-greaterThanOrEqual-xl mb-6 md:mb-12 grid grid-cols-napari-3-col-fr"
+      class="text-black bg-gray-100 p-5 fresnel-greaterThanOrEqual-xl mb-6 md:mb-12 list-none grid grid-cols-3"
     >
       <li
         class="mb-4 text-sm"
@@ -558,7 +558,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       </li>
     </ul>
     <ul
-      class="list-none text-black bg-gray-100 p-5 fresnel-lessThan-xl mb-6 md:mb-12"
+      class="text-black bg-gray-100 p-5 fresnel-lessThan-xl mb-6 md:mb-12 list-none"
     >
       <li
         class="mb-4 text-sm"
@@ -1221,7 +1221,16 @@ the coverage at least stays the same before you submit a pull request.
       </p>
     </div>
     <div
-      class="fresnel-lessThan-3xl fresnel-lessThan-3xl flex flex-col xl:grid xl:grid-cols-napari-3-col-fr 3xl:flex"
+      class="absolute min-w-napari-xs"
+    />
+    <button
+      class="mb-6 md:mb-12 2xl:mb-20 bg-napari-primary h-12 w-full lg:max-w-napari-side-col"
+      type="button"
+    >
+      Install
+    </button>
+    <div
+      class="fresnel-lessThan-3xl fresnel-lessThan-3xl grid xl:grid-cols-3 3xl:grid-cols-1"
       id="pluginMetadata"
     >
       <ul
@@ -1460,7 +1469,7 @@ the coverage at least stays the same before you submit a pull request.
       class="absolute min-w-napari-xs"
     />
     <button
-      class="bg-napari-primary 2xl:fixed h-12 w-full lg:max-w-napari-side-col"
+      class="fixed bg-napari-primary h-12 w-full lg:max-w-napari-side-col"
       type="button"
     >
       Install

--- a/client/src/components/PluginSearch/__snapshots__/PluginSearch.test.tsx.snap
+++ b/client/src/components/PluginSearch/__snapshots__/PluginSearch.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<PluginSearch /> should match snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="flex 2xl:grid 2xl:justify-center p-6 md:p-14 2xl:px-0 2xl:gap-14 2xl:grid-cols-napari-2-col 3xl:grid-cols-napari-3-col"
+    class="grid grid-cols-1 justify-center gap-6 md:gap-12 2xl:grid-cols-napari-2-col 3xl:grid-cols-napari-3-col"
   >
     <div
       class="fresnel-container fresnel-greaterThanOrEqual-3xl "

--- a/client/src/components/common/ColumnLayout/ColumnLayout.tsx
+++ b/client/src/components/common/ColumnLayout/ColumnLayout.tsx
@@ -1,29 +1,56 @@
 import clsx from 'clsx';
-import { HTMLAttributes, ReactNode } from 'react';
+import React, { createElement, HTMLAttributes, ReactNode } from 'react';
 
 interface Props extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * Children to render as columns. The 1st, 2nd, and 3rd child nodes are used
+   * for the 1st, 2nd, and 3rd columns, respectively.
+   */
   children: ReactNode;
+
+  /**
+   * Root component to use for column layout. The default is `div`.
+   */
+  component?: React.ElementType;
+
+  /**
+   * Most layouts use the `225px 775px` for the 2-column layout, but some
+   * require the layout to be `775px 225px`. For example, the plugin details
+   * page needs this for the plugin summary and TOC.
+   */
+  reverseTwoColumn?: boolean;
 }
 
-export function ColumnLayout({ children, ...props }: Props) {
-  return (
-    <div
-      className={clsx(
-        // Layout
-        'flex 2xl:grid 2xl:justify-center',
+export function ColumnLayout({
+  children,
+  className,
+  component = 'div',
+  reverseTwoColumn,
+  ...props
+}: Props) {
+  // Use `createElement()` to dynamically create element from `component` prop.
+  return createElement(
+    component,
+    {
+      className: clsx(
+        className,
 
-        // Padding
-        'p-6 md:p-14 2xl:px-0',
+        // Layout
+        'grid grid-cols-1 justify-center',
 
         // Grid gap
-        '2xl:gap-14',
+        'gap-6 md:gap-12',
 
-        // Grid columns
-        '2xl:grid-cols-napari-2-col 3xl:grid-cols-napari-3-col',
-      )}
-      {...props}
-    >
-      {children}
-    </div>
+        // 2-column grid
+        reverseTwoColumn
+          ? '2xl:grid-cols-napari-2-col-reverse'
+          : '2xl:grid-cols-napari-2-col',
+
+        // 3-column grid
+        '3xl:grid-cols-napari-3-col',
+      ),
+      ...props,
+    },
+    children,
   );
 }

--- a/client/src/components/common/ColumnLayout/__snapshots__/ColumnLayout.test.tsx.snap
+++ b/client/src/components/common/ColumnLayout/__snapshots__/ColumnLayout.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<ColumnLayout /> should match snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="flex 2xl:grid 2xl:justify-center p-6 md:p-14 2xl:px-0 2xl:gap-14 2xl:grid-cols-napari-2-col 3xl:grid-cols-napari-3-col"
+    class="grid grid-cols-1 justify-center gap-6 md:gap-12 2xl:grid-cols-napari-2-col 3xl:grid-cols-napari-3-col"
   >
     <div />
     <div />

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -40,17 +40,13 @@ module.exports = {
         'napari-nav-mobile': 'min-content 1fr',
 
         'napari-2-col': [
-          theme('width.napari-center-col'),
           theme('width.napari-side-col'),
+          theme('width.napari-center-col'),
         ].join(' '),
 
-        /*
-          App bar 2 column layout is reversed because the logo needs to be
-          smaller than the search container.
-        */
-        'napari-app-bar-2-col': [
-          theme('width.napari-side-col'),
+        'napari-2-col-reverse': [
           theme('width.napari-center-col'),
+          theme('width.napari-side-col'),
         ].join(' '),
 
         'napari-3-col': [
@@ -58,8 +54,6 @@ module.exports = {
           theme('width.napari-center-col'),
           theme('width.napari-side-col'),
         ].join(' '),
-
-        'napari-3-col-fr': 'repeat(3, 1fr)',
       }),
 
       maxWidth: (theme) => theme('width'),


### PR DESCRIPTION
## Description

This PR has a few changes for the column layout, app bar, and plugin page. It includes refactors to the column layout for 2-columns, a few updates from Lia's design changes, and simplifies the styling for some components.

## Changes

- Updates tailwind config:
  - Removed `napari-3-col-fr` because [it already exists as `grid-cols-3`](https://tailwindcss.com/docs/grid-template-columns)
  - Changed the order of `napari-2-col` to be `225px 775px`
  - Renamed `napari-app-bar-2-col` to `napari-2-col-reverse` and changed order to `775px 225px`
- Updated ColumnLayout
  - Added `component` for changing the root component. This is so the AppBar can use `nav` as the root component
  - Added `reverseTwoColumn` to render the 2-column layout with `napari-2-col-reverse`
- Add / Update usages of ColumnLayout in AppBar and PluginDetails
- Lia's design updates
  - Move app bar links to the header 
  - Add CTA button to bottom of page

## Demos

### App Bar Links

![image](https://user-images.githubusercontent.com/2176050/118163132-7d360e80-b3d6-11eb-8673-19d6fce67b0a.png)


### 2nd CTA Button at Bottom of Plugin Page

![image](https://user-images.githubusercontent.com/2176050/118163240-9f2f9100-b3d6-11eb-8a96-5c2344391502.png)

![image](https://user-images.githubusercontent.com/2176050/118163314-b0789d80-b3d6-11eb-840e-96a2890ed9a1.png)