### PR TITLE
Refactor to use 5-column layout

### DIFF
--- a/client/src/components/AppBar/AppBar.tsx
+++ b/client/src/components/AppBar/AppBar.tsx
@@ -90,8 +90,10 @@ export function AppBar() {
           // Padding
           'px-6 md:px-12 2xl:p-0',
 
-          // Grid layout for smaller screens
-          'grid-cols-[min-content,1fr]',
+          // Grid layout for smaller screens. This allows the search bar to
+          // extend to its max width to the left. The `zero:` modifier is used
+          // to increase specificity over ColumnLayout.
+          'zero:grid-cols-[min-content,1fr]',
         )}
         component="nav"
       >
@@ -102,11 +104,14 @@ export function AppBar() {
             // Flex layout
             'flex items-center',
 
-            // Take 100% of width, but limit to center column width.
-            'w-full max-w-napari-center-col',
+            // Take 100% of width.
+            'w-full',
 
             // Align container to the right of the grid cell
             'justify-self-end',
+
+            // Use more columns on larger screens
+            'xl:col-span-2 2xl:col-span-3',
           )}
         >
           <SearchBar />

--- a/client/src/components/AppBar/__snapshots__/AppBar.test.tsx.snap
+++ b/client/src/components/AppBar/__snapshots__/AppBar.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`<AppBar /> should match snapshot 1`] = `
     </button>
   </div>
   <nav
-    class="bg-napari-primary h-napari-app-bar justify-center items-center px-6 md:px-12 2xl:p-0 zero:grid-cols-[min-content,1fr] grid grid-cols-napari-2 justify-center gap-6 md:gap-12 xl:grid-cols-napari-3 2xl:grid-cols-napari-4 3xl:grid-cols-napari-5"
+    class="bg-napari-primary h-napari-app-bar justify-center items-center px-6 md:px-12 2xl:p-0 zero:grid-cols-[min-content,1fr] grid grid-cols-2 justify-center gap-6 md:gap-12 xl:grid-cols-napari-3 2xl:grid-cols-napari-4 3xl:grid-cols-napari-5"
   >
     <header
       class="flex"

--- a/client/src/components/AppBar/__snapshots__/AppBar.test.tsx.snap
+++ b/client/src/components/AppBar/__snapshots__/AppBar.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`<AppBar /> should match snapshot 1`] = `
     </button>
   </div>
   <nav
-    class="bg-napari-primary h-napari-app-bar justify-center items-center px-6 md:px-12 2xl:p-0 grid-cols-[min-content,1fr] grid grid-cols-1 justify-center gap-6 md:gap-12 2xl:grid-cols-napari-2-col 3xl:grid-cols-napari-3-col"
+    class="bg-napari-primary h-napari-app-bar justify-center items-center px-6 md:px-12 2xl:p-0 zero:grid-cols-[min-content,1fr] grid grid-cols-napari-2 justify-center gap-6 md:gap-12 xl:grid-cols-napari-3 2xl:grid-cols-napari-4 3xl:grid-cols-napari-5"
   >
     <header
       class="flex"
@@ -89,7 +89,7 @@ exports[`<AppBar /> should match snapshot 1`] = `
       </a>
     </header>
     <div
-      class="flex items-center w-full max-w-napari-center-col justify-self-end"
+      class="flex items-center w-full justify-self-end xl:col-span-2 2xl:col-span-3"
     >
       <form
         class="flex flex-auto items-center border-b-2 border-black"

--- a/client/src/components/Layout/__snapshots__/Layout.test.tsx.snap
+++ b/client/src/components/Layout/__snapshots__/Layout.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`<Layout /> should match snapshot 1`] = `
     </button>
   </div>
   <nav
-    class="bg-napari-primary h-napari-app-bar justify-center items-center px-6 md:px-12 2xl:p-0 grid-cols-[min-content,1fr] grid grid-cols-1 justify-center gap-6 md:gap-12 2xl:grid-cols-napari-2-col 3xl:grid-cols-napari-3-col"
+    class="bg-napari-primary h-napari-app-bar justify-center items-center px-6 md:px-12 2xl:p-0 zero:grid-cols-[min-content,1fr] grid grid-cols-napari-2 justify-center gap-6 md:gap-12 xl:grid-cols-napari-3 2xl:grid-cols-napari-4 3xl:grid-cols-napari-5"
   >
     <header
       class="flex"
@@ -89,7 +89,7 @@ exports[`<Layout /> should match snapshot 1`] = `
       </a>
     </header>
     <div
-      class="flex items-center w-full max-w-napari-center-col justify-self-end"
+      class="flex items-center w-full justify-self-end xl:col-span-2 2xl:col-span-3"
     >
       <form
         class="flex flex-auto items-center border-b-2 border-black"

--- a/client/src/components/Layout/__snapshots__/Layout.test.tsx.snap
+++ b/client/src/components/Layout/__snapshots__/Layout.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`<Layout /> should match snapshot 1`] = `
     </button>
   </div>
   <nav
-    class="bg-napari-primary h-napari-app-bar justify-center items-center px-6 md:px-12 2xl:p-0 zero:grid-cols-[min-content,1fr] grid grid-cols-napari-2 justify-center gap-6 md:gap-12 xl:grid-cols-napari-3 2xl:grid-cols-napari-4 3xl:grid-cols-napari-5"
+    class="bg-napari-primary h-napari-app-bar justify-center items-center px-6 md:px-12 2xl:p-0 zero:grid-cols-[min-content,1fr] grid grid-cols-2 justify-center gap-6 md:gap-12 xl:grid-cols-napari-3 2xl:grid-cols-napari-4 3xl:grid-cols-napari-5"
   >
     <header
       class="flex"

--- a/client/src/components/PluginDetails/CallToActionButton.tsx
+++ b/client/src/components/PluginDetails/CallToActionButton.tsx
@@ -26,7 +26,7 @@ export function CallToActionButton({ className }: Props) {
           'bg-napari-primary',
 
           // Dimensions
-          'h-12 w-full lg:max-w-napari-side-col',
+          'h-12 w-full lg:max-w-napari-col',
         )}
         onClick={() => setVisible(true)}
         type="button"

--- a/client/src/components/PluginDetails/InstallModal.tsx
+++ b/client/src/components/PluginDetails/InstallModal.tsx
@@ -158,7 +158,7 @@ export function InstallModal({ onClose, visible }: InstallModalProps) {
             'p-6 md:p-12',
 
             // Dimensions
-            'w-5/6 max-w-napari-center-col max-h-[706px]',
+            'w-5/6 max-w-[775px] max-h-[706px]',
 
             // Positioning: This centers the modal in the middle of the viewport
             'top-1/2 left-1/2',

--- a/client/src/components/PluginDetails/PluginDetails.tsx
+++ b/client/src/components/PluginDetails/PluginDetails.tsx
@@ -65,9 +65,9 @@ function PluginCenterColumn() {
         </a>
       </Media>
 
-      <SupportInfo className="mb-6 md:mb-12 col-span-2" />
+      <SupportInfo className="mb-6 md:mb-12" />
 
-      <Markdown className="mb-10 col-span-3" disableHeader>
+      <Markdown className="mb-10" disableHeader>
         {plugin.description}
       </Markdown>
 

--- a/client/src/components/PluginDetails/PluginDetails.tsx
+++ b/client/src/components/PluginDetails/PluginDetails.tsx
@@ -20,7 +20,7 @@ function PluginCenterColumn() {
   const { plugin } = usePluginState();
 
   return (
-    <article className="w-full">
+    <article className="w-full col-span-2 xl:col-span-3">
       <h1 className="font-bold text-4xl">{plugin.name}</h1>
       <h2 className="font-semibold my-6 text-lg">{plugin.summary}</h2>
 
@@ -65,9 +65,9 @@ function PluginCenterColumn() {
         </a>
       </Media>
 
-      <SupportInfo className="mb-6 md:mb-12" />
+      <SupportInfo className="mb-6 md:mb-12 col-span-2" />
 
-      <Markdown className="mb-10" disableHeader>
+      <Markdown className="mb-10 col-span-3" disableHeader>
         {plugin.description}
       </Markdown>
 
@@ -101,12 +101,7 @@ function PluginRightColumn() {
  */
 export function PluginDetails() {
   return (
-    <ColumnLayout
-      className="p-6 md:p-12 2xl:px-0"
-      data-testid="pluginDetails"
-      // Use reverse 2-column layout to render 225px TOC on the right side.
-      reverseTwoColumn
-    >
+    <ColumnLayout className="p-6 md:p-12 2xl:px-0" data-testid="pluginDetails">
       <PluginLeftColumn />
       <PluginCenterColumn />
       <PluginRightColumn />

--- a/client/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
+++ b/client/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<PluginDetails /> should match snapshot 1`] = `
 <div
-  class="p-6 md:p-12 2xl:px-0 grid grid-cols-1 justify-center gap-6 md:gap-12 2xl:grid-cols-napari-2-col-reverse 3xl:grid-cols-napari-3-col"
+  class="p-6 md:p-12 2xl:px-0 grid grid-cols-napari-2 justify-center gap-6 md:gap-12 xl:grid-cols-napari-3 2xl:grid-cols-napari-4 3xl:grid-cols-napari-5"
   data-testid="pluginDetails"
 >
   <div
@@ -242,7 +242,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
     </div>
   </div>
   <article
-    class="w-full"
+    class="w-full col-span-2 xl:col-span-3"
   >
     <h1
       class="font-bold text-4xl"
@@ -261,7 +261,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
         class="absolute min-w-napari-xs"
       />
       <button
-        class="fresnel-lessThan-2xl bg-napari-primary h-12 w-full lg:max-w-napari-side-col"
+        class="fresnel-lessThan-2xl bg-napari-primary h-12 w-full lg:max-w-napari-col"
         type="button"
       >
         Install
@@ -274,7 +274,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       </a>
     </div>
     <ul
-      class="text-black bg-gray-100 p-5 fresnel-greaterThanOrEqual-xl mb-6 md:mb-12 list-none grid grid-cols-3"
+      class="text-black bg-gray-100 p-5 fresnel-greaterThanOrEqual-xl mb-6 md:mb-12 col-span-2 list-none grid grid-cols-3"
     >
       <li
         class="mb-4 text-sm"
@@ -558,7 +558,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       </li>
     </ul>
     <ul
-      class="text-black bg-gray-100 p-5 fresnel-lessThan-xl mb-6 md:mb-12 list-none"
+      class="text-black bg-gray-100 p-5 fresnel-lessThan-xl mb-6 md:mb-12 col-span-2 list-none"
     >
       <li
         class="mb-4 text-sm"
@@ -842,7 +842,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       </li>
     </ul>
     <div
-      class="mb-10 markdown prose max-w-none"
+      class="mb-10 col-span-3 markdown prose max-w-none"
     >
       
 
@@ -1224,7 +1224,7 @@ the coverage at least stays the same before you submit a pull request.
       class="absolute min-w-napari-xs"
     />
     <button
-      class="mb-6 md:mb-12 2xl:mb-20 bg-napari-primary h-12 w-full lg:max-w-napari-side-col"
+      class="mb-6 md:mb-12 2xl:mb-20 bg-napari-primary h-12 w-full lg:max-w-napari-col"
       type="button"
     >
       Install
@@ -1469,7 +1469,7 @@ the coverage at least stays the same before you submit a pull request.
       class="absolute min-w-napari-xs"
     />
     <button
-      class="fixed bg-napari-primary h-12 w-full lg:max-w-napari-side-col"
+      class="fixed bg-napari-primary h-12 w-full lg:max-w-napari-col"
       type="button"
     >
       Install

--- a/client/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
+++ b/client/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<PluginDetails /> should match snapshot 1`] = `
 <div
-  class="p-6 md:p-12 2xl:px-0 grid grid-cols-napari-2 justify-center gap-6 md:gap-12 xl:grid-cols-napari-3 2xl:grid-cols-napari-4 3xl:grid-cols-napari-5"
+  class="p-6 md:p-12 2xl:px-0 grid grid-cols-2 justify-center gap-6 md:gap-12 xl:grid-cols-napari-3 2xl:grid-cols-napari-4 3xl:grid-cols-napari-5"
   data-testid="pluginDetails"
 >
   <div

--- a/client/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
+++ b/client/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
@@ -274,7 +274,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       </a>
     </div>
     <ul
-      class="text-black bg-gray-100 p-5 fresnel-greaterThanOrEqual-xl mb-6 md:mb-12 col-span-2 list-none grid grid-cols-3"
+      class="text-black bg-gray-100 p-5 fresnel-greaterThanOrEqual-xl mb-6 md:mb-12 list-none grid grid-cols-3"
     >
       <li
         class="mb-4 text-sm"
@@ -558,7 +558,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       </li>
     </ul>
     <ul
-      class="text-black bg-gray-100 p-5 fresnel-lessThan-xl mb-6 md:mb-12 col-span-2 list-none"
+      class="text-black bg-gray-100 p-5 fresnel-lessThan-xl mb-6 md:mb-12 list-none"
     >
       <li
         class="mb-4 text-sm"
@@ -842,7 +842,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       </li>
     </ul>
     <div
-      class="mb-10 col-span-3 markdown prose max-w-none"
+      class="mb-10 markdown prose max-w-none"
     >
       
 

--- a/client/src/components/PluginSearch/__snapshots__/PluginSearch.test.tsx.snap
+++ b/client/src/components/PluginSearch/__snapshots__/PluginSearch.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<PluginSearch /> should match snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="grid grid-cols-1 justify-center gap-6 md:gap-12 2xl:grid-cols-napari-2-col 3xl:grid-cols-napari-3-col"
+    class="grid grid-cols-napari-2 justify-center gap-6 md:gap-12 xl:grid-cols-napari-3 2xl:grid-cols-napari-4 3xl:grid-cols-napari-5"
   >
     <div
       class="fresnel-container fresnel-greaterThanOrEqual-3xl "

--- a/client/src/components/PluginSearch/__snapshots__/PluginSearch.test.tsx.snap
+++ b/client/src/components/PluginSearch/__snapshots__/PluginSearch.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<PluginSearch /> should match snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="grid grid-cols-napari-2 justify-center gap-6 md:gap-12 xl:grid-cols-napari-3 2xl:grid-cols-napari-4 3xl:grid-cols-napari-5"
+    class="grid grid-cols-2 justify-center gap-6 md:gap-12 xl:grid-cols-napari-3 2xl:grid-cols-napari-4 3xl:grid-cols-napari-5"
   >
     <div
       class="fresnel-container fresnel-greaterThanOrEqual-3xl "

--- a/client/src/components/common/ColumnLayout/ColumnLayout.tsx
+++ b/client/src/components/common/ColumnLayout/ColumnLayout.tsx
@@ -31,7 +31,7 @@ export function ColumnLayout({
         className,
 
         // Layout
-        'grid grid-cols-napari-2 justify-center',
+        'grid grid-cols-2 justify-center',
 
         // Grid gap
         'gap-6 md:gap-12',

--- a/client/src/components/common/ColumnLayout/ColumnLayout.tsx
+++ b/client/src/components/common/ColumnLayout/ColumnLayout.tsx
@@ -12,20 +12,15 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
    * Root component to use for column layout. The default is `div`.
    */
   component?: React.ElementType;
-
-  /**
-   * Most layouts use the `225px 775px` for the 2-column layout, but some
-   * require the layout to be `775px 225px`. For example, the plugin details
-   * page needs this for the plugin summary and TOC.
-   */
-  reverseTwoColumn?: boolean;
 }
 
+/**
+ * Component for rendering napari's column layout.
+ */
 export function ColumnLayout({
   children,
   className,
   component = 'div',
-  reverseTwoColumn,
   ...props
 }: Props) {
   // Use `createElement()` to dynamically create element from `component` prop.
@@ -36,18 +31,15 @@ export function ColumnLayout({
         className,
 
         // Layout
-        'grid grid-cols-1 justify-center',
+        'grid grid-cols-napari-2 justify-center',
 
         // Grid gap
         'gap-6 md:gap-12',
 
-        // 2-column grid
-        reverseTwoColumn
-          ? '2xl:grid-cols-napari-2-col-reverse'
-          : '2xl:grid-cols-napari-2-col',
-
-        // 3-column grid
-        '3xl:grid-cols-napari-3-col',
+        // Use more columns for larger screens
+        'xl:grid-cols-napari-3',
+        '2xl:grid-cols-napari-4',
+        '3xl:grid-cols-napari-5',
       ),
       ...props,
     },

--- a/client/src/components/common/ColumnLayout/__snapshots__/ColumnLayout.test.tsx.snap
+++ b/client/src/components/common/ColumnLayout/__snapshots__/ColumnLayout.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<ColumnLayout /> should match snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="grid grid-cols-1 justify-center gap-6 md:gap-12 2xl:grid-cols-napari-2-col 3xl:grid-cols-napari-3-col"
+    class="grid grid-cols-napari-2 justify-center gap-6 md:gap-12 xl:grid-cols-napari-3 2xl:grid-cols-napari-4 3xl:grid-cols-napari-5"
   >
     <div />
     <div />

--- a/client/src/components/common/ColumnLayout/__snapshots__/ColumnLayout.test.tsx.snap
+++ b/client/src/components/common/ColumnLayout/__snapshots__/ColumnLayout.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<ColumnLayout /> should match snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="grid grid-cols-napari-2 justify-center gap-6 md:gap-12 xl:grid-cols-napari-3 2xl:grid-cols-napari-4 3xl:grid-cols-napari-5"
+    class="grid grid-cols-2 justify-center gap-6 md:gap-12 xl:grid-cols-napari-3 2xl:grid-cols-napari-4 3xl:grid-cols-napari-5"
   >
     <div />
     <div />

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -13,7 +13,7 @@ const screens = reduce(
   {},
 );
 
-function remToPixels(value) {
+function pixelsToRem(value) {
   return `${value / 16}rem`;
 }
 
@@ -27,8 +27,8 @@ module.exports = {
     extend: {
       spacing: {
         // Use 25px and 50px for margins, paddings, gaps, etc.
-        6: remToPixels(25),
-        12: remToPixels(50),
+        6: pixelsToRem(25),
+        12: pixelsToRem(50),
       },
 
       colors: {
@@ -56,11 +56,7 @@ module.exports = {
             return result;
           },
 
-          {
-            // Use fractional width for 2-column layout
-            // https://css-tricks.com/introduction-fr-css-unit/
-            'napari-2': 'repeat(2, 1fr)',
-          },
+          {},
         );
       },
 

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -13,6 +13,10 @@ const screens = reduce(
   {},
 );
 
+function remToPixels(value) {
+  return `${value / 16}rem`;
+}
+
 module.exports = {
   mode: 'jit',
   darkMode: 'media',
@@ -21,6 +25,12 @@ module.exports = {
   theme: {
     screens,
     extend: {
+      spacing: {
+        // Use 25px and 50px for margins, paddings, gaps, etc.
+        6: remToPixels(25),
+        12: remToPixels(50),
+      },
+
       colors: {
         'napari-primary': '#80d1ff',
         'napari-primary-light': 'rgba(128, 215, 255, 0.25)',
@@ -28,33 +38,31 @@ module.exports = {
 
       width: (theme) => ({
         'napari-xs': theme('screens.xs'),
-        'napari-center-col': '775px',
-        'napari-side-col': '225px',
+        'napari-col': '225px',
       }),
 
       height: {
         'napari-app-bar': '75px',
       },
 
-      gridTemplateColumns: (theme) => ({
-        'napari-nav-mobile': 'min-content 1fr',
+      gridTemplateColumns: (theme) => {
+        const width = theme('width.napari-col');
+        const columns = [3, 4, 5];
 
-        'napari-2-col': [
-          theme('width.napari-side-col'),
-          theme('width.napari-center-col'),
-        ].join(' '),
+        return columns.reduce(
+          // Add `repeat(225px, $column)` for each column
+          (result, count) => {
+            result[`napari-${count}`] = `repeat(${count}, ${width})`;
+            return result;
+          },
 
-        'napari-2-col-reverse': [
-          theme('width.napari-center-col'),
-          theme('width.napari-side-col'),
-        ].join(' '),
-
-        'napari-3-col': [
-          theme('width.napari-side-col'),
-          theme('width.napari-center-col'),
-          theme('width.napari-side-col'),
-        ].join(' '),
-      }),
+          {
+            // Use fractional width for 2-column layout
+            // https://css-tricks.com/introduction-fr-css-unit/
+            'napari-2': 'repeat(2, 1fr)',
+          },
+        );
+      },
 
       maxWidth: (theme) => theme('width'),
       minWidth: (theme) => theme('width'),


### PR DESCRIPTION
## Description

This PR updates the Tailwind config and `ColumnLayout` component to use five 225px column layouts instead of the current `225px 775px 225px` column layout.

## Changes

- Updated Tailwind config
  - Refactored grid column layout to 2-5 columns
  - Renamed `napari-side-col` to `napari-col`
  - Removed `napari-center-col`
  - Added [spacing config](https://tailwindcss.com/docs/customizing-spacing) to use `25px` and `50px` spacing from Lia's designs
- Updated `ColumnLayout` to use 2-5 column layout classes
- Fixed styles for `AppBar` and `PluginDetails` 

## Demos

Rendering is a bit slow because I'm also rendering the columns and gaps in Chrome Dev Tools.

https://user-images.githubusercontent.com/2176050/118181263-639fc180-b3ec-11eb-84f3-80b13aff1a67.mp4
