### PR TITLE
Add new hub breakpoints

### DIFF
--- a/client/breakpoints.js
+++ b/client/breakpoints.js
@@ -6,6 +6,19 @@
 module.exports = {
   // Special screen size for fresnel when using `lessThan` queries.
   zero: 0,
+  'screen-300': 300,
+  'screen-375': 375,
+  'screen-495': 495,
+  'screen-550': 550,
+  'screen-560': 560,
+  'screen-600': 600,
+  'screen-655': 655,
+  'screen-725': 725,
+  'screen-875': 875,
+  'screen-1150': 1150,
+  'screen-1425': 1425,
+
+  // TODO Remove when breakpoint existing usages are renamed.
   xs: 300,
   sm: 375,
   md: 495,


### PR DESCRIPTION
## Description

This PR adds the new breakpoints to the config. This also adds the new and existing breakpoints under new names using the name format `screen-{width in pixels}`.

This format is an improvement over the original format because:

1. **It's more scalable**. With the old format, adding a new breakpoint in between breakpoints meant the other breakpoints would have to be renamed in both the config and the code. Now it's just the screen and width number.
2. **It's more readable**. When looking at class names, it's easier to understand what screen size the breakpoint is for. Compare `screen-875:flex` to `xl:flex`. You would need to look at `breakpoints.js` to know what `xl` is if you didn't memorize it.

I've left the old breakpoint names so we can refactor existing usages in future PRs.