### PR TITLE
Sort Plugins Form

### DIFF
--- a/client/src/components/AppBar/__snapshots__/AppBar.test.tsx.snap
+++ b/client/src/components/AppBar/__snapshots__/AppBar.test.tsx.snap
@@ -126,6 +126,7 @@ exports[`<AppBar /> should match snapshot 1`] = `
         />
         <button
           aria-label="Submit search query"
+          data-testid="submitQueryButton"
           type="button"
         >
           <svg

--- a/client/src/components/Layout/__snapshots__/Layout.test.tsx.snap
+++ b/client/src/components/Layout/__snapshots__/Layout.test.tsx.snap
@@ -126,6 +126,7 @@ exports[`<Layout /> should match snapshot 1`] = `
         />
         <button
           aria-label="Submit search query"
+          data-testid="submitQueryButton"
           type="button"
         >
           <svg

--- a/client/src/components/PluginSearch/PluginSearchControls.tsx
+++ b/client/src/components/PluginSearch/PluginSearchControls.tsx
@@ -1,25 +1,23 @@
-import { useSearchState } from '@/context/search';
+import clsx from 'clsx';
+import { AnimateSharedLayout } from 'framer-motion';
+
+import { PluginSortByForm } from './PluginSortByForm';
 
 /**
  * Renders a JSON string of the search state. This should be replaced with the
  * actual sort and filter components.
  */
 export function PluginSearchControls() {
-  const state = useSearchState();
-
-  const stateReport = {
-    filter: state?.filter.state,
-    search: state?.search.query,
-    sort: state?.sort.sortType,
-  };
-
   return (
-    <div className="flex flex-col row-span-4 gap-6">
-      <p>TODO search filters</p>
-
-      <pre className="overflow-x-auto text-xs">
-        {JSON.stringify(stateReport, null, 2)}
-      </pre>
+    <div
+      className={clsx(
+        'grid gap-6',
+        'col-span-2 screen-875:col-span-1 screen-875:row-span-3',
+      )}
+    >
+      <AnimateSharedLayout>
+        <PluginSortByForm />
+      </AnimateSharedLayout>
     </div>
   );
 }

--- a/client/src/components/PluginSearch/PluginSearchControls.tsx
+++ b/client/src/components/PluginSearch/PluginSearchControls.tsx
@@ -4,8 +4,7 @@ import { AnimateSharedLayout } from 'framer-motion';
 import { PluginSortByForm } from './PluginSortByForm';
 
 /**
- * Renders a JSON string of the search state. This should be replaced with the
- * actual sort and filter components.
+ * Renders the plugin search controls for filtering and sorting the list of plugins.
  */
 export function PluginSearchControls() {
   return (

--- a/client/src/components/PluginSearch/PluginSearchResultList.tsx
+++ b/client/src/components/PluginSearch/PluginSearchResultList.tsx
@@ -12,7 +12,7 @@ export function PluginSearchResultList() {
       <h3
         className={clsx(
           'col-span-2',
-          'font-bold text-xl mb-6',
+          'font-bold text-xl my-6',
           'screen-875:col-start-2',
         )}
       >

--- a/client/src/components/PluginSearch/PluginSortByForm.tsx
+++ b/client/src/components/PluginSearch/PluginSortByForm.tsx
@@ -74,6 +74,8 @@ function SortForm() {
               : {})}
           >
             <FormControlLabel
+              data-testid="sortByRadio"
+              data-selected={sortType === sort?.sortType}
               value={sortType}
               control={
                 <Radio

--- a/client/src/components/PluginSearch/PluginSortByForm.tsx
+++ b/client/src/components/PluginSearch/PluginSortByForm.tsx
@@ -25,12 +25,16 @@ const SORT_BY_LABELS: Record<SearchSortType, string> = {
   [SearchSortType.PluginName]: 'Plugin name',
 };
 
+/**
+ * Component for the radio form for selecting the plugin sort type.
+ */
 function SortForm() {
   const { search, sort } = useSearchState() ?? {};
   const isSearching = !!search?.query;
 
   const radios: SearchSortType[] = [];
 
+  // Add relevance sort type if user is searching fro a plugin.
   if (isSearching) {
     radios.push(SearchSortType.Relevance);
   }
@@ -86,6 +90,11 @@ function SortForm() {
   );
 }
 
+/**
+ * Renders the plugin sort form. For smaller screen sizes (< 875px), an
+ * expandable accordion layout is used. For larger screens, the sort form is
+ * rendered as-is.
+ */
 export function PluginSortByForm() {
   const form = <SortForm />;
 

--- a/client/src/components/PluginSearch/PluginSortByForm.tsx
+++ b/client/src/components/PluginSearch/PluginSortByForm.tsx
@@ -1,0 +1,101 @@
+import {
+  FormControl,
+  FormControlLabel,
+  FormLabel,
+  Radio,
+  RadioGroup,
+} from '@material-ui/core';
+import clsx from 'clsx';
+import { motion } from 'framer-motion';
+
+import { Accordion } from '@/components/common';
+import { MediaFragment } from '@/components/common/media';
+import { SearchSortType, useSearchState } from '@/context/search';
+
+const DEFAULT_SORT_BY_RADIO_ORDER: SearchSortType[] = [
+  SearchSortType.PluginName,
+  SearchSortType.ReleaseDate,
+  SearchSortType.FirstReleased,
+];
+
+const SORT_BY_LABELS: Record<SearchSortType, string> = {
+  [SearchSortType.Relevance]: 'Relevance',
+  [SearchSortType.FirstReleased]: 'First released',
+  [SearchSortType.ReleaseDate]: 'Release date',
+  [SearchSortType.PluginName]: 'Plugin name',
+};
+
+function SortForm() {
+  const { search, sort } = useSearchState() ?? {};
+  const isSearching = !!search?.query;
+
+  const radios: SearchSortType[] = [];
+
+  if (isSearching) {
+    radios.push(SearchSortType.Relevance);
+  }
+
+  radios.push(...DEFAULT_SORT_BY_RADIO_ORDER);
+
+  return (
+    <FormControl component="fieldset">
+      {/* Only show label on larger screens. This is because the Accordion already includes a title. */}
+      <MediaFragment greaterThanOrEqual="screen-875">
+        <FormLabel
+          className="uppercase text-black font-semibold text-sm mb-2"
+          component="legend"
+          focused={false}
+        >
+          Sort By
+        </FormLabel>
+      </MediaFragment>
+
+      <RadioGroup
+        aria-label="sort plugins by"
+        name="sort-by"
+        value={sort?.sortType}
+        onChange={(event) => sort?.setSortType(event.target.value)}
+      >
+        {radios.map((sortType) => (
+          <motion.div
+            key={sortType}
+            layout
+            // Only animate opacity on relevance
+            {...(sortType === SearchSortType.Relevance
+              ? {
+                  initial: { opacity: 0 },
+                  animate: { opacity: 1 },
+                  exit: { opacity: 0 },
+                }
+              : {})}
+          >
+            <FormControlLabel
+              value={sortType}
+              control={
+                <Radio
+                  className={clsx('text-black fill-current')}
+                  color="default"
+                />
+              }
+              label={SORT_BY_LABELS[sortType]}
+            />
+          </motion.div>
+        ))}
+      </RadioGroup>
+    </FormControl>
+  );
+}
+
+export function PluginSortByForm() {
+  const form = <SortForm />;
+
+  return (
+    <>
+      <MediaFragment lessThan="screen-875">
+        <Accordion title="Sort By">{form}</Accordion>
+      </MediaFragment>
+
+      <MediaFragment greaterThanOrEqual="screen-875">{form}</MediaFragment>
+    </>
+  );
+}

--- a/client/src/components/PluginSearch/__snapshots__/PluginSearch.test.tsx.snap
+++ b/client/src/components/PluginSearch/__snapshots__/PluginSearch.test.tsx.snap
@@ -287,40 +287,445 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
       class="p-6 md:p-12 grid justify-center gap-x-6 md:gap-x-12 grid-cols-2 screen-875:grid-cols-napari-3 screen-1150:grid-cols-napari-3 screen-1425:grid-cols-napari-5"
     >
       <div
-        class="flex flex-col row-span-4 gap-6"
+        class="grid gap-6 col-span-2 screen-875:col-span-1 screen-875:row-span-3"
       >
-        <p>
-          TODO search filters
-        </p>
-        <pre
-          class="overflow-x-auto text-xs"
+        <div
+          class="MuiPaper-root MuiAccordion-root shadow-none fresnel-lessThan-screen-875 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
         >
-          {
-  "filter": {
-    "developmentStatus": {
-      "onlyStablePlugins": false
-    },
-    "license": {
-      "onlyOpenSourcePlugins": false
-    },
-    "operatingSystems": {
-      "All": false,
-      "Windows 10": false,
-      "Linux": false
-    },
-    "pythonVersions": {
-      "&gt;=3.6": false,
-      "&gt;=3.7": false,
-      "&lt;3.9": false
-    }
-  },
-  "search": "",
-  "sort": "relevance"
-}
-        </pre>
+          <div
+            aria-disabled="false"
+            aria-expanded="false"
+            class="MuiButtonBase-root MuiAccordionSummary-root flex-row-reverse p-0 font-semibold"
+            role="button"
+            tabindex="0"
+          >
+            <div
+              class="MuiAccordionSummary-content !ml-6"
+            >
+              Sort By
+            </div>
+            <div
+              aria-disabled="false"
+              aria-hidden="true"
+              class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon p-0 MuiIconButton-edgeEnd"
+            >
+              <span
+                class="MuiIconButton-label"
+              >
+                <svg
+                  fill="none"
+                  height="12"
+                  viewBox="0 0 16 12"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <g
+                    clip-path="url(#clip0)"
+                  >
+                    <path
+                      d="M1 2.07107L8.07107 9.14214L15.1421 2.07107"
+                      stroke="black"
+                      stroke-width="2"
+                    />
+                  </g>
+                  <defs>
+                    <clippath
+                      id="clip0"
+                    >
+                      <rect
+                        fill="white"
+                        height="12"
+                        width="16"
+                      />
+                    </clippath>
+                  </defs>
+                </svg>
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </div>
+          </div>
+          <div
+            class="MuiCollapse-container MuiCollapse-hidden"
+            style="min-height: 0px;"
+          >
+            <div
+              class="MuiCollapse-wrapper"
+            >
+              <div
+                class="MuiCollapse-wrapperInner"
+              >
+                <div
+                  role="region"
+                >
+                  <div
+                    class="MuiAccordionDetails-root p-0"
+                  >
+                    <fieldset
+                      class="MuiFormControl-root"
+                    >
+                      <div
+                        aria-label="sort plugins by"
+                        class="MuiFormGroup-root"
+                        role="radiogroup"
+                      >
+                        <div
+                          style="transform: translate3d(0px, 0px, 0) scale(NaN, NaN); transform-origin: 50% 50% 0;"
+                        >
+                          <label
+                            class="MuiFormControlLabel-root"
+                          >
+                            <span
+                              aria-disabled="false"
+                              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiRadio-root text-black fill-current"
+                            >
+                              <span
+                                class="MuiIconButton-label"
+                              >
+                                <input
+                                  class="PrivateSwitchBase-input-4"
+                                  name="sort-by"
+                                  type="radio"
+                                  value="pluginName"
+                                />
+                                <div
+                                  class="PrivateRadioButtonIcon-root-5"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root"
+                                    focusable="false"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <path
+                                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                                    />
+                                  </svg>
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-6"
+                                    focusable="false"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <path
+                                      d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                                    />
+                                  </svg>
+                                </div>
+                              </span>
+                              <span
+                                class="MuiTouchRipple-root"
+                              />
+                            </span>
+                            <span
+                              class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                            >
+                              Plugin name
+                            </span>
+                          </label>
+                        </div>
+                        <div
+                          style="transform: translate3d(0px, 0px, 0) scale(NaN, NaN); transform-origin: 50% 50% 0;"
+                        >
+                          <label
+                            class="MuiFormControlLabel-root"
+                          >
+                            <span
+                              aria-disabled="false"
+                              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiRadio-root text-black fill-current"
+                            >
+                              <span
+                                class="MuiIconButton-label"
+                              >
+                                <input
+                                  class="PrivateSwitchBase-input-4"
+                                  name="sort-by"
+                                  type="radio"
+                                  value="releaseDate"
+                                />
+                                <div
+                                  class="PrivateRadioButtonIcon-root-5"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root"
+                                    focusable="false"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <path
+                                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                                    />
+                                  </svg>
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-6"
+                                    focusable="false"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <path
+                                      d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                                    />
+                                  </svg>
+                                </div>
+                              </span>
+                              <span
+                                class="MuiTouchRipple-root"
+                              />
+                            </span>
+                            <span
+                              class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                            >
+                              Release date
+                            </span>
+                          </label>
+                        </div>
+                        <div
+                          style="transform: translate3d(0px, 0px, 0) scale(NaN, NaN); transform-origin: 50% 50% 0;"
+                        >
+                          <label
+                            class="MuiFormControlLabel-root"
+                          >
+                            <span
+                              aria-disabled="false"
+                              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiRadio-root text-black fill-current"
+                            >
+                              <span
+                                class="MuiIconButton-label"
+                              >
+                                <input
+                                  class="PrivateSwitchBase-input-4"
+                                  name="sort-by"
+                                  type="radio"
+                                  value="firstReleased"
+                                />
+                                <div
+                                  class="PrivateRadioButtonIcon-root-5"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root"
+                                    focusable="false"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <path
+                                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                                    />
+                                  </svg>
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-6"
+                                    focusable="false"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <path
+                                      d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                                    />
+                                  </svg>
+                                </div>
+                              </span>
+                              <span
+                                class="MuiTouchRipple-root"
+                              />
+                            </span>
+                            <span
+                              class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                            >
+                              First released
+                            </span>
+                          </label>
+                        </div>
+                      </div>
+                    </fieldset>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <fieldset
+          class="MuiFormControl-root"
+        >
+          <legend
+            class="MuiFormLabel-root fresnel-greaterThanOrEqual-screen-875 uppercase text-black font-semibold text-sm mb-2"
+          >
+            Sort By
+          </legend>
+          <div
+            aria-label="sort plugins by"
+            class="MuiFormGroup-root"
+            role="radiogroup"
+          >
+            <div
+              style="transform: translate3d(0px, 0px, 0) scale(NaN, NaN); transform-origin: 50% 50% 0;"
+            >
+              <label
+                class="MuiFormControlLabel-root"
+              >
+                <span
+                  aria-disabled="false"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiRadio-root text-black fill-current"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <input
+                      class="PrivateSwitchBase-input-4"
+                      name="sort-by"
+                      type="radio"
+                      value="pluginName"
+                    />
+                    <div
+                      class="PrivateRadioButtonIcon-root-5"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                        />
+                      </svg>
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-6"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                        />
+                      </svg>
+                    </div>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </span>
+                <span
+                  class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                >
+                  Plugin name
+                </span>
+              </label>
+            </div>
+            <div
+              style="transform: translate3d(0px, 0px, 0) scale(NaN, NaN); transform-origin: 50% 50% 0;"
+            >
+              <label
+                class="MuiFormControlLabel-root"
+              >
+                <span
+                  aria-disabled="false"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiRadio-root text-black fill-current"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <input
+                      class="PrivateSwitchBase-input-4"
+                      name="sort-by"
+                      type="radio"
+                      value="releaseDate"
+                    />
+                    <div
+                      class="PrivateRadioButtonIcon-root-5"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                        />
+                      </svg>
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-6"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                        />
+                      </svg>
+                    </div>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </span>
+                <span
+                  class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                >
+                  Release date
+                </span>
+              </label>
+            </div>
+            <div
+              style="transform: translate3d(0px, 0px, 0) scale(NaN, NaN); transform-origin: 50% 50% 0;"
+            >
+              <label
+                class="MuiFormControlLabel-root"
+              >
+                <span
+                  aria-disabled="false"
+                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiRadio-root text-black fill-current"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <input
+                      class="PrivateSwitchBase-input-4"
+                      name="sort-by"
+                      type="radio"
+                      value="firstReleased"
+                    />
+                    <div
+                      class="PrivateRadioButtonIcon-root-5"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                        />
+                      </svg>
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root PrivateRadioButtonIcon-layer-6"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                        />
+                      </svg>
+                    </div>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </span>
+                <span
+                  class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                >
+                  First released
+                </span>
+              </label>
+            </div>
+          </div>
+        </fieldset>
       </div>
       <h3
-        class="col-span-2 font-bold text-xl mb-6 screen-875:col-start-2"
+        class="col-span-2 font-bold text-xl my-6 screen-875:col-start-2"
       >
         Browse plugins
       </h3>

--- a/client/src/components/PluginSearch/__snapshots__/PluginSearch.test.tsx.snap
+++ b/client/src/components/PluginSearch/__snapshots__/PluginSearch.test.tsx.snap
@@ -260,6 +260,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
         />
         <button
           aria-label="Submit search query"
+          data-testid="submitQueryButton"
           type="button"
         >
           <svg
@@ -375,6 +376,8 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                         >
                           <label
                             class="MuiFormControlLabel-root"
+                            data-selected="false"
+                            data-testid="sortByRadio"
                           >
                             <span
                               aria-disabled="false"
@@ -430,6 +433,8 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                         >
                           <label
                             class="MuiFormControlLabel-root"
+                            data-selected="false"
+                            data-testid="sortByRadio"
                           >
                             <span
                               aria-disabled="false"
@@ -485,6 +490,8 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                         >
                           <label
                             class="MuiFormControlLabel-root"
+                            data-selected="false"
+                            data-testid="sortByRadio"
                           >
                             <span
                               aria-disabled="false"
@@ -561,6 +568,8 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
             >
               <label
                 class="MuiFormControlLabel-root"
+                data-selected="false"
+                data-testid="sortByRadio"
               >
                 <span
                   aria-disabled="false"
@@ -616,6 +625,8 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
             >
               <label
                 class="MuiFormControlLabel-root"
+                data-selected="false"
+                data-testid="sortByRadio"
               >
                 <span
                   aria-disabled="false"
@@ -671,6 +682,8 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
             >
               <label
                 class="MuiFormControlLabel-root"
+                data-selected="false"
+                data-testid="sortByRadio"
               >
                 <span
                   aria-disabled="false"

--- a/client/src/components/SearchBar/SearchBar.tsx
+++ b/client/src/components/SearchBar/SearchBar.tsx
@@ -130,6 +130,7 @@ export function SearchBar({ large, ...props }: Props) {
 
       <button
         aria-label={query ? 'Clear search bar text' : 'Submit search query'}
+        data-testid={query ? 'clearQueryButton' : 'submitQueryButton'}
         onClick={async () => {
           // Clear local query if close button is clicked and the search engine
           // is currently rendering the results for another query.

--- a/client/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
+++ b/client/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`<SearchBar /> should match snapshot 1`] = `
     />
     <button
       aria-label="Submit search query"
+      data-testid="submitQueryButton"
       type="button"
     >
       <svg

--- a/client/src/components/common/Accordion/Accordion.tsx
+++ b/client/src/components/common/Accordion/Accordion.tsx
@@ -1,0 +1,34 @@
+import {
+  Accordion as MUIAccordion,
+  AccordionDetails,
+  AccordionSummary,
+} from '@material-ui/core';
+import clsx from 'clsx';
+import { ReactNode } from 'react';
+
+import { Expand } from '@/components/common/icons';
+
+interface Props {
+  children: ReactNode;
+  className?: string;
+  title?: string;
+}
+
+/**
+ * Wrapper component over Material UI accordion with napari hub specific customizations.
+ */
+export function Accordion({ children, className, title }: Props) {
+  return (
+    <MUIAccordion className={clsx('shadow-none', className)}>
+      <AccordionSummary
+        className="flex-row-reverse p-0 font-semibold"
+        classes={{ content: '!ml-6', expandIcon: 'p-0' }}
+        expandIcon={<Expand />}
+      >
+        {title}
+      </AccordionSummary>
+
+      <AccordionDetails className="p-0">{children}</AccordionDetails>
+    </MUIAccordion>
+  );
+}

--- a/client/src/components/common/Accordion/index.tsx
+++ b/client/src/components/common/Accordion/index.tsx
@@ -1,0 +1,1 @@
+export * from './Accordion';

--- a/client/src/components/common/icons/Expand.tsx
+++ b/client/src/components/common/icons/Expand.tsx
@@ -1,0 +1,28 @@
+import { IconProps } from './icons.type';
+
+export function Expand({ alt, className }: IconProps) {
+  return (
+    <svg
+      width="16"
+      height="12"
+      viewBox="0 0 16 12"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      {alt && <title>{alt}</title>}
+      <g clipPath="url(#clip0)">
+        <path
+          d="M1 2.07107L8.07107 9.14214L15.1421 2.07107"
+          stroke="black"
+          strokeWidth="2"
+        />
+      </g>
+      <defs>
+        <clipPath id="clip0">
+          <rect width="16" height="12" fill="white" />
+        </clipPath>
+      </defs>
+    </svg>
+  );
+}

--- a/client/src/components/common/icons/index.ts
+++ b/client/src/components/common/icons/index.ts
@@ -1,6 +1,7 @@
 export * from './Close';
 export * from './Copy';
 export * from './CZI';
+export * from './Expand';
 export * from './GitHub';
 export * from './Hub';
 export * from './icons.type';

--- a/client/src/components/common/index.ts
+++ b/client/src/components/common/index.ts
@@ -1,3 +1,4 @@
+export * from './Accordion';
 export * from './ColumnLayout';
 export * from './Divider';
 export * from './ErrorMessage';

--- a/client/src/context/search/constants.ts
+++ b/client/src/context/search/constants.ts
@@ -13,7 +13,7 @@ export enum SearchSortType {
   PluginName = 'pluginName',
 }
 
-export const DEFAULT_SORT_TYPE = SearchSortType.ReleaseDate;
+export const DEFAULT_SORT_TYPE = SearchSortType.PluginName;
 
 /**
  * Query parameters used for storing search form data.

--- a/client/src/context/search/constants.ts
+++ b/client/src/context/search/constants.ts
@@ -13,7 +13,7 @@ export enum SearchSortType {
   PluginName = 'pluginName',
 }
 
-export const DEFAULT_SORT_TYPE = SearchSortType.PluginName;
+export const DEFAULT_SORT_TYPE = SearchSortType.ReleaseDate;
 
 /**
  * Query parameters used for storing search form data.

--- a/client/tests/pages/home.test.ts
+++ b/client/tests/pages/home.test.ts
@@ -26,6 +26,10 @@ async function submitQuery(query: string) {
   await page.press('[data-testid=searchBarInput]', 'Enter');
 }
 
+async function getSelectedSortByRadio() {
+  return page.$('[data-testid=sortByRadio][data-selected=true]');
+}
+
 describe('/ (Home page)', () => {
   it('should update URL parameter when entering query', async () => {
     const query = 'video';
@@ -78,7 +82,17 @@ describe('/ (Home page)', () => {
     await page.waitForNavigation();
 
     await page.goBack();
+    await page.waitForNavigation();
+
     expect(hasSearchParam(page, query)).toBe(true);
     await expect(await getFirstSearchResultName()).toHaveText('napari_video');
+  });
+
+  it('should switch to relevance sort type when searching', async () => {
+    await page.goto(getSearchURL());
+    await expect(await getSelectedSortByRadio()).toHaveText('Release date');
+
+    await submitQuery('video');
+    await expect(await getSelectedSortByRadio()).toHaveText('Relevance');
   });
 });


### PR DESCRIPTION
## Description

Depends on #54.

This PR sets up the form UI for selecting the plugin sort type. This uses Material UI's [Accordion](https://material-ui.com/components/accordion/) and [Radio](https://material-ui.com/components/radio-buttons/) components to create the form.

## Demos

Demo Link: https://napari-hub-sort-plugins-demo.vercel.app/

### Accordion on Smaller Screens

https://user-images.githubusercontent.com/2176050/119407556-3deea400-bc99-11eb-9425-74f74647d735.mp4

### Separate Column on Larger Screens

https://user-images.githubusercontent.com/2176050/119407553-3b8c4a00-bc99-11eb-8c88-cdad525a4c59.mp4

### Relevance Option when Searching

https://user-images.githubusercontent.com/2176050/119407540-37f8c300-bc99-11eb-9e90-a13b4504245b.mp4