### PR TITLE
Add health check

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -70,7 +70,7 @@ module.exports = {
       definitions are generated using `export default styles`.
     */
     {
-      files: ['./src/pages/**/*.tsx', './src/**/*.module.scss.d.ts'],
+      files: ['./src/pages/**/*.ts{,x}', './src/**/*.module.scss.d.ts'],
       rules: {
         'import/no-default-export': 'off',
         'import/prefer-default-export': 'error',

--- a/client/next.config.js
+++ b/client/next.config.js
@@ -5,7 +5,7 @@ const withMDX = mdx({
 });
 
 module.exports = withMDX({
-  pageExtensions: ['tsx', 'mdx'],
+  pageExtensions: ['ts', 'tsx', 'mdx'],
 
   // Enable webpack 5 support for faster builds :)
   // https://nextjs.org/docs/messages/webpack5

--- a/client/src/pages/api/health.ts
+++ b/client/src/pages/api/health.ts
@@ -1,0 +1,8 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default function healthCheck(
+  _: NextApiRequest,
+  res: NextApiResponse,
+): void {
+  res.status(200).json({ status: 'ok' });
+}


### PR DESCRIPTION
## Description

Sets up Next.js routing and and adds a health check API that returns a 200.

Demo: https://napari-hub-health-check-demo.vercel.app/api/health