### PR TITLE
Use static values for Python Version and Operating System filters

### DIFF
--- a/client/src/context/search/filter.hooks.ts
+++ b/client/src/context/search/filter.hooks.ts
@@ -35,10 +35,7 @@ function useInitialFormState(results: SearchResult[]) {
     }
   }, [initialFilterParam]);
 
-  return defaultsDeep(
-    initialFormState,
-    getDefaultState(results),
-  ) as FilterFormState;
+  return defaultsDeep(initialFormState, getDefaultState()) as FilterFormState;
 }
 
 /**
@@ -48,7 +45,7 @@ function useInitialFormState(results: SearchResult[]) {
  * @returns The filter form state
  */
 function useForm(results: SearchResult[]) {
-  const initialState = useInitialFormState(results) ?? getDefaultState(results);
+  const initialState = useInitialFormState(results) ?? getDefaultState();
 
   // We don't need the first parameter because we're storing the form state in a
   // separate `useState()` below.

--- a/client/src/context/search/filter.hooks.ts
+++ b/client/src/context/search/filter.hooks.ts
@@ -23,7 +23,7 @@ import { SearchResult } from './search.types';
  * @param results Search results
  * @returns The initial form state
  */
-function useInitialFormState(results: SearchResult[]) {
+function useInitialFormState() {
   const initialFilterParam =
     useActiveURLParameter(SearchQueryParams.Filter) ?? '';
 
@@ -44,8 +44,8 @@ function useInitialFormState(results: SearchResult[]) {
  * @param results Search results to populate initial state with
  * @returns The filter form state
  */
-function useForm(results: SearchResult[]) {
-  const initialState = useInitialFormState(results) ?? getDefaultState();
+function useForm() {
+  const initialState = useInitialFormState();
 
   // We don't need the first parameter because we're storing the form state in a
   // separate `useState()` below.
@@ -59,7 +59,7 @@ function useForm(results: SearchResult[]) {
    * Resets the filter form state to its default state.
    */
   function clearAll() {
-    setState(getDefaultState(results));
+    setState(getDefaultState());
   }
 
   // Update the filter query parameter with the filtered state
@@ -92,7 +92,7 @@ export type FilterForm = ReturnType<typeof useForm>;
  * @returns Filtered results and form data
  */
 export function useFilters(results: SearchResult[]) {
-  const filterForm = useForm(results);
+  const filterForm = useForm();
   const filteredResults = filterResults(results, filterForm.state);
 
   return {

--- a/client/src/context/search/filter.types.ts
+++ b/client/src/context/search/filter.types.ts
@@ -13,9 +13,22 @@ export interface LicenseFormState {
 }
 
 /**
- * State used for holding checked state of multiple checkboxes.
+ * Form state for filtering on operating systems.
  */
-export type CheckboxFormState = Record<string, boolean>;
+export interface OperatingSystemState {
+  linux: boolean;
+  mac: boolean;
+  windows: boolean;
+}
+
+/**
+ * Form state for filtering on python versions.
+ */
+export interface PythonVersionsState {
+  3.7: boolean;
+  3.8: boolean;
+  3.9: boolean;
+}
 
 /**
  * Root state object for the filter form. Each state object is a
@@ -25,6 +38,6 @@ export type CheckboxFormState = Record<string, boolean>;
 export interface FilterFormState {
   developmentStatus: DevelopmentStatusFormState;
   license: LicenseFormState;
-  operatingSystems: CheckboxFormState;
-  pythonVersions: CheckboxFormState;
+  operatingSystems: OperatingSystemState;
+  pythonVersions: PythonVersionsState;
 }

--- a/client/src/context/search/filter.types.ts
+++ b/client/src/context/search/filter.types.ts
@@ -15,19 +15,10 @@ export interface LicenseFormState {
 /**
  * Form state for filtering on operating systems.
  */
-export interface OperatingSystemState {
+export interface OperatingSystemFormState {
   linux: boolean;
   mac: boolean;
   windows: boolean;
-}
-
-/**
- * Form state for filtering on python versions.
- */
-export interface PythonVersionsState {
-  3.7: boolean;
-  3.8: boolean;
-  3.9: boolean;
 }
 
 /**
@@ -38,6 +29,6 @@ export interface PythonVersionsState {
 export interface FilterFormState {
   developmentStatus: DevelopmentStatusFormState;
   license: LicenseFormState;
-  operatingSystems: OperatingSystemState;
-  pythonVersions: PythonVersionsState;
+  operatingSystems: OperatingSystemFormState;
+  pythonVersions: Record<string, boolean>;
 }

--- a/client/src/context/search/filter.utils.ts
+++ b/client/src/context/search/filter.utils.ts
@@ -4,6 +4,8 @@ import { DeepPartial } from 'utility-types';
 
 import { FilterFormState } from './filter.types';
 
+const SUPPORTED_PYTHON_VERSIONS = ['3.7', '3.8', '3.9'];
+
 /**
  * Returns the default filter form state derived from the search results.
  *
@@ -26,11 +28,10 @@ export function getDefaultState(): FilterFormState {
       windows: false,
     },
 
-    pythonVersions: {
-      '3.7': false,
-      '3.8': false,
-      '3.9': false,
-    },
+    pythonVersions: SUPPORTED_PYTHON_VERSIONS.reduce(
+      (state, version) => set(state, [version], false),
+      {} as FilterFormState['pythonVersions'],
+    ),
   };
 }
 

--- a/client/src/context/search/filter.utils.ts
+++ b/client/src/context/search/filter.utils.ts
@@ -2,44 +2,7 @@ import { isEmpty, pickBy, reduce, set } from 'lodash';
 import { Dispatch, SetStateAction } from 'react';
 import { DeepPartial } from 'utility-types';
 
-import { formatOperatingSystem } from '@/utils';
-
-import { CheckboxFormState, FilterFormState } from './filter.types';
-import { SearchResult } from './search.types';
-
-/**
- * Returns the initial checkbox state for Python versions using the search
- * results. This extends initial state with the versions available from
- * the search results.
- *
- * @param results
- * @returns The version checkbox state
- */
-function getInitialPythonVersionState(results: SearchResult[]) {
-  return results.reduce<CheckboxFormState>((state, { plugin }) => {
-    // eslint-disable-next-line no-param-reassign
-    state[plugin.python_version] = false;
-    return state;
-  }, {});
-}
-
-/**
- * Returns the initial checkbox state for operating systems using the search
- * results. This extends the initial state with the operating systems available
- * from the search results.
- *
- * @param results Search results
- * @returns The OS checkbox state
- */
-function getInitialOperatingSystemState(results: SearchResult[]) {
-  return results.reduce<CheckboxFormState>((state, { plugin }) => {
-    plugin.operating_system.forEach((os) => {
-      // eslint-disable-next-line no-param-reassign
-      state[formatOperatingSystem(os)] = false;
-    });
-    return state;
-  }, {});
-}
+import { FilterFormState } from './filter.types';
 
 /**
  * Returns the default filter form state derived from the search results.
@@ -47,16 +10,27 @@ function getInitialOperatingSystemState(results: SearchResult[]) {
  * @param results Search results
  * @returns The default state
  */
-export function getDefaultState(results: SearchResult[]): FilterFormState {
+export function getDefaultState(): FilterFormState {
   return {
     developmentStatus: {
       onlyStablePlugins: false,
     },
+
     license: {
       onlyOpenSourcePlugins: false,
     },
-    operatingSystems: getInitialOperatingSystemState(results),
-    pythonVersions: getInitialPythonVersionState(results),
+
+    operatingSystems: {
+      linux: false,
+      mac: false,
+      windows: false,
+    },
+
+    pythonVersions: {
+      '3.7': false,
+      '3.8': false,
+      '3.9': false,
+    },
   };
 }
 


### PR DESCRIPTION
## Description

This PR replaces the dynamically populated form state values with static values as discussed on the CZI slack. This is because napari supports a specific matrix of python versions and operating systems, so it's better to use our own values instead.
