### PR TITLE
Filter chips

### DIFF
--- a/client/src/components/PluginSearch/FilterChips.tsx
+++ b/client/src/components/PluginSearch/FilterChips.tsx
@@ -1,0 +1,85 @@
+import { Button, Chip } from '@material-ui/core';
+import { Close } from '@material-ui/icons';
+import { isEmpty } from 'lodash';
+
+import { useSearchState } from '@/context/search';
+import { FilterFormState } from '@/context/search/filter.types';
+
+/**
+ * Labels to render for a particular state key.
+ */
+const KEY_LABELS: Record<keyof FilterFormState, string> = {
+  developmentStatus: 'Development status',
+  license: 'License',
+  operatingSystems: 'Operating system',
+  pythonVersions: 'Python version',
+};
+
+/**
+ * Labels to render for a particular sub-state key.
+ *
+ * TODO Find a better way to add typing for this to prevent discrepancies
+ * between the state data and the labels.
+ */
+const SUBKEY_LABEL: Record<string, string | undefined> = {
+  // Dev Status labels
+  onlyStablePlugins: 'Stable',
+
+  // License labels
+  onlyOpenSourcePlugins: 'Open Source',
+
+  // OS labels
+  linux: 'Linux',
+  mac: 'Mac',
+  windows: 'Windows',
+};
+
+interface Props {
+  className?: string;
+}
+
+/**
+ * Component that renders a list of chips for each enabled filter. Each chip
+ * includes a button to disable the filter. It's also possible to clear all the
+ * filters by clicking the clear all filters button.
+ */
+export function FilterChips({ className }: Props) {
+  const { filter } = useSearchState() ?? {};
+
+  if (isEmpty(filter?.chips)) {
+    return null;
+  }
+
+  return (
+    <div className={className}>
+      {/* Clear filters button */}
+      <Button
+        classes={{ label: 'underline' }}
+        className="inline-block mr-2"
+        onClick={() => filter?.clearAll()}
+      >
+        Clear all filters
+      </Button>
+
+      {/* Chip list */}
+      <ul className="inline flex-wrap gap-2">
+        {filter?.chips.map(({ id, key, subKey }) => (
+          <li className="inline-block my-1 ml-1" key={id}>
+            <Chip
+              label={
+                <>
+                  <span>{KEY_LABELS[key]}</span>
+                  <span className="font-bold ml-1">
+                    {SUBKEY_LABEL[subKey] ?? subKey}
+                  </span>
+                </>
+              }
+              deleteIcon={<Close className="text-black fill-current w-4 h-4" />}
+              onDelete={() => filter?.removeChip(key, subKey)}
+            />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/client/src/components/PluginSearch/PluginSearchResultList.tsx
+++ b/client/src/components/PluginSearch/PluginSearchResultList.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx';
 
 import { useSearchState } from '@/context/search';
 
+import { FilterChips } from './FilterChips';
 import { PluginSearchResult } from './PluginSearchResult';
 
 export function PluginSearchResultList() {
@@ -18,6 +19,8 @@ export function PluginSearchResultList() {
       >
         Browse plugins
       </h3>
+
+      <FilterChips className="col-span-2 screen-1425:col-span-3 mb-6" />
 
       {results.map(({ plugin }) => (
         <PluginSearchResult

--- a/client/src/context/search/filter.hooks.ts
+++ b/client/src/context/search/filter.hooks.ts
@@ -1,4 +1,4 @@
-import { defaultsDeep, pickBy } from 'lodash';
+import { defaultsDeep } from 'lodash';
 import { useEffect, useMemo, useState } from 'react';
 import { JsonParam, useQueryParam, withDefault } from 'use-query-params';
 import { DeepPartial } from 'utility-types';
@@ -80,10 +80,10 @@ function useForm() {
     setState((prevState) => ({
       ...prevState,
 
-      [key]: pickBy(
-        prevState[key as keyof FilterFormState],
-        (_, prevSubKey) => prevSubKey !== subKey,
-      ),
+      [key]: {
+        ...prevState[key as keyof FilterFormState],
+        [subKey]: false,
+      },
     }));
   }
 

--- a/client/src/context/search/filter.hooks.ts
+++ b/client/src/context/search/filter.hooks.ts
@@ -1,4 +1,4 @@
-import { defaultsDeep } from 'lodash';
+import { defaultsDeep, pickBy } from 'lodash';
 import { useEffect, useMemo, useState } from 'react';
 import { JsonParam, useQueryParam, withDefault } from 'use-query-params';
 import { DeepPartial } from 'utility-types';
@@ -10,6 +10,7 @@ import { FilterFormState } from './filter.types';
 import {
   filterFalsyValues,
   getCheckboxSetter,
+  getChipState,
   getDefaultState,
 } from './filter.utils';
 import { filterResults } from './filters';
@@ -54,6 +55,7 @@ function useForm() {
   >(SearchQueryParams.Filter, withDefault(JsonParam, initialState));
 
   const [state, setState] = useState<FilterFormState>(initialState);
+  const chips = getChipState(state);
 
   /**
    * Resets the filter form state to its default state.
@@ -68,13 +70,35 @@ function useForm() {
     state,
   ]);
 
+  /**
+   * Removes a chip from the chips state.
+   *
+   * @param key The key of root filter state
+   * @param subKey The sub key of the filter state
+   */
+  function removeChip(key: string, subKey: string) {
+    setState((prevState) => ({
+      ...prevState,
+
+      [key]: pickBy(
+        prevState[key as keyof FilterFormState],
+        (_, prevSubKey) => prevSubKey !== subKey,
+      ),
+    }));
+  }
+
   return {
+    // State
+    chips,
+    state,
+
+    // State update functions
     clearAll,
+    removeChip,
     setDevelopmentStatus: getCheckboxSetter(setState, 'developmentStatus'),
     setLicense: getCheckboxSetter(setState, 'license'),
     setOperatingSystem: getCheckboxSetter(setState, 'operatingSystems'),
     setPythonVersion: getCheckboxSetter(setState, 'pythonVersions'),
-    state,
   };
 }
 

--- a/client/src/context/search/filter.types.ts
+++ b/client/src/context/search/filter.types.ts
@@ -32,3 +32,13 @@ export interface FilterFormState {
   operatingSystems: OperatingSystemFormState;
   pythonVersions: Record<string, boolean>;
 }
+
+/**
+ * Form state for rendering filters in a chip / pill above the plugin search results.
+ */
+export interface FilterChipFormState {
+  id: string;
+  key: keyof FilterFormState;
+  subKey: string;
+  value: boolean;
+}

--- a/client/src/context/search/filter.utils.ts
+++ b/client/src/context/search/filter.utils.ts
@@ -1,8 +1,8 @@
-import { isEmpty, pickBy, reduce, set } from 'lodash';
+import { forEach, isEmpty, pickBy, reduce, set } from 'lodash';
 import { Dispatch, SetStateAction } from 'react';
 import { DeepPartial } from 'utility-types';
 
-import { FilterFormState } from './filter.types';
+import { FilterChipFormState, FilterFormState } from './filter.types';
 
 const SUPPORTED_PYTHON_VERSIONS = ['3.7', '3.8', '3.9'];
 
@@ -33,6 +33,29 @@ export function getDefaultState(): FilterFormState {
       {} as FilterFormState['pythonVersions'],
     ),
   };
+}
+
+export function getChipID(key: string, subKey: string): string {
+  return `${key}-${subKey}`;
+}
+
+export function getChipState(state: FilterFormState): FilterChipFormState[] {
+  const chips: FilterChipFormState[] = [];
+
+  forEach(state, (subState, key) => {
+    forEach(subState, (value: boolean, subKey) => {
+      if (value) {
+        chips.push({
+          subKey,
+          value,
+          key: key as keyof FilterFormState,
+          id: getChipID(key, subKey),
+        });
+      }
+    });
+  });
+
+  return chips;
 }
 
 /**


### PR DESCRIPTION
## Description

This PR implements the UI and state for rendering filter chips. The chip state is derived from the form state, so any updates to the form state will automatically update the chip state.

## Demos

Demo Link: https://napari-hub-filter-chips-demo.vercel.app/?filter=%7B%22developmentStatus%22%3A%7B%22onlyStablePlugins%22%3Atrue%7D%2C%22license%22%3A%7B%22onlyOpenSourcePlugins%22%3Atrue%7D%2C%22operatingSystems%22%3A%7B%22linux%22%3Atrue%7D%2C%22pythonVersions%22%3A%7B%223.9%22%3Atrue%7D%7D

### Adding filter chips

Filter chips can be added by updating the form state. When the checkbox UI is ready, checking the filter will add it to the filter chips.

https://user-images.githubusercontent.com/2176050/119678723-9be3ce80-bdf4-11eb-8d04-8501fb4ed7eb.mp4

### Removing Filter Chips

Filter chips can be removed by clicking clicking on the close button or when clearing all filters. When the checkbox UI is ready, un-checking the filter will also remove it from the filter chips.

https://user-images.githubusercontent.com/2176050/119678783-aa31ea80-bdf4-11eb-879b-dd2629e88f30.mp4

## Follow ups

- The order of the filter chips is dependent on the object state. So when adding filter chips, the order will always be: development status, license, operating systems, and then python versions. It makes more sense to me to show the chips in order of when they were enabled, but this will require some UI state to track the history.
