### PR TITLE
Filter implementations

### DIFF
--- a/client/jest/setupTests.ts
+++ b/client/jest/setupTests.ts
@@ -27,3 +27,9 @@ jest.mock('next/router', () => ({
     query: {},
   }),
 }));
+
+jest.mock('@/context/spdx', () => ({
+  useSpdx: jest.fn().mockReturnValue({
+    isOSIApproved: jest.fn().mockReturnValue(false),
+  }),
+}));

--- a/client/modules.d.ts
+++ b/client/modules.d.ts
@@ -9,3 +9,14 @@ declare module 'remark-remove-comments' {
   const plugin: Pluggable<any[], Settings>;
   export default plugin;
 }
+
+declare module '@renovate/pep440' {
+  /**
+   * Determines if a version string satisfies the version specifier. The
+   * comparison is based on PEP440: https://www.python.org/dev/peps/pep-0440
+   *
+   * @param version The version string.
+   * @param specifier  The version specifier.
+   */
+  export function satisfies(version: string, specifier: string): boolean;
+}

--- a/client/package.json
+++ b/client/package.json
@@ -32,6 +32,7 @@
     "@mdx-js/loader": "^1.6.22",
     "@mdx-js/react": "^1.6.22",
     "@next/mdx": "^10.1.3",
+    "@renovate/pep440": "^1.0.0",
     "@testing-library/react-hooks": "^5.1.2",
     "@types/lodash-es": "^4.17.4",
     "@types/unist": "^2.0.3",

--- a/client/src/axios.ts
+++ b/client/src/axios.ts
@@ -24,5 +24,7 @@ export const hubAPI = axios.create({
   },
 });
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-axios.defaults.headers.common.Host = API_URL_HOST;
+export const spdxLicenseDataAPI = axios.create({
+  baseURL:
+    'https://raw.githubusercontent.com/spdx/license-list-data/master/json/licenses.json',
+});

--- a/client/src/axios.ts
+++ b/client/src/axios.ts
@@ -17,7 +17,12 @@ const API_URL = process.env.API_URL || 'http://localhost:8081';
  */
 const API_URL_HOST = process.env.API_URL_HOST || new URL(API_URL).host;
 
-axios.defaults.baseURL = API_URL;
+export const hubAPI = axios.create({
+  baseURL: API_URL,
+  headers: {
+    Host: API_URL_HOST,
+  },
+});
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 axios.defaults.headers.common.Host = API_URL_HOST;

--- a/client/src/components/PluginSearch/PluginSearch.test.tsx
+++ b/client/src/components/PluginSearch/PluginSearch.test.tsx
@@ -12,10 +12,6 @@ import pluginIndex from '@/fixtures/index.json';
 
 import { PluginSearch } from './PluginSearch';
 
-jest.mock('next/router', () => ({
-  useRouter: jest.fn(),
-}));
-
 function mockSearch(query = '') {
   type Replace = NextRouter['replace'];
   const replace = jest

--- a/client/src/context/search/filter.hooks.ts
+++ b/client/src/context/search/filter.hooks.ts
@@ -12,7 +12,7 @@ import {
   getCheckboxSetter,
   getDefaultState,
 } from './filter.utils';
-import { filterResults } from './filters';
+import { useFilterResults } from './filters';
 import { SearchResult } from './search.types';
 
 /**
@@ -93,7 +93,7 @@ export type FilterForm = ReturnType<typeof useForm>;
  */
 export function useFilters(results: SearchResult[]) {
   const filterForm = useForm();
-  const filteredResults = filterResults(results, filterForm.state);
+  const filteredResults = useFilterResults(results, filterForm.state);
 
   return {
     filteredResults,

--- a/client/src/context/search/filters.test.ts
+++ b/client/src/context/search/filters.test.ts
@@ -1,9 +1,12 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useSpdx } from '@/context/spdx';
 import pluginIndex from '@/fixtures/index.json';
 import { PluginIndexData } from '@/types';
 
 import { FilterFormState } from './filter.types';
 import { getDefaultState } from './filter.utils';
-import { filterResults } from './filters';
+import { useFilterResults } from './filters';
 import { SearchResult } from './search.types';
 
 function getResults(...plugins: PluginIndexData[]): SearchResult[] {
@@ -47,12 +50,14 @@ describe('filterResults()', () => {
 
   beforeEach(() => {
     state = getDefaultState();
+    (useSpdx as jest.Mock).mockClear();
   });
 
   describe('filter by python versions', () => {
     it('should allow all plugins when no filters are enabled', () => {
       const results = getVersionResults('>=3.10', '>=3.9');
-      expect(filterResults(results, state)).toEqual(results);
+      const { result } = renderHook(() => useFilterResults(results, state));
+      expect(result.current).toEqual(results);
     });
 
     it("should filter plugins that don't match an exact version", () => {
@@ -81,9 +86,10 @@ describe('filterResults()', () => {
 
       state.pythonVersions['3.9'] = true;
 
-      testCases.forEach(({ input, output }) =>
-        expect(filterResults(input, state)).toEqual(output),
-      );
+      testCases.forEach(({ input, output }) => {
+        const { result } = renderHook(() => useFilterResults(input, state));
+        expect(result.current).toEqual(output);
+      });
     });
   });
 
@@ -93,7 +99,8 @@ describe('filterResults()', () => {
         ['Operating System :: OS Independent'],
         ['Operating System :: POSIX :: Linux'],
       );
-      expect(filterResults(results, state)).toEqual(results);
+      const { result } = renderHook(() => useFilterResults(results, state));
+      expect(result.current).toEqual(results);
     });
 
     it('should allow OS Independent plugins', () => {
@@ -102,7 +109,9 @@ describe('filterResults()', () => {
         ['Operating System :: POSIX :: Linux'],
       );
       state.operatingSystems.mac = true;
-      expect(filterResults(results, state)).toEqual(
+
+      const { result } = renderHook(() => useFilterResults(results, state));
+      expect(result.current).toEqual(
         getOperatingSystemResults(['Operating System :: OS Independent']),
       );
     });
@@ -143,7 +152,9 @@ describe('filterResults()', () => {
       testCases.forEach(({ input, output }) => {
         state = getDefaultState();
         Object.assign(state.operatingSystems, input);
-        expect(filterResults(results, state)).toEqual(output);
+
+        const { result } = renderHook(() => useFilterResults(results, state));
+        expect(result.current).toEqual(output);
       });
     });
   });
@@ -158,7 +169,8 @@ describe('filterResults()', () => {
     );
 
     it('should allow all plugins when no filters are enabled', () => {
-      expect(filterResults(results, state)).toEqual(results);
+      const { result } = renderHook(() => useFilterResults(results, state));
+      expect(result.current).toEqual(results);
     });
 
     it('should filter stable plugins', () => {
@@ -167,7 +179,9 @@ describe('filterResults()', () => {
         ['Development Status :: 5 - Production/Stable'],
         ['Development Status :: 6 - Mature'],
       );
-      expect(filterResults(results, state)).toEqual(expected);
+
+      const { result } = renderHook(() => useFilterResults(results, state));
+      expect(result.current).toEqual(expected);
     });
   });
 });

--- a/client/src/context/search/filters.test.ts
+++ b/client/src/context/search/filters.test.ts
@@ -197,8 +197,6 @@ describe('filterResults()', () => {
   describe('filter by license', () => {
     const results = getLicenseResults('valid', 'invalid');
 
-    beforeEach(() => {});
-
     it('should allow all plugins when no filters are enabled', () => {
       const { result } = renderHook(() => useFilterResults(results, state));
       expect(result.current).toEqual(results);

--- a/client/src/context/search/filters.test.ts
+++ b/client/src/context/search/filters.test.ts
@@ -1,0 +1,69 @@
+import pluginIndex from '@/fixtures/index.json';
+import { PluginIndexData } from '@/types';
+
+import { FilterFormState } from './filter.types';
+import { getDefaultState } from './filter.utils';
+import { filterResults } from './filters';
+import { SearchResult } from './search.types';
+
+function getResults(...plugins: PluginIndexData[]): SearchResult[] {
+  return plugins.map((plugin) => ({
+    index: 0,
+    plugin,
+  }));
+}
+
+function getVersionResults(...versions: string[]): SearchResult[] {
+  const plugins = versions.map((python_version) => ({
+    ...pluginIndex[0],
+    python_version,
+  }));
+
+  return getResults(...plugins);
+}
+
+describe('filterResults()', () => {
+  let state: FilterFormState;
+
+  beforeEach(() => {
+    state = getDefaultState();
+  });
+
+  describe('filter by python versions', () => {
+    it('should allow all plugins when no filters are enabled', () => {
+      const results = getVersionResults('>=3.10', '>=3.9');
+      expect(filterResults(results, state)).toEqual(results);
+    });
+
+    it("should filter plugins that don't match an exact version", () => {
+      const testCases = [
+        {
+          input: getVersionResults('>=3.10', '==3.9'),
+          output: getVersionResults('==3.9'),
+        },
+        {
+          input: getVersionResults('>=3.10', '>=3.9'),
+          output: getVersionResults('>=3.9'),
+        },
+        {
+          input: getVersionResults('>=3.10', '>3.8'),
+          output: getVersionResults('>3.8'),
+        },
+        {
+          input: getVersionResults('>=3.10', '<3.10'),
+          output: getVersionResults('<3.10'),
+        },
+        {
+          input: getVersionResults('>=3.10', '<3.10,!=3.9'),
+          output: [],
+        },
+      ];
+
+      state.pythonVersions['3.9'] = true;
+
+      testCases.forEach(({ input, output }) =>
+        expect(filterResults(input, state)).toEqual(output),
+      );
+    });
+  });
+});

--- a/client/src/context/search/filters.test.ts
+++ b/client/src/context/search/filters.test.ts
@@ -33,6 +33,15 @@ function getOperatingSystemResults(
   return getResults(...plugins);
 }
 
+function getDevStatusResults(...devStatuses: string[][]): SearchResult[] {
+  const plugins = devStatuses.map((development_status) => ({
+    ...pluginIndex[0],
+    development_status,
+  }));
+
+  return getResults(...plugins);
+}
+
 describe('filterResults()', () => {
   let state: FilterFormState;
 
@@ -136,6 +145,29 @@ describe('filterResults()', () => {
         Object.assign(state.operatingSystems, input);
         expect(filterResults(results, state)).toEqual(output);
       });
+    });
+  });
+
+  describe('filter by development status', () => {
+    const results = getDevStatusResults(
+      ['Development Status :: 1 - Planning'],
+      ['Development Status :: 2 - Pre-Alpha'],
+      ['Development Status :: 5 - Production/Stable'],
+      ['Development Status :: 6 - Mature'],
+      ['Development Status :: 7 - Inactive'],
+    );
+
+    it('should allow all plugins when no filters are enabled', () => {
+      expect(filterResults(results, state)).toEqual(results);
+    });
+
+    it('should filter stable plugins', () => {
+      state.developmentStatus.onlyStablePlugins = true;
+      const expected = getDevStatusResults(
+        ['Development Status :: 5 - Production/Stable'],
+        ['Development Status :: 6 - Mature'],
+      );
+      expect(filterResults(results, state)).toEqual(expected);
     });
   });
 });

--- a/client/src/context/search/filters.ts
+++ b/client/src/context/search/filters.ts
@@ -5,6 +5,8 @@
 import { satisfies } from '@renovate/pep440';
 import { flow, intersection, isEmpty, some } from 'lodash';
 
+import { useSpdx } from '@/context/spdx';
+
 import { FilterFormState, OperatingSystemFormState } from './filter.types';
 import { SearchResult } from './search.types';
 import { SearchResultTransformFunction } from './types';
@@ -89,10 +91,16 @@ function useFilterByDevelopmentStatus(
 }
 
 function useFilterByLicense(
-  _: FilterFormState,
+  state: FilterFormState,
   results: SearchResult[],
 ): SearchResult[] {
-  return results;
+  const { isOSIApproved } = useSpdx();
+
+  if (!state.license.onlyOpenSourcePlugins) {
+    return results;
+  }
+
+  return results.filter(({ plugin }) => isOSIApproved(plugin.license));
 }
 
 /**

--- a/client/src/context/search/filters.ts
+++ b/client/src/context/search/filters.ts
@@ -3,7 +3,7 @@
  */
 
 import { satisfies } from '@renovate/pep440';
-import { flow, isEmpty, some } from 'lodash';
+import { flow, intersection, isEmpty, some } from 'lodash';
 
 import { FilterFormState, OperatingSystemFormState } from './filter.types';
 import { SearchResult } from './search.types';
@@ -68,11 +68,24 @@ function filterByOperatingSystem(
   });
 }
 
+const STABLE_DEV_STATUS = [
+  'Development Status :: 5 - Production/Stable',
+  'Development Status :: 6 - Mature',
+];
+
 function filterByDevelopmentStatus(
-  _: FilterFormState,
+  state: FilterFormState,
   results: SearchResult[],
 ): SearchResult[] {
-  return results;
+  if (!state.developmentStatus.onlyStablePlugins) {
+    return results;
+  }
+
+  // Filter plugins that include at least one of the stable dev statuses.
+  return results.filter(
+    ({ plugin }) =>
+      !isEmpty(intersection(STABLE_DEV_STATUS, plugin.development_status)),
+  );
 }
 
 function filterByLicense(

--- a/client/src/context/search/filters.ts
+++ b/client/src/context/search/filters.ts
@@ -9,7 +9,7 @@ import { FilterFormState, OperatingSystemFormState } from './filter.types';
 import { SearchResult } from './search.types';
 import { SearchResultTransformFunction } from './types';
 
-function filterByPythonVersion(
+function useFilterByPythonVersion(
   state: FilterFormState,
   results: SearchResult[],
 ): SearchResult[] {
@@ -38,7 +38,7 @@ const FILTER_OS_PATTERN: Record<keyof OperatingSystemFormState, RegExp> = {
   windows: /Windows/,
 };
 
-function filterByOperatingSystem(
+function useFilterByOperatingSystem(
   state: FilterFormState,
   results: SearchResult[],
 ): SearchResult[] {
@@ -73,7 +73,7 @@ const STABLE_DEV_STATUS = [
   'Development Status :: 6 - Mature',
 ];
 
-function filterByDevelopmentStatus(
+function useFilterByDevelopmentStatus(
   state: FilterFormState,
   results: SearchResult[],
 ): SearchResult[] {
@@ -88,7 +88,7 @@ function filterByDevelopmentStatus(
   );
 }
 
-function filterByLicense(
+function useFilterByLicense(
   _: FilterFormState,
   results: SearchResult[],
 ): SearchResult[] {
@@ -99,10 +99,10 @@ function filterByLicense(
  * List of functions to include for filtering search results.
  */
 const FILTERS = [
-  filterByPythonVersion,
-  filterByOperatingSystem,
-  filterByDevelopmentStatus,
-  filterByLicense,
+  useFilterByPythonVersion,
+  useFilterByOperatingSystem,
+  useFilterByDevelopmentStatus,
+  useFilterByLicense,
 ];
 
 /**
@@ -113,16 +113,16 @@ const FILTERS = [
  * @param state The filter form state
  * @returns The filtered search results
  */
-export function filterResults(
+export function useFilterResults(
   results: SearchResult[],
   state: FilterFormState,
 ): SearchResult[] {
   // `flow()` will execute a list of functions and provide successive results to
   // each function:
   // https://lodash.com/docs/4.17.15#flow
-  const filter: SearchResultTransformFunction = flow(
+  const useFilter: SearchResultTransformFunction = flow(
     FILTERS.map((fn) => fn.bind(null, state)),
   );
 
-  return filter(results);
+  return useFilter(results);
 }

--- a/client/src/context/spdx/index.ts
+++ b/client/src/context/spdx/index.ts
@@ -1,0 +1,2 @@
+export * from './spdx.context';
+export * from './spdx.types';

--- a/client/src/context/spdx/spdx.context.tsx
+++ b/client/src/context/spdx/spdx.context.tsx
@@ -1,0 +1,59 @@
+import { createContext, ReactNode, useContext, useRef } from 'react';
+
+import { SpdxLicenseData } from './spdx.types';
+
+interface SpdxContext {
+  /**
+   * Checks if the license is OSI approved based on the SPDX license data.
+   *
+   * @param license The license ID string
+   */
+  isOSIApproved(license: string): boolean;
+}
+
+interface Props {
+  children: ReactNode;
+  licenses: SpdxLicenseData[];
+}
+
+const SpdxLicenseContext = createContext<SpdxContext | null>(null);
+
+/**
+ * Hook for accessing the search state context.
+ */
+export function useSpdx(): SpdxContext {
+  const spdx = useContext(SpdxLicenseContext);
+
+  if (!spdx) {
+    throw new Error('useSpdx() must be used in a SpdxLicenseProvider');
+  }
+
+  return spdx;
+}
+
+/**
+ * Provider for storing SPDX license data and providing an API for getting
+ * license information.
+ */
+export function SpdxLicenseProvider({ children, licenses }: Props) {
+  // Use ref so that we only create the set once.
+  const osiApprovedLicenseSetRef = useRef<Set<string> | undefined>();
+
+  if (!osiApprovedLicenseSetRef.current) {
+    osiApprovedLicenseSetRef.current = new Set(
+      licenses
+        .filter((license) => license.isOsiApproved)
+        .map((license) => license.licenseId),
+    );
+  }
+
+  function isOSIApproved(license: string): boolean {
+    return osiApprovedLicenseSetRef?.current?.has(license) ?? false;
+  }
+
+  return (
+    <SpdxLicenseContext.Provider value={{ isOSIApproved }}>
+      {children}
+    </SpdxLicenseContext.Provider>
+  );
+}

--- a/client/src/context/spdx/spdx.types.ts
+++ b/client/src/context/spdx/spdx.types.ts
@@ -1,0 +1,17 @@
+export interface SpdxLicenseResponse {
+  licenseListVersion: string;
+  licenses: SpdxLicenseData[];
+  releaseDate: string;
+}
+
+export interface SpdxLicenseData {
+  reference: string;
+  isDeprecatedLicenseId: boolean;
+  detailsUrl: string;
+  referenceNumber: number;
+  name: string;
+  licenseId: string;
+  seeAlso: string[];
+  isOsiApproved: boolean;
+  isFsfLibre?: boolean;
+}

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,6 +1,7 @@
-import axios, { AxiosError } from 'axios';
+import { AxiosError } from 'axios';
 import { ReactNode } from 'react';
 
+import { hubAPI } from '@/axios';
 import { ErrorMessage } from '@/components/common';
 import { PluginSearch } from '@/components/PluginSearch';
 import { PluginSearchProvider } from '@/context/search';
@@ -17,7 +18,7 @@ export async function getServerSideProps() {
   const props: Props = {};
 
   try {
-    const { data } = await axios.get<PluginIndexData[]>(url);
+    const { data } = await hubAPI.get<PluginIndexData[]>(url);
     props.index = data;
   } catch (err) {
     const error = err as AxiosError;

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -19,9 +19,6 @@ interface Props {
   error?: string;
 }
 
-const LICENSE_JSON_URL =
-  'https://raw.githubusercontent.com/spdx/license-list-data/master/json/licenses.json';
-
 export async function getServerSideProps() {
   const url = '/plugins/index';
   const props: Props = {};
@@ -30,7 +27,7 @@ export async function getServerSideProps() {
     const { data: index } = await hubAPI.get<PluginIndexData[]>(url);
     const {
       data: { licenses },
-    } = await spdxLicenseDataAPI.get<SpdxLicenseResponse>(LICENSE_JSON_URL);
+    } = await spdxLicenseDataAPI.get<SpdxLicenseResponse>('');
 
     Object.assign(props, { index, licenses });
   } catch (err) {

--- a/client/src/pages/plugins/[name].tsx
+++ b/client/src/pages/plugins/[name].tsx
@@ -1,7 +1,8 @@
-import axios, { AxiosError } from 'axios';
+import { AxiosError } from 'axios';
 import { GetServerSidePropsContext } from 'next';
 import { ParsedUrlQuery } from 'node:querystring';
 
+import { hubAPI } from '@/axios';
 import { PluginDetails } from '@/components';
 import { ErrorMessage } from '@/components/common';
 import { PluginStateProvider } from '@/context/plugin';
@@ -56,7 +57,7 @@ export async function getServerSideProps({
   const props: Partial<Props> = {};
 
   try {
-    const { data } = await axios.get<PluginData | RequestError>(url);
+    const { data } = await hubAPI.get<PluginData | RequestError>(url);
 
     if (isRequestError(data)) {
       props.error = JSON.stringify(data, null, 2);

--- a/client/src/pages/plugins/index.tsx
+++ b/client/src/pages/plugins/index.tsx
@@ -1,5 +1,6 @@
-import axios, { AxiosError } from 'axios';
+import { AxiosError } from 'axios';
 
+import { hubAPI } from '@/axios';
 import { ErrorMessage, Link } from '@/components/common';
 
 interface Props {
@@ -16,7 +17,7 @@ export async function getServerSideProps() {
   const props: Partial<Props> = {};
 
   try {
-    const { data } = await axios.get<Record<string, string>>(url);
+    const { data } = await hubAPI.get<Record<string, string>>(url);
     props.plugins = data;
   } catch (err) {
     const error = err as AxiosError;

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -326,6 +326,14 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime-corejs3@^7.12.1":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.14.0.tgz#6bf5fbc0b961f8e3202888cb2cd0fb7a0a9a3f66"
+  integrity sha512-0R0HTZWHLk6G8jIk0FtoX+AatCtKnswS98VhXwGImFc759PJRp4Tru0PQYZofyijTFUr+gT8Mu7sgXVJLQ0ceg==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@7.12.5":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
@@ -853,6 +861,13 @@
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/context-base/-/context-base-0.14.0.tgz#c67fc20a4d891447ca1a855d7d70fa79a3533001"
   integrity sha512-sDOAZcYwynHFTbLo6n8kIbLiVF3a3BLkrmehJUyEbT9F+Smbi47kLGS2gG2g0fjBLR/Lr1InPD7kXL7FaTqEkw==
+
+"@renovate/pep440@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@renovate/pep440/-/pep440-1.0.0.tgz#9e05cac649b6a3d027cba7f2939b085de78f39ea"
+  integrity sha512-k3pZVxGEGpU7rpH507/9vxfFjuxX7qx4MSj9Fk+6zBsf/uZmAy8x97dNtZacbge7gP9TazbW1d7SEb5vsOmKlw==
+  dependencies:
+    xregexp "4.4.1"
 
 "@sideway/address@^4.1.0":
   version "4.1.1"
@@ -11168,6 +11183,13 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+
+xregexp@4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-4.4.1.tgz#c84a88fa79e9ab18ca543959712094492185fe65"
+  integrity sha512-2u9HwfadaJaY9zHtRRnH6BY6CQVNQKkYm3oLtC9gJXXzfsbACg5X5e4EZZGVAH+YIfa+QA9lsFQTTe3HURF3ag==
+  dependencies:
+    "@babel/runtime-corejs3" "^7.12.1"
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
## Description

This PR implements the filtering logic for python versions, operating systems, development status, and licenses. 

### Filter Implementations Details

#### Python Version

The python version filter uses PEP440 to determine if a plugin version specifier satisfies a selected version filter. For example, if the user selects Python 3.9, plugins with `>=3.6` will be visible, while plugins with `<3.9` will be filtered. 

The module used is the [https://www.npmjs.com/package/@renovate/pep440](@renovate/pep440) module. There isn't documentation on the module unfortunately (probably because it's a supplementary module to another project), so I had to read through the source code to find which function to use. From my findings, the [`satisfies()`](https://github.com/renovatebot/pep440/blob/ab5327a63aefeff2ded4ab3384f83d1de589a877/lib/specifier.js#L123-L126) function accomplished what we need.

### OSI Approved

SPDX maintains a [repo](https://github.com/spdx/license-list-data) with [software licenses in JSON](https://github.com/spdx/license-list-data/blob/master/json/licenses.json), so we need to fetch the data and pass it to the filter somehow.

There's a limitation with the current filter implementation where it's not easy to pass in new input data to the filter. To get around this, I converted the filter functions to hooks. This makes them more flexible, able to hold state, and access data stored in contexts. Then I created the SPDX license context to provide an API on the licensing data.
