### PR TITLE
Plugin Search styling fixes

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
     "dev": "nodemon -x 'run-p dev:*' -w tailwind.config.js",
     "dev:api": "node mock-server",
     "dev:next": "next dev -p 8080",
-    "dev:tsm": "tsm -w -e default 'src/**/*.module.scss'",
+    "dev:tsm": "tsm -w -e default -p.@ src 'src/**/*.module.scss'",
     "lint": "run-p lint:*",
     "lint:prettier": "prettier --check .",
     "lint:stylelint": "stylelint **/*.scss",

--- a/client/package.json
+++ b/client/package.json
@@ -104,6 +104,7 @@
     "playwright": "^1.10.0",
     "plop": "^2.7.4",
     "postcss": "^8.2.10",
+    "postcss-strip-units": "^2.0.1",
     "prettier": "^2.2.1",
     "sass": "^1.32.8",
     "stylelint": "^13.12.0",

--- a/client/postcss.config.js
+++ b/client/postcss.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  plugins: ['tailwindcss', 'autoprefixer'],
+  plugins: ['tailwindcss', 'autoprefixer', 'postcss-strip-units'],
 };

--- a/client/src/components/AppBar/AppBarLanding.module.scss
+++ b/client/src/components/AppBar/AppBarLanding.module.scss
@@ -5,6 +5,7 @@
 }
 
 .logo {
+  height: calculate-rem(194px);
   width: viewport-clamp(122px, 223px);
 }
 

--- a/client/src/components/AppBar/AppBarLanding.module.scss
+++ b/client/src/components/AppBar/AppBarLanding.module.scss
@@ -1,11 +1,13 @@
+@import '@/utils/styles';
+
 .heading {
-  font-size: clamp(35px, 10vw, 61px);
+  font-size: viewport-clamp(35px, 61px);
 }
 
 .logo {
-  width: clamp(122px, 35vw, 223px);
+  width: viewport-clamp(122px, 223px);
 }
 
 .list li {
-  font-size: clamp(14px, 4vw, 24px);
+  font-size: viewport-clamp(14px, 24px);
 }

--- a/client/src/components/AppBar/AppBarLanding.tsx
+++ b/client/src/components/AppBar/AppBarLanding.tsx
@@ -45,6 +45,7 @@ export function AppBarLanding() {
       classes={{
         // Use 3-column layout instead of 4-column.
         fourColumn: 'screen-1150:grid-cols-napari-3',
+        gap: 'gap-x-6 md:gap-x-12',
       }}
       component="header"
     >
@@ -59,7 +60,7 @@ export function AppBarLanding() {
       <h1
         className={clsx(
           'font-bold col-span-full',
-          '-mt-12 screen-1425:m-0',
+          'mb-6 md:mb-12',
           'screen-1425:col-start-2 screen-1425:col-span-3',
           styles.heading,
         )}
@@ -87,7 +88,7 @@ export function AppBarLanding() {
 
       {/* Render as separate list so that it renders below everything on smaller screens. */}
       <MediaFragment lessThan="screen-725">
-        <List className="col-span-2 px-6">{lastListNode}</List>
+        <List className="col-span-2 px-6 mt-4">{lastListNode}</List>
       </MediaFragment>
     </ColumnLayout>
   );

--- a/client/src/components/AppBar/AppBarLanding.tsx
+++ b/client/src/components/AppBar/AppBarLanding.tsx
@@ -69,7 +69,6 @@ export function AppBarLanding() {
 
       <Hub
         className={clsx(
-          'h-full',
           'self-center justify-self-end',
           'screen-1425:row-start-2 screen-1425:col-start-2',
           styles.logo,

--- a/client/src/components/PluginSearch/PluginSearchControls.tsx
+++ b/client/src/components/PluginSearch/PluginSearchControls.tsx
@@ -1,5 +1,8 @@
+import { Divider } from '@material-ui/core';
 import clsx from 'clsx';
 import { AnimateSharedLayout } from 'framer-motion';
+
+import { Media } from '@/components/common/media';
 
 import { PluginFilterByForm } from './PluginFilterByForm';
 import { PluginSortByForm } from './PluginSortByForm';
@@ -20,6 +23,11 @@ export function PluginSearchControls() {
     >
       <AnimateSharedLayout>
         <PluginSortByForm />
+
+        <Media className="my-6" greaterThanOrEqual="screen-875">
+          <Divider className="bg-black" />
+        </Media>
+
         <PluginFilterByForm />
       </AnimateSharedLayout>
     </aside>

--- a/client/src/components/PluginSearch/PluginSearchControls.tsx
+++ b/client/src/components/PluginSearch/PluginSearchControls.tsx
@@ -9,16 +9,19 @@ import { PluginSortByForm } from './PluginSortByForm';
  */
 export function PluginSearchControls() {
   return (
-    <div
+    <aside
       className={clsx(
-        'grid gap-6',
-        'col-span-2 screen-875:col-span-1 screen-875:row-span-3',
+        // Grid
+        'col-span-2 screen-875:col-span-1',
+
+        // Margins
+        'mb-6 screen-875:m-0',
       )}
     >
       <AnimateSharedLayout>
         <PluginSortByForm />
         <PluginFilterByForm />
       </AnimateSharedLayout>
-    </div>
+    </aside>
   );
 }

--- a/client/src/components/PluginSearch/PluginSearchControls.tsx
+++ b/client/src/components/PluginSearch/PluginSearchControls.tsx
@@ -1,6 +1,6 @@
 import { Divider } from '@material-ui/core';
 import clsx from 'clsx';
-import { AnimateSharedLayout } from 'framer-motion';
+import { AnimateSharedLayout, motion } from 'framer-motion';
 
 import { Media } from '@/components/common/media';
 
@@ -25,10 +25,12 @@ export function PluginSearchControls() {
         <PluginSortByForm />
 
         <Media className="my-6" greaterThanOrEqual="screen-875">
-          <Divider className="bg-black" />
+          <Divider layout component={motion.div} className="bg-black" />
         </Media>
 
-        <PluginFilterByForm />
+        <motion.div layout>
+          <PluginFilterByForm />
+        </motion.div>
       </AnimateSharedLayout>
     </aside>
   );

--- a/client/src/components/PluginSearch/PluginSearchResult.tsx
+++ b/client/src/components/PluginSearch/PluginSearchResult.tsx
@@ -136,7 +136,7 @@ export function PluginSearchResult({ className, matches, plugin }: Props) {
         data-testid="searchResult"
         className={clsx(
           'grid gap-x-6 md:gap-x-12',
-          'screen-600:grid-cols-napari-2',
+          'screen-600:grid-cols-2',
           'screen-1425:grid-cols-napari-3',
         )}
       >

--- a/client/src/components/PluginSearch/PluginSearchResultList.tsx
+++ b/client/src/components/PluginSearch/PluginSearchResultList.tsx
@@ -1,39 +1,42 @@
 import clsx from 'clsx';
+import { isEmpty } from 'lodash';
 
 import { useSearchState } from '@/context/search';
 
+import { ColumnLayout } from '../common';
 import { FilterChips } from './FilterChips';
 import { PluginSearchResult } from './PluginSearchResult';
 
 export function PluginSearchResultList() {
-  const { results = [] } = useSearchState() ?? {};
+  const { filter, results = [] } = useSearchState() ?? {};
 
   return (
-    <>
+    <section className="col-span-2 screen-1425:col-span-3">
       <h3
-        className={clsx(
-          'col-span-2',
-          'font-bold text-xl my-6',
-          'screen-875:col-start-2',
-        )}
+        className={clsx('font-bold text-xl', isEmpty(filter?.chips) && 'mb-5')}
       >
-        Browse plugins
+        Browse plugins: {results.length}
       </h3>
 
-      <FilterChips className="col-span-2 screen-1425:col-span-3 mb-6" />
+      <FilterChips className="my-5" />
 
-      {results.map(({ plugin, matches }) => (
-        <PluginSearchResult
-          className={clsx(
-            'col-span-2',
-            'screen-875:col-start-2 screen-875:col-span-2',
-            'screen-1425:col-start-2 screen-1425:col-span-3',
-          )}
-          key={plugin.name}
-          plugin={plugin}
-          matches={matches}
-        />
-      ))}
-    </>
+      <ColumnLayout
+        classes={{
+          threeColumn: '',
+          fiveColumn: '',
+          fourColumn: '',
+          gap: 'gap-x-6 md:gap-x-12',
+        }}
+      >
+        {results.map(({ plugin, matches }) => (
+          <PluginSearchResult
+            className={clsx('col-span-2', 'screen-1425:col-span-3')}
+            key={plugin.name}
+            plugin={plugin}
+            matches={matches}
+          />
+        ))}
+      </ColumnLayout>
+    </section>
   );
 }

--- a/client/src/components/PluginSearch/__snapshots__/PluginSearch.test.tsx.snap
+++ b/client/src/components/PluginSearch/__snapshots__/PluginSearch.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<PluginSearch /> should match snapshot 1`] = `
 <DocumentFragment>
   <header
-    class="bg-napari-primary p-6 screen-495:p-12 grid justify-center gap-6 md:gap-12 grid-cols-2 screen-875:grid-cols-napari-3 screen-1150:grid-cols-napari-3 screen-1425:grid-cols-napari-5"
+    class="bg-napari-primary p-6 screen-495:p-12 grid justify-center gap-x-6 md:gap-x-12 grid-cols-2 screen-875:grid-cols-napari-3 screen-1150:grid-cols-napari-3 screen-1425:grid-cols-napari-5"
   >
     <div
       class="fresnel-container fresnel-greaterThanOrEqual-screen-1425 "
@@ -74,13 +74,13 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
       </nav>
     </div>
     <h1
-      class="font-bold col-span-full -mt-12 screen-1425:m-0 screen-1425:col-start-2 screen-1425:col-span-3 heading"
+      class="font-bold col-span-full mb-6 md:mb-12 screen-1425:col-start-2 screen-1425:col-span-3 heading"
     >
       Discover, install, and share napari plugins
     </h1>
     <svg
       aria-hidden="true"
-      class="h-full self-center justify-self-end screen-1425:row-start-2 screen-1425:col-start-2 logo"
+      class="self-center justify-self-end screen-1425:row-start-2 screen-1425:col-start-2 logo"
       fill="none"
       height="198"
       viewBox="0 0 226 198"
@@ -228,7 +228,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
       </li>
     </ul>
     <ul
-      class="list-disc font-semibold space-y-4 list fresnel-lessThan-screen-725 col-span-2 px-6"
+      class="list-disc font-semibold space-y-4 list fresnel-lessThan-screen-725 col-span-2 px-6 mt-4"
     >
       <li>
         Share your image analysis tools with napari’s growing community
@@ -287,8 +287,8 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
     <div
       class="p-6 md:p-12 grid justify-center gap-x-6 md:gap-x-12 grid-cols-2 screen-875:grid-cols-napari-3 screen-1150:grid-cols-napari-3 screen-1425:grid-cols-napari-5"
     >
-      <div
-        class="grid gap-6 col-span-2 screen-875:col-span-1 screen-875:row-span-3"
+      <aside
+        class="col-span-2 screen-875:col-span-1 mb-6 screen-875:m-0"
       >
         <div
           class="MuiPaper-root MuiAccordion-root shadow-none fresnel-lessThan-screen-875 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
@@ -737,572 +737,585 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
           </div>
         </fieldset>
         <div
-          class="fresnel-container fresnel-lessThan-screen-875 "
+          class="fresnel-container fresnel-greaterThanOrEqual-screen-875 my-6"
         >
           <div
-            class="MuiPaper-root MuiAccordion-root shadow-none MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiDivider-root bg-black"
+            role="separator"
+            style="transform: translate3d(0px, 0px, 0) scale(NaN, NaN); transform-origin: 50% 50% 0;"
+          />
+        </div>
+        <div
+          style="transform: translate3d(0px, 0px, 0) scale(NaN, NaN); transform-origin: 50% 50% 0;"
+        >
+          <div
+            class="fresnel-container fresnel-lessThan-screen-875 "
           >
             <div
-              aria-disabled="false"
-              aria-expanded="false"
-              class="MuiButtonBase-root MuiAccordionSummary-root flex-row-reverse p-0 font-semibold"
-              role="button"
-              tabindex="0"
+              class="MuiPaper-root MuiAccordion-root shadow-none MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
             >
-              <div
-                class="MuiAccordionSummary-content !ml-6"
-              >
-                Filter By
-              </div>
               <div
                 aria-disabled="false"
-                aria-hidden="true"
-                class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon p-0 MuiIconButton-edgeEnd"
-              >
-                <span
-                  class="MuiIconButton-label"
-                >
-                  <svg
-                    fill="none"
-                    height="12"
-                    viewBox="0 0 16 12"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      clip-path="url(#clip0)"
-                    >
-                      <path
-                        d="M1 2.07107L8.07107 9.14214L15.1421 2.07107"
-                        stroke="black"
-                        stroke-width="2"
-                      />
-                    </g>
-                    <defs>
-                      <clippath
-                        id="clip0"
-                      >
-                        <rect
-                          fill="white"
-                          height="12"
-                          width="16"
-                        />
-                      </clippath>
-                    </defs>
-                  </svg>
-                </span>
-                <span
-                  class="MuiTouchRipple-root"
-                />
-              </div>
-            </div>
-            <div
-              class="MuiCollapse-container MuiCollapse-hidden"
-              style="min-height: 0px;"
-            >
-              <div
-                class="MuiCollapse-wrapper"
+                aria-expanded="false"
+                class="MuiButtonBase-root MuiAccordionSummary-root flex-row-reverse p-0 font-semibold"
+                role="button"
+                tabindex="0"
               >
                 <div
-                  class="MuiCollapse-wrapperInner"
+                  class="MuiAccordionSummary-content !ml-6"
+                >
+                  Filter By
+                </div>
+                <div
+                  aria-disabled="false"
+                  aria-hidden="true"
+                  class="MuiButtonBase-root MuiIconButton-root MuiAccordionSummary-expandIcon p-0 MuiIconButton-edgeEnd"
+                >
+                  <span
+                    class="MuiIconButton-label"
+                  >
+                    <svg
+                      fill="none"
+                      height="12"
+                      viewBox="0 0 16 12"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <g
+                        clip-path="url(#clip0)"
+                      >
+                        <path
+                          d="M1 2.07107L8.07107 9.14214L15.1421 2.07107"
+                          stroke="black"
+                          stroke-width="2"
+                        />
+                      </g>
+                      <defs>
+                        <clippath
+                          id="clip0"
+                        >
+                          <rect
+                            fill="white"
+                            height="12"
+                            width="16"
+                          />
+                        </clippath>
+                      </defs>
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </div>
+              </div>
+              <div
+                class="MuiCollapse-container MuiCollapse-hidden"
+                style="min-height: 0px;"
+              >
+                <div
+                  class="MuiCollapse-wrapper"
                 >
                   <div
-                    role="region"
+                    class="MuiCollapse-wrapperInner"
                   >
                     <div
-                      class="MuiAccordionDetails-root p-0"
+                      role="region"
                     >
                       <div
-                        class="flex flex-col gap-6"
+                        class="MuiAccordionDetails-root p-0"
                       >
                         <div
-                          class="fresnel-container fresnel-greaterThanOrEqual-screen-875 "
-                        />
-                        <fieldset
-                          class="MuiFormControl-root"
+                          class="flex flex-col gap-6"
                         >
-                          <legend
-                            class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
-                            data-testid="title"
-                          >
-                            Python versions
-                          </legend>
                           <div
-                            class="MuiFormGroup-root gap-2"
+                            class="fresnel-container fresnel-greaterThanOrEqual-screen-875 "
+                          />
+                          <fieldset
+                            class="MuiFormControl-root"
                           >
-                            <label
-                              class="MuiFormControlLabel-root items-start m-0"
-                              data-testid="input"
+                            <legend
+                              class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
+                              data-testid="title"
                             >
-                              <span
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 PrivateSwitchBase-checked-2 Mui-checked"
+                              Python versions
+                            </legend>
+                            <div
+                              class="MuiFormGroup-root gap-2"
+                            >
+                              <label
+                                class="MuiFormControlLabel-root items-start m-0"
+                                data-testid="input"
                               >
                                 <span
-                                  class="MuiIconButton-label"
+                                  aria-disabled="false"
+                                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 PrivateSwitchBase-checked-2 Mui-checked"
                                 >
-                                  <input
-                                    checked=""
-                                    class="PrivateSwitchBase-input-4"
-                                    data-indeterminate="false"
-                                    type="checkbox"
-                                    value="true"
-                                  />
-                                  <svg
-                                    class="w-4 h-4"
-                                    fill="none"
-                                    height="14"
-                                    viewBox="0 0 14 14"
-                                    width="14"
-                                    xmlns="http://www.w3.org/2000/svg"
+                                  <span
+                                    class="MuiIconButton-label"
                                   >
-                                    <title>
-                                      checked checkbox
-                                    </title>
-                                    <rect
-                                      height="13"
-                                      stroke="black"
-                                      width="13"
-                                      x="0.5"
-                                      y="0.5"
+                                    <input
+                                      checked=""
+                                      class="PrivateSwitchBase-input-4"
+                                      data-indeterminate="false"
+                                      type="checkbox"
+                                      value="true"
                                     />
-                                    <path
-                                      d="M2.5 7 l3 3 l6 -6"
-                                      stroke="black"
-                                      stroke-width="1.5"
-                                    />
-                                  </svg>
+                                    <svg
+                                      class="w-4 h-4"
+                                      fill="none"
+                                      height="14"
+                                      viewBox="0 0 14 14"
+                                      width="14"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <title>
+                                        checked checkbox
+                                      </title>
+                                      <rect
+                                        height="13"
+                                        stroke="black"
+                                        width="13"
+                                        x="0.5"
+                                        y="0.5"
+                                      />
+                                      <path
+                                        d="M2.5 7 l3 3 l6 -6"
+                                        stroke="black"
+                                        stroke-width="1.5"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="MuiTouchRipple-root"
+                                  />
                                 </span>
                                 <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </span>
-                              <span
-                                class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                              >
-                                3.6
-                              </span>
-                            </label>
-                            <label
-                              class="MuiFormControlLabel-root items-start m-0"
-                              data-testid="input"
-                            >
-                              <span
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                                  class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                                >
+                                  3.6
+                                </span>
+                              </label>
+                              <label
+                                class="MuiFormControlLabel-root items-start m-0"
+                                data-testid="input"
                               >
                                 <span
-                                  class="MuiIconButton-label"
+                                  aria-disabled="false"
+                                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
                                 >
-                                  <input
-                                    class="PrivateSwitchBase-input-4"
-                                    data-indeterminate="false"
-                                    type="checkbox"
-                                    value="false"
-                                  />
-                                  <svg
-                                    class="w-4 h-4"
-                                    fill="none"
-                                    height="14"
-                                    viewBox="0 0 14 14"
-                                    width="14"
-                                    xmlns="http://www.w3.org/2000/svg"
+                                  <span
+                                    class="MuiIconButton-label"
                                   >
-                                    <title>
-                                      unchecked checkbox
-                                    </title>
-                                    <rect
-                                      height="13"
-                                      stroke="black"
-                                      width="13"
-                                      x="0.5"
-                                      y="0.5"
+                                    <input
+                                      class="PrivateSwitchBase-input-4"
+                                      data-indeterminate="false"
+                                      type="checkbox"
+                                      value="false"
                                     />
-                                  </svg>
+                                    <svg
+                                      class="w-4 h-4"
+                                      fill="none"
+                                      height="14"
+                                      viewBox="0 0 14 14"
+                                      width="14"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <title>
+                                        unchecked checkbox
+                                      </title>
+                                      <rect
+                                        height="13"
+                                        stroke="black"
+                                        width="13"
+                                        x="0.5"
+                                        y="0.5"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="MuiTouchRipple-root"
+                                  />
                                 </span>
                                 <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </span>
-                              <span
-                                class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                              >
-                                3.7
-                              </span>
-                            </label>
-                            <label
-                              class="MuiFormControlLabel-root items-start m-0"
-                              data-testid="input"
-                            >
-                              <span
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                                  class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                                >
+                                  3.7
+                                </span>
+                              </label>
+                              <label
+                                class="MuiFormControlLabel-root items-start m-0"
+                                data-testid="input"
                               >
                                 <span
-                                  class="MuiIconButton-label"
+                                  aria-disabled="false"
+                                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
                                 >
-                                  <input
-                                    class="PrivateSwitchBase-input-4"
-                                    data-indeterminate="false"
-                                    type="checkbox"
-                                    value="false"
-                                  />
-                                  <svg
-                                    class="w-4 h-4"
-                                    fill="none"
-                                    height="14"
-                                    viewBox="0 0 14 14"
-                                    width="14"
-                                    xmlns="http://www.w3.org/2000/svg"
+                                  <span
+                                    class="MuiIconButton-label"
                                   >
-                                    <title>
-                                      unchecked checkbox
-                                    </title>
-                                    <rect
-                                      height="13"
-                                      stroke="black"
-                                      width="13"
-                                      x="0.5"
-                                      y="0.5"
+                                    <input
+                                      class="PrivateSwitchBase-input-4"
+                                      data-indeterminate="false"
+                                      type="checkbox"
+                                      value="false"
                                     />
-                                  </svg>
+                                    <svg
+                                      class="w-4 h-4"
+                                      fill="none"
+                                      height="14"
+                                      viewBox="0 0 14 14"
+                                      width="14"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <title>
+                                        unchecked checkbox
+                                      </title>
+                                      <rect
+                                        height="13"
+                                        stroke="black"
+                                        width="13"
+                                        x="0.5"
+                                        y="0.5"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="MuiTouchRipple-root"
+                                  />
                                 </span>
                                 <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </span>
-                              <span
-                                class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                              >
-                                3.8
-                              </span>
-                            </label>
-                            <label
-                              class="MuiFormControlLabel-root items-start m-0"
-                              data-testid="input"
-                            >
-                              <span
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                                  class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                                >
+                                  3.8
+                                </span>
+                              </label>
+                              <label
+                                class="MuiFormControlLabel-root items-start m-0"
+                                data-testid="input"
                               >
                                 <span
-                                  class="MuiIconButton-label"
+                                  aria-disabled="false"
+                                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
                                 >
-                                  <input
-                                    class="PrivateSwitchBase-input-4"
-                                    data-indeterminate="false"
-                                    type="checkbox"
-                                    value="false"
-                                  />
-                                  <svg
-                                    class="w-4 h-4"
-                                    fill="none"
-                                    height="14"
-                                    viewBox="0 0 14 14"
-                                    width="14"
-                                    xmlns="http://www.w3.org/2000/svg"
+                                  <span
+                                    class="MuiIconButton-label"
                                   >
-                                    <title>
-                                      unchecked checkbox
-                                    </title>
-                                    <rect
-                                      height="13"
-                                      stroke="black"
-                                      width="13"
-                                      x="0.5"
-                                      y="0.5"
+                                    <input
+                                      class="PrivateSwitchBase-input-4"
+                                      data-indeterminate="false"
+                                      type="checkbox"
+                                      value="false"
                                     />
-                                  </svg>
+                                    <svg
+                                      class="w-4 h-4"
+                                      fill="none"
+                                      height="14"
+                                      viewBox="0 0 14 14"
+                                      width="14"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <title>
+                                        unchecked checkbox
+                                      </title>
+                                      <rect
+                                        height="13"
+                                        stroke="black"
+                                        width="13"
+                                        x="0.5"
+                                        y="0.5"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="MuiTouchRipple-root"
+                                  />
                                 </span>
                                 <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </span>
-                              <span
-                                class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                              >
-                                3.9
-                              </span>
-                            </label>
-                          </div>
-                        </fieldset>
-                        <fieldset
-                          class="MuiFormControl-root"
-                        >
-                          <legend
-                            class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
-                            data-testid="title"
+                                  class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                                >
+                                  3.9
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                          <fieldset
+                            class="MuiFormControl-root"
                           >
-                            Operating system
-                          </legend>
-                          <div
-                            class="MuiFormGroup-root gap-2"
-                          >
-                            <label
-                              class="MuiFormControlLabel-root items-start m-0"
-                              data-testid="input"
+                            <legend
+                              class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
+                              data-testid="title"
                             >
-                              <span
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                              Operating system
+                            </legend>
+                            <div
+                              class="MuiFormGroup-root gap-2"
+                            >
+                              <label
+                                class="MuiFormControlLabel-root items-start m-0"
+                                data-testid="input"
                               >
                                 <span
-                                  class="MuiIconButton-label"
+                                  aria-disabled="false"
+                                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
                                 >
-                                  <input
-                                    class="PrivateSwitchBase-input-4"
-                                    data-indeterminate="false"
-                                    type="checkbox"
-                                    value="false"
-                                  />
-                                  <svg
-                                    class="w-4 h-4"
-                                    fill="none"
-                                    height="14"
-                                    viewBox="0 0 14 14"
-                                    width="14"
-                                    xmlns="http://www.w3.org/2000/svg"
+                                  <span
+                                    class="MuiIconButton-label"
                                   >
-                                    <title>
-                                      unchecked checkbox
-                                    </title>
-                                    <rect
-                                      height="13"
-                                      stroke="black"
-                                      width="13"
-                                      x="0.5"
-                                      y="0.5"
+                                    <input
+                                      class="PrivateSwitchBase-input-4"
+                                      data-indeterminate="false"
+                                      type="checkbox"
+                                      value="false"
                                     />
-                                  </svg>
+                                    <svg
+                                      class="w-4 h-4"
+                                      fill="none"
+                                      height="14"
+                                      viewBox="0 0 14 14"
+                                      width="14"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <title>
+                                        unchecked checkbox
+                                      </title>
+                                      <rect
+                                        height="13"
+                                        stroke="black"
+                                        width="13"
+                                        x="0.5"
+                                        y="0.5"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="MuiTouchRipple-root"
+                                  />
                                 </span>
                                 <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </span>
-                              <span
-                                class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                              >
-                                Linux
-                              </span>
-                            </label>
-                            <label
-                              class="MuiFormControlLabel-root items-start m-0"
-                              data-testid="input"
-                            >
-                              <span
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                                  class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                                >
+                                  Linux
+                                </span>
+                              </label>
+                              <label
+                                class="MuiFormControlLabel-root items-start m-0"
+                                data-testid="input"
                               >
                                 <span
-                                  class="MuiIconButton-label"
+                                  aria-disabled="false"
+                                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
                                 >
-                                  <input
-                                    class="PrivateSwitchBase-input-4"
-                                    data-indeterminate="false"
-                                    type="checkbox"
-                                    value="false"
-                                  />
-                                  <svg
-                                    class="w-4 h-4"
-                                    fill="none"
-                                    height="14"
-                                    viewBox="0 0 14 14"
-                                    width="14"
-                                    xmlns="http://www.w3.org/2000/svg"
+                                  <span
+                                    class="MuiIconButton-label"
                                   >
-                                    <title>
-                                      unchecked checkbox
-                                    </title>
-                                    <rect
-                                      height="13"
-                                      stroke="black"
-                                      width="13"
-                                      x="0.5"
-                                      y="0.5"
+                                    <input
+                                      class="PrivateSwitchBase-input-4"
+                                      data-indeterminate="false"
+                                      type="checkbox"
+                                      value="false"
                                     />
-                                  </svg>
+                                    <svg
+                                      class="w-4 h-4"
+                                      fill="none"
+                                      height="14"
+                                      viewBox="0 0 14 14"
+                                      width="14"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <title>
+                                        unchecked checkbox
+                                      </title>
+                                      <rect
+                                        height="13"
+                                        stroke="black"
+                                        width="13"
+                                        x="0.5"
+                                        y="0.5"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="MuiTouchRipple-root"
+                                  />
                                 </span>
                                 <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </span>
-                              <span
-                                class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                              >
-                                Mac
-                              </span>
-                            </label>
-                            <label
-                              class="MuiFormControlLabel-root items-start m-0"
-                              data-testid="input"
-                            >
-                              <span
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                                  class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                                >
+                                  Mac
+                                </span>
+                              </label>
+                              <label
+                                class="MuiFormControlLabel-root items-start m-0"
+                                data-testid="input"
                               >
                                 <span
-                                  class="MuiIconButton-label"
+                                  aria-disabled="false"
+                                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
                                 >
-                                  <input
-                                    class="PrivateSwitchBase-input-4"
-                                    data-indeterminate="false"
-                                    type="checkbox"
-                                    value="false"
-                                  />
-                                  <svg
-                                    class="w-4 h-4"
-                                    fill="none"
-                                    height="14"
-                                    viewBox="0 0 14 14"
-                                    width="14"
-                                    xmlns="http://www.w3.org/2000/svg"
+                                  <span
+                                    class="MuiIconButton-label"
                                   >
-                                    <title>
-                                      unchecked checkbox
-                                    </title>
-                                    <rect
-                                      height="13"
-                                      stroke="black"
-                                      width="13"
-                                      x="0.5"
-                                      y="0.5"
+                                    <input
+                                      class="PrivateSwitchBase-input-4"
+                                      data-indeterminate="false"
+                                      type="checkbox"
+                                      value="false"
                                     />
-                                  </svg>
+                                    <svg
+                                      class="w-4 h-4"
+                                      fill="none"
+                                      height="14"
+                                      viewBox="0 0 14 14"
+                                      width="14"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <title>
+                                        unchecked checkbox
+                                      </title>
+                                      <rect
+                                        height="13"
+                                        stroke="black"
+                                        width="13"
+                                        x="0.5"
+                                        y="0.5"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="MuiTouchRipple-root"
+                                  />
                                 </span>
                                 <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </span>
-                              <span
-                                class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                              >
-                                Windows
-                              </span>
-                            </label>
-                          </div>
-                        </fieldset>
-                        <fieldset
-                          class="MuiFormControl-root"
-                        >
-                          <legend
-                            class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
-                            data-testid="title"
+                                  class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                                >
+                                  Windows
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                          <fieldset
+                            class="MuiFormControl-root"
                           >
-                            Development status
-                          </legend>
-                          <div
-                            class="MuiFormGroup-root gap-2"
-                          >
-                            <label
-                              class="MuiFormControlLabel-root items-start m-0"
-                              data-testid="input"
+                            <legend
+                              class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
+                              data-testid="title"
                             >
-                              <span
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                              Development status
+                            </legend>
+                            <div
+                              class="MuiFormGroup-root gap-2"
+                            >
+                              <label
+                                class="MuiFormControlLabel-root items-start m-0"
+                                data-testid="input"
                               >
                                 <span
-                                  class="MuiIconButton-label"
+                                  aria-disabled="false"
+                                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
                                 >
-                                  <input
-                                    class="PrivateSwitchBase-input-4"
-                                    data-indeterminate="false"
-                                    type="checkbox"
-                                    value="false"
-                                  />
-                                  <svg
-                                    class="w-4 h-4"
-                                    fill="none"
-                                    height="14"
-                                    viewBox="0 0 14 14"
-                                    width="14"
-                                    xmlns="http://www.w3.org/2000/svg"
+                                  <span
+                                    class="MuiIconButton-label"
                                   >
-                                    <title>
-                                      unchecked checkbox
-                                    </title>
-                                    <rect
-                                      height="13"
-                                      stroke="black"
-                                      width="13"
-                                      x="0.5"
-                                      y="0.5"
+                                    <input
+                                      class="PrivateSwitchBase-input-4"
+                                      data-indeterminate="false"
+                                      type="checkbox"
+                                      value="false"
                                     />
-                                  </svg>
+                                    <svg
+                                      class="w-4 h-4"
+                                      fill="none"
+                                      height="14"
+                                      viewBox="0 0 14 14"
+                                      width="14"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <title>
+                                        unchecked checkbox
+                                      </title>
+                                      <rect
+                                        height="13"
+                                        stroke="black"
+                                        width="13"
+                                        x="0.5"
+                                        y="0.5"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="MuiTouchRipple-root"
+                                  />
                                 </span>
                                 <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </span>
-                              <span
-                                class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                              >
-                                Only show stable plugins
-                              </span>
-                            </label>
-                          </div>
-                        </fieldset>
-                        <fieldset
-                          class="MuiFormControl-root"
-                        >
-                          <legend
-                            class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
-                            data-testid="title"
+                                  class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                                >
+                                  Only show stable plugins
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                          <fieldset
+                            class="MuiFormControl-root"
                           >
-                            License
-                          </legend>
-                          <div
-                            class="MuiFormGroup-root gap-2"
-                          >
-                            <label
-                              class="MuiFormControlLabel-root items-start m-0"
-                              data-testid="input"
+                            <legend
+                              class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
+                              data-testid="title"
                             >
-                              <span
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                              License
+                            </legend>
+                            <div
+                              class="MuiFormGroup-root gap-2"
+                            >
+                              <label
+                                class="MuiFormControlLabel-root items-start m-0"
+                                data-testid="input"
                               >
                                 <span
-                                  class="MuiIconButton-label"
+                                  aria-disabled="false"
+                                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
                                 >
-                                  <input
-                                    class="PrivateSwitchBase-input-4"
-                                    data-indeterminate="false"
-                                    type="checkbox"
-                                    value="false"
-                                  />
-                                  <svg
-                                    class="w-4 h-4"
-                                    fill="none"
-                                    height="14"
-                                    viewBox="0 0 14 14"
-                                    width="14"
-                                    xmlns="http://www.w3.org/2000/svg"
+                                  <span
+                                    class="MuiIconButton-label"
                                   >
-                                    <title>
-                                      unchecked checkbox
-                                    </title>
-                                    <rect
-                                      height="13"
-                                      stroke="black"
-                                      width="13"
-                                      x="0.5"
-                                      y="0.5"
+                                    <input
+                                      class="PrivateSwitchBase-input-4"
+                                      data-indeterminate="false"
+                                      type="checkbox"
+                                      value="false"
                                     />
-                                  </svg>
+                                    <svg
+                                      class="w-4 h-4"
+                                      fill="none"
+                                      height="14"
+                                      viewBox="0 0 14 14"
+                                      width="14"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <title>
+                                        unchecked checkbox
+                                      </title>
+                                      <rect
+                                        height="13"
+                                        stroke="black"
+                                        width="13"
+                                        x="0.5"
+                                        y="0.5"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    class="MuiTouchRipple-root"
+                                  />
                                 </span>
                                 <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </span>
-                              <span
-                                class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                              >
-                                Only show plugins with open source license
-                              </span>
-                            </label>
-                          </div>
-                        </fieldset>
+                                  class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                                >
+                                  Only show plugins with open source license
+                                </span>
+                              </label>
+                            </div>
+                          </fieldset>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1310,4541 +1323,4549 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
               </div>
             </div>
           </div>
-        </div>
-        <div
-          class="fresnel-container fresnel-greaterThanOrEqual-screen-875 "
-        >
           <div
-            class="flex flex-col gap-6"
+            class="fresnel-container fresnel-greaterThanOrEqual-screen-875 "
           >
             <div
-              class="fresnel-container fresnel-greaterThanOrEqual-screen-875 "
+              class="flex flex-col gap-6"
             >
-              <legend
-                class="MuiFormLabel-root uppercase text-black font-semibold text-sm"
+              <div
+                class="fresnel-container fresnel-greaterThanOrEqual-screen-875 "
               >
-                Filter By
-              </legend>
+                <legend
+                  class="MuiFormLabel-root uppercase text-black font-semibold text-sm"
+                >
+                  Filter By
+                </legend>
+              </div>
+              <fieldset
+                class="MuiFormControl-root"
+              >
+                <legend
+                  class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
+                  data-testid="title"
+                >
+                  Python versions
+                </legend>
+                <div
+                  class="MuiFormGroup-root gap-2"
+                >
+                  <label
+                    class="MuiFormControlLabel-root items-start m-0"
+                    data-testid="input"
+                  >
+                    <span
+                      aria-disabled="false"
+                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 PrivateSwitchBase-checked-2 Mui-checked"
+                    >
+                      <span
+                        class="MuiIconButton-label"
+                      >
+                        <input
+                          checked=""
+                          class="PrivateSwitchBase-input-4"
+                          data-indeterminate="false"
+                          type="checkbox"
+                          value="true"
+                        />
+                        <svg
+                          class="w-4 h-4"
+                          fill="none"
+                          height="14"
+                          viewBox="0 0 14 14"
+                          width="14"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <title>
+                            checked checkbox
+                          </title>
+                          <rect
+                            height="13"
+                            stroke="black"
+                            width="13"
+                            x="0.5"
+                            y="0.5"
+                          />
+                          <path
+                            d="M2.5 7 l3 3 l6 -6"
+                            stroke="black"
+                            stroke-width="1.5"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiTouchRipple-root"
+                      />
+                    </span>
+                    <span
+                      class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                    >
+                      3.6
+                    </span>
+                  </label>
+                  <label
+                    class="MuiFormControlLabel-root items-start m-0"
+                    data-testid="input"
+                  >
+                    <span
+                      aria-disabled="false"
+                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                    >
+                      <span
+                        class="MuiIconButton-label"
+                      >
+                        <input
+                          class="PrivateSwitchBase-input-4"
+                          data-indeterminate="false"
+                          type="checkbox"
+                          value="false"
+                        />
+                        <svg
+                          class="w-4 h-4"
+                          fill="none"
+                          height="14"
+                          viewBox="0 0 14 14"
+                          width="14"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <title>
+                            unchecked checkbox
+                          </title>
+                          <rect
+                            height="13"
+                            stroke="black"
+                            width="13"
+                            x="0.5"
+                            y="0.5"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiTouchRipple-root"
+                      />
+                    </span>
+                    <span
+                      class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                    >
+                      3.7
+                    </span>
+                  </label>
+                  <label
+                    class="MuiFormControlLabel-root items-start m-0"
+                    data-testid="input"
+                  >
+                    <span
+                      aria-disabled="false"
+                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                    >
+                      <span
+                        class="MuiIconButton-label"
+                      >
+                        <input
+                          class="PrivateSwitchBase-input-4"
+                          data-indeterminate="false"
+                          type="checkbox"
+                          value="false"
+                        />
+                        <svg
+                          class="w-4 h-4"
+                          fill="none"
+                          height="14"
+                          viewBox="0 0 14 14"
+                          width="14"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <title>
+                            unchecked checkbox
+                          </title>
+                          <rect
+                            height="13"
+                            stroke="black"
+                            width="13"
+                            x="0.5"
+                            y="0.5"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiTouchRipple-root"
+                      />
+                    </span>
+                    <span
+                      class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                    >
+                      3.8
+                    </span>
+                  </label>
+                  <label
+                    class="MuiFormControlLabel-root items-start m-0"
+                    data-testid="input"
+                  >
+                    <span
+                      aria-disabled="false"
+                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                    >
+                      <span
+                        class="MuiIconButton-label"
+                      >
+                        <input
+                          class="PrivateSwitchBase-input-4"
+                          data-indeterminate="false"
+                          type="checkbox"
+                          value="false"
+                        />
+                        <svg
+                          class="w-4 h-4"
+                          fill="none"
+                          height="14"
+                          viewBox="0 0 14 14"
+                          width="14"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <title>
+                            unchecked checkbox
+                          </title>
+                          <rect
+                            height="13"
+                            stroke="black"
+                            width="13"
+                            x="0.5"
+                            y="0.5"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiTouchRipple-root"
+                      />
+                    </span>
+                    <span
+                      class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                    >
+                      3.9
+                    </span>
+                  </label>
+                </div>
+              </fieldset>
+              <fieldset
+                class="MuiFormControl-root"
+              >
+                <legend
+                  class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
+                  data-testid="title"
+                >
+                  Operating system
+                </legend>
+                <div
+                  class="MuiFormGroup-root gap-2"
+                >
+                  <label
+                    class="MuiFormControlLabel-root items-start m-0"
+                    data-testid="input"
+                  >
+                    <span
+                      aria-disabled="false"
+                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                    >
+                      <span
+                        class="MuiIconButton-label"
+                      >
+                        <input
+                          class="PrivateSwitchBase-input-4"
+                          data-indeterminate="false"
+                          type="checkbox"
+                          value="false"
+                        />
+                        <svg
+                          class="w-4 h-4"
+                          fill="none"
+                          height="14"
+                          viewBox="0 0 14 14"
+                          width="14"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <title>
+                            unchecked checkbox
+                          </title>
+                          <rect
+                            height="13"
+                            stroke="black"
+                            width="13"
+                            x="0.5"
+                            y="0.5"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiTouchRipple-root"
+                      />
+                    </span>
+                    <span
+                      class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                    >
+                      Linux
+                    </span>
+                  </label>
+                  <label
+                    class="MuiFormControlLabel-root items-start m-0"
+                    data-testid="input"
+                  >
+                    <span
+                      aria-disabled="false"
+                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                    >
+                      <span
+                        class="MuiIconButton-label"
+                      >
+                        <input
+                          class="PrivateSwitchBase-input-4"
+                          data-indeterminate="false"
+                          type="checkbox"
+                          value="false"
+                        />
+                        <svg
+                          class="w-4 h-4"
+                          fill="none"
+                          height="14"
+                          viewBox="0 0 14 14"
+                          width="14"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <title>
+                            unchecked checkbox
+                          </title>
+                          <rect
+                            height="13"
+                            stroke="black"
+                            width="13"
+                            x="0.5"
+                            y="0.5"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiTouchRipple-root"
+                      />
+                    </span>
+                    <span
+                      class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                    >
+                      Mac
+                    </span>
+                  </label>
+                  <label
+                    class="MuiFormControlLabel-root items-start m-0"
+                    data-testid="input"
+                  >
+                    <span
+                      aria-disabled="false"
+                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                    >
+                      <span
+                        class="MuiIconButton-label"
+                      >
+                        <input
+                          class="PrivateSwitchBase-input-4"
+                          data-indeterminate="false"
+                          type="checkbox"
+                          value="false"
+                        />
+                        <svg
+                          class="w-4 h-4"
+                          fill="none"
+                          height="14"
+                          viewBox="0 0 14 14"
+                          width="14"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <title>
+                            unchecked checkbox
+                          </title>
+                          <rect
+                            height="13"
+                            stroke="black"
+                            width="13"
+                            x="0.5"
+                            y="0.5"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiTouchRipple-root"
+                      />
+                    </span>
+                    <span
+                      class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                    >
+                      Windows
+                    </span>
+                  </label>
+                </div>
+              </fieldset>
+              <fieldset
+                class="MuiFormControl-root"
+              >
+                <legend
+                  class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
+                  data-testid="title"
+                >
+                  Development status
+                </legend>
+                <div
+                  class="MuiFormGroup-root gap-2"
+                >
+                  <label
+                    class="MuiFormControlLabel-root items-start m-0"
+                    data-testid="input"
+                  >
+                    <span
+                      aria-disabled="false"
+                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                    >
+                      <span
+                        class="MuiIconButton-label"
+                      >
+                        <input
+                          class="PrivateSwitchBase-input-4"
+                          data-indeterminate="false"
+                          type="checkbox"
+                          value="false"
+                        />
+                        <svg
+                          class="w-4 h-4"
+                          fill="none"
+                          height="14"
+                          viewBox="0 0 14 14"
+                          width="14"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <title>
+                            unchecked checkbox
+                          </title>
+                          <rect
+                            height="13"
+                            stroke="black"
+                            width="13"
+                            x="0.5"
+                            y="0.5"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiTouchRipple-root"
+                      />
+                    </span>
+                    <span
+                      class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                    >
+                      Only show stable plugins
+                    </span>
+                  </label>
+                </div>
+              </fieldset>
+              <fieldset
+                class="MuiFormControl-root"
+              >
+                <legend
+                  class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
+                  data-testid="title"
+                >
+                  License
+                </legend>
+                <div
+                  class="MuiFormGroup-root gap-2"
+                >
+                  <label
+                    class="MuiFormControlLabel-root items-start m-0"
+                    data-testid="input"
+                  >
+                    <span
+                      aria-disabled="false"
+                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                    >
+                      <span
+                        class="MuiIconButton-label"
+                      >
+                        <input
+                          class="PrivateSwitchBase-input-4"
+                          data-indeterminate="false"
+                          type="checkbox"
+                          value="false"
+                        />
+                        <svg
+                          class="w-4 h-4"
+                          fill="none"
+                          height="14"
+                          viewBox="0 0 14 14"
+                          width="14"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <title>
+                            unchecked checkbox
+                          </title>
+                          <rect
+                            height="13"
+                            stroke="black"
+                            width="13"
+                            x="0.5"
+                            y="0.5"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="MuiTouchRipple-root"
+                      />
+                    </span>
+                    <span
+                      class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                    >
+                      Only show plugins with open source license
+                    </span>
+                  </label>
+                </div>
+              </fieldset>
             </div>
-            <fieldset
-              class="MuiFormControl-root"
-            >
-              <legend
-                class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
-                data-testid="title"
-              >
-                Python versions
-              </legend>
-              <div
-                class="MuiFormGroup-root gap-2"
-              >
-                <label
-                  class="MuiFormControlLabel-root items-start m-0"
-                  data-testid="input"
-                >
-                  <span
-                    aria-disabled="false"
-                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 PrivateSwitchBase-checked-2 Mui-checked"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <input
-                        checked=""
-                        class="PrivateSwitchBase-input-4"
-                        data-indeterminate="false"
-                        type="checkbox"
-                        value="true"
-                      />
-                      <svg
-                        class="w-4 h-4"
-                        fill="none"
-                        height="14"
-                        viewBox="0 0 14 14"
-                        width="14"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <title>
-                          checked checkbox
-                        </title>
-                        <rect
-                          height="13"
-                          stroke="black"
-                          width="13"
-                          x="0.5"
-                          y="0.5"
-                        />
-                        <path
-                          d="M2.5 7 l3 3 l6 -6"
-                          stroke="black"
-                          stroke-width="1.5"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </span>
-                  <span
-                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                  >
-                    3.6
-                  </span>
-                </label>
-                <label
-                  class="MuiFormControlLabel-root items-start m-0"
-                  data-testid="input"
-                >
-                  <span
-                    aria-disabled="false"
-                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <input
-                        class="PrivateSwitchBase-input-4"
-                        data-indeterminate="false"
-                        type="checkbox"
-                        value="false"
-                      />
-                      <svg
-                        class="w-4 h-4"
-                        fill="none"
-                        height="14"
-                        viewBox="0 0 14 14"
-                        width="14"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <title>
-                          unchecked checkbox
-                        </title>
-                        <rect
-                          height="13"
-                          stroke="black"
-                          width="13"
-                          x="0.5"
-                          y="0.5"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </span>
-                  <span
-                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                  >
-                    3.7
-                  </span>
-                </label>
-                <label
-                  class="MuiFormControlLabel-root items-start m-0"
-                  data-testid="input"
-                >
-                  <span
-                    aria-disabled="false"
-                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <input
-                        class="PrivateSwitchBase-input-4"
-                        data-indeterminate="false"
-                        type="checkbox"
-                        value="false"
-                      />
-                      <svg
-                        class="w-4 h-4"
-                        fill="none"
-                        height="14"
-                        viewBox="0 0 14 14"
-                        width="14"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <title>
-                          unchecked checkbox
-                        </title>
-                        <rect
-                          height="13"
-                          stroke="black"
-                          width="13"
-                          x="0.5"
-                          y="0.5"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </span>
-                  <span
-                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                  >
-                    3.8
-                  </span>
-                </label>
-                <label
-                  class="MuiFormControlLabel-root items-start m-0"
-                  data-testid="input"
-                >
-                  <span
-                    aria-disabled="false"
-                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <input
-                        class="PrivateSwitchBase-input-4"
-                        data-indeterminate="false"
-                        type="checkbox"
-                        value="false"
-                      />
-                      <svg
-                        class="w-4 h-4"
-                        fill="none"
-                        height="14"
-                        viewBox="0 0 14 14"
-                        width="14"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <title>
-                          unchecked checkbox
-                        </title>
-                        <rect
-                          height="13"
-                          stroke="black"
-                          width="13"
-                          x="0.5"
-                          y="0.5"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </span>
-                  <span
-                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                  >
-                    3.9
-                  </span>
-                </label>
-              </div>
-            </fieldset>
-            <fieldset
-              class="MuiFormControl-root"
-            >
-              <legend
-                class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
-                data-testid="title"
-              >
-                Operating system
-              </legend>
-              <div
-                class="MuiFormGroup-root gap-2"
-              >
-                <label
-                  class="MuiFormControlLabel-root items-start m-0"
-                  data-testid="input"
-                >
-                  <span
-                    aria-disabled="false"
-                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <input
-                        class="PrivateSwitchBase-input-4"
-                        data-indeterminate="false"
-                        type="checkbox"
-                        value="false"
-                      />
-                      <svg
-                        class="w-4 h-4"
-                        fill="none"
-                        height="14"
-                        viewBox="0 0 14 14"
-                        width="14"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <title>
-                          unchecked checkbox
-                        </title>
-                        <rect
-                          height="13"
-                          stroke="black"
-                          width="13"
-                          x="0.5"
-                          y="0.5"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </span>
-                  <span
-                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                  >
-                    Linux
-                  </span>
-                </label>
-                <label
-                  class="MuiFormControlLabel-root items-start m-0"
-                  data-testid="input"
-                >
-                  <span
-                    aria-disabled="false"
-                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <input
-                        class="PrivateSwitchBase-input-4"
-                        data-indeterminate="false"
-                        type="checkbox"
-                        value="false"
-                      />
-                      <svg
-                        class="w-4 h-4"
-                        fill="none"
-                        height="14"
-                        viewBox="0 0 14 14"
-                        width="14"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <title>
-                          unchecked checkbox
-                        </title>
-                        <rect
-                          height="13"
-                          stroke="black"
-                          width="13"
-                          x="0.5"
-                          y="0.5"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </span>
-                  <span
-                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                  >
-                    Mac
-                  </span>
-                </label>
-                <label
-                  class="MuiFormControlLabel-root items-start m-0"
-                  data-testid="input"
-                >
-                  <span
-                    aria-disabled="false"
-                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <input
-                        class="PrivateSwitchBase-input-4"
-                        data-indeterminate="false"
-                        type="checkbox"
-                        value="false"
-                      />
-                      <svg
-                        class="w-4 h-4"
-                        fill="none"
-                        height="14"
-                        viewBox="0 0 14 14"
-                        width="14"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <title>
-                          unchecked checkbox
-                        </title>
-                        <rect
-                          height="13"
-                          stroke="black"
-                          width="13"
-                          x="0.5"
-                          y="0.5"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </span>
-                  <span
-                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                  >
-                    Windows
-                  </span>
-                </label>
-              </div>
-            </fieldset>
-            <fieldset
-              class="MuiFormControl-root"
-            >
-              <legend
-                class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
-                data-testid="title"
-              >
-                Development status
-              </legend>
-              <div
-                class="MuiFormGroup-root gap-2"
-              >
-                <label
-                  class="MuiFormControlLabel-root items-start m-0"
-                  data-testid="input"
-                >
-                  <span
-                    aria-disabled="false"
-                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <input
-                        class="PrivateSwitchBase-input-4"
-                        data-indeterminate="false"
-                        type="checkbox"
-                        value="false"
-                      />
-                      <svg
-                        class="w-4 h-4"
-                        fill="none"
-                        height="14"
-                        viewBox="0 0 14 14"
-                        width="14"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <title>
-                          unchecked checkbox
-                        </title>
-                        <rect
-                          height="13"
-                          stroke="black"
-                          width="13"
-                          x="0.5"
-                          y="0.5"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </span>
-                  <span
-                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                  >
-                    Only show stable plugins
-                  </span>
-                </label>
-              </div>
-            </fieldset>
-            <fieldset
-              class="MuiFormControl-root"
-            >
-              <legend
-                class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
-                data-testid="title"
-              >
-                License
-              </legend>
-              <div
-                class="MuiFormGroup-root gap-2"
-              >
-                <label
-                  class="MuiFormControlLabel-root items-start m-0"
-                  data-testid="input"
-                >
-                  <span
-                    aria-disabled="false"
-                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <input
-                        class="PrivateSwitchBase-input-4"
-                        data-indeterminate="false"
-                        type="checkbox"
-                        value="false"
-                      />
-                      <svg
-                        class="w-4 h-4"
-                        fill="none"
-                        height="14"
-                        viewBox="0 0 14 14"
-                        width="14"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <title>
-                          unchecked checkbox
-                        </title>
-                        <rect
-                          height="13"
-                          stroke="black"
-                          width="13"
-                          x="0.5"
-                          y="0.5"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </span>
-                  <span
-                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                  >
-                    Only show plugins with open source license
-                  </span>
-                </label>
-              </div>
-            </fieldset>
           </div>
         </div>
-      </div>
-      <h3
-        class="col-span-2 font-bold text-xl my-6 screen-875:col-start-2"
+      </aside>
+      <section
+        class="col-span-2 screen-1425:col-span-3"
       >
-        Browse plugins
-      </h3>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/napari-compressed-labels-io"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
+        <h3
+          class="font-bold text-xl mb-5"
         >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                napari-compressed-labels-io
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                Plugin exploring different options for reading and writing compressed and portable labels layers in napari.
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Draga Doncila
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.0.2
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                03 March 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                MIT
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.6
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/affinder"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
+          Browse plugins: 36
+        </h3>
+        <div
+          class="grid justify-center gap-x-6 md:gap-x-12 grid-cols-2"
         >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                affinder
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                Quickly find the affine matrix mapping one image to another using manual correspondence points annotation
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Juan Nunez-Iglesias
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.2.0
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                24 March 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                BSD-3
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.7
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/napping"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                napping
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                Control point mapping and coordination transformation using napari
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Jonas Windhager
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.1.7
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                15 March 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                MIT
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.7
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/napari-console"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                napari-console
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                A plugin that adds a console to napari
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Nicholas Sofroniew
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.0.3
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                14 February 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                BSD-3
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.7
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/napari-hdf5-labels-io"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                napari-hdf5-labels-io
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                Napari plugin to store set of layers in a .h5 file. Label layer are stored in a sparse representation
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Duway Nicolas Lesmes Leon
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.2.dev13
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                07 April 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                GNU GPL v3.0
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &lt;3.9
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/PlatyMatch"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                PlatyMatch
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                \`PlatyMatch\` allows registration of volumetric images of embryos by establishing correspondences between cells
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Manan Lalit
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.0.2
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                03 May 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                BSD-3
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.6
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/napari_video"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                napari_video
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                napari plugin for reading videos.
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Jan Clemens
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.2.6
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                16 March 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              />
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.6
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              />
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/cellfinder-napari"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                cellfinder-napari
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                Efficient cell detection in large images
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Adam Tyson
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.0.9
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                27 April 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                GPL-3.0
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.6
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/napari-svg"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                napari-svg
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                A plugin for reading and writing svg files with napari
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Nicholas Sofroniew
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.1.5
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                01 May 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                BSD-3
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.7
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/napari-yapic-prediction"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                napari-yapic-prediction
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                Napari widget plugin to perform yapic model segmentation prediction in the napari window
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Duway Nicolas Lesmes Leon
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.1.dev78
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                21 April 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                GNU GPL v3.0
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.6
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/napari-demo"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                napari-demo
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                demo plugin
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Ziyang Liu
-              </li>
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Justin T. Kiggins
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.0.2
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                26 April 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                BSD-3
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.6
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/ome-zarr"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                ome-zarr
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                Implementation of images in Zarr files.
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                The Open Microscopy Team
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.0.18
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                24 April 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              />
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.6
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/napari-brainreg"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                napari-brainreg
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                Visualise brainreg registration output
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Adam Tyson
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.2.3
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                13 November 2020
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                MIT
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.6
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/napari-itk-io"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                napari-itk-io
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                File IO with itk for napari
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Matt McCormick
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.1.0
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                28 April 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                Apache Software License 2.0
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.6
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/napari-imc"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                napari-imc
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                Imaging Mass Cytometry (IMC) file type support for napari
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Jonas Windhager
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.5.3
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                15 March 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                MIT
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.7
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/napari-mri"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                napari-mri
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                A simple plugin to use with napari for 3D-viewing of                  Magnetic Resonance Imaging file formats
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                SUSMITA SAHA
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.1.0
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                20 March 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              />
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.7
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/napari-properties-viewer"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                napari-properties-viewer
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                A viewer for napari layer properties
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Kevin Yamauchi
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.0.1
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                28 April 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                BSD-3
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.6
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/napari-medical-image-formats"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                napari-medical-image-formats
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                A Plugin in order to read medical image formats such as DICOM and NIfTI
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Marc Boucsein, Marc Buckmakowski
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.3.6
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                24 April 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                BSD-3
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.7
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/misic-napari-plugin"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                misic-napari-plugin
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                segmentation of bacteria
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                lcb-iam-pswap-le
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.1.1
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                09 April 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                MIT
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.6
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/napari-dv"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                napari-dv
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                Deltavision/MRC file reader for napari
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Talley Lambert
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.2.5
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                27 January 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                MIT
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.6
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/nd2-dask"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                nd2-dask
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                Plugin to load nd2 data into napari
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Draga Doncila Pop
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.0.5
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                03 February 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                BSD-3
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.6
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/napari-czifile2"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                napari-czifile2
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                Carl Zeiss Image (.czi) file support for napari
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Jonas Windhager
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.2.1
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                17 April 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                MIT
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.7
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/napari-dzi-zarr"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                napari-dzi-zarr
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                An experimental plugin for viewing Deep Zoom Images (DZI) with napari and zarr.
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Trevor Manz
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.1.2
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                06 April 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                BSD-3
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.6
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/napari-animation"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                napari-animation
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                A plugin to make animations with napari
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Nicholas Sofroniew, Alister Burt, Guillaume Witz, Faris Abouakil, Talley Lambert
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.0.1rc5
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                03 May 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                BSD 3-Clause
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.7
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/napari-minimal-plugin"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                napari-minimal-plugin
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                A minimal plugin
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Manan Lalit
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.0.1
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                02 May 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                BSD-3
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.6
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/napari-cellfinder"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                napari-cellfinder
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                Visualise cellfinder results with napari
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Adam Tyson
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.2.1
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                14 January 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                MIT
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.6
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/napari-nikon-nd2"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                napari-nikon-nd2
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                Opens Nikon ND2 files into napari.
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Chris Wood
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.1.3
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                03 February 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                Apache Software License 2.0
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.6
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/napari-em-reader"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                napari-em-reader
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                A napari plugin to read .em files
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Lorenzo Gaifas
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.1.0
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                23 February 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                BSD-3
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.6
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/elastix-napari"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                elastix-napari
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                A toolbox for rigid and nonrigid registration of images.
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Viktor van der Valk
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.1.3
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                16 April 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                Apache Software License 2.0
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.6
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/PartSeg"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                PartSeg
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                PartSeg is python GUI for bio imaging analysis especially nucleus analysis,
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Grzegorz Bokota
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.13.4
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                17 April 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                BSD-3-Clause
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.7
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/brainglobe-napari-io"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                brainglobe-napari-io
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                Read and write files from the BrainGlobe neuroanatomy suite
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Adam Tyson
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.0.2
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                12 March 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                GPL-3.0
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.6
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/napari-aicsimageio"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                napari-aicsimageio
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                AICSImageIO bindings for napari
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Jackson Maxfield Brown
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.2.0
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                13 December 2020
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                BSD-3-Clause
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.7
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              />
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/napari-lazy-openslide"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                napari-lazy-openslide
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                A plugin to lazily load multiscale whole-slide images with openslide and dask.
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Trevor Manz
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.2.0
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                30 January 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                BSD-3
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.6
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/napari-btrack-reader"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                napari-btrack-reader
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                A plugin to load btrack files
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Alan R. Lowe
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.1.0
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                05 November 2020
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                BSD-3
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.6
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/cellpose-napari"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                cellpose-napari
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                a generalist algorithm for anatomical segmentation
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Carsen Stringer
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.1.3
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                02 May 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                BSD-3
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.6
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                All
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
-      <a
-        class="col-span-2 screen-875:col-start-2 screen-875:col-span-2 screen-1425:col-start-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
-        href="/plugins/brainreg-segment"
-      >
-        <article
-          class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-napari-2 screen-1425:grid-cols-napari-3"
-          data-testid="searchResult"
-        >
-          <div
-            class="screen-1425:col-span-2 flex flex-col justify-between"
-          >
-            <div>
-              <h4
-                class="inline font-bold text-lg"
-                data-testid="searchResultName"
-              >
-                brainreg-segment
-              </h4>
-              <p
-                class="mt-2"
-                data-testid="searchResultSummary"
-              >
-                Manual segmentation of 3D brain structures in a common anatomical space
-              </p>
-            </div>
-            <ul
-              class="mt-5 text-xs"
-            >
-              <li
-                class="my-2 font-bold"
-                data-testid="searchResultAuthor"
-              >
-                Adam Tyson, Horst Obenhaus
-              </li>
-            </ul>
-          </div>
-          <ul
-            class="mt-4 screen-600:m-0 space-y-1 text-sm"
-          >
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                0.2.7
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                release date: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                26 April 2021
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                license: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              />
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                Python version: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                &gt;=3.7
-              </span>
-            </li>
-            <li
-              class="grid grid-cols-[auto,1fr]"
-            >
-              <h5
-                class="inline whitespace-nowrap"
-              >
-                operating system: 
-              </h5>
-              <span
-                class="font-bold ml-1"
-              >
-                Windows 10, Linux
-              </span>
-            </li>
-          </ul>
-        </article>
-      </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/napari-compressed-labels-io"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    napari-compressed-labels-io
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    Plugin exploring different options for reading and writing compressed and portable labels layers in napari.
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Draga Doncila
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.0.2
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    03 March 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    MIT
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.6
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/affinder"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    affinder
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    Quickly find the affine matrix mapping one image to another using manual correspondence points annotation
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Juan Nunez-Iglesias
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.2.0
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    24 March 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    BSD-3
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.7
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/napping"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    napping
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    Control point mapping and coordination transformation using napari
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Jonas Windhager
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.1.7
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    15 March 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    MIT
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.7
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/napari-console"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    napari-console
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    A plugin that adds a console to napari
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Nicholas Sofroniew
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.0.3
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    14 February 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    BSD-3
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.7
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/napari-hdf5-labels-io"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    napari-hdf5-labels-io
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    Napari plugin to store set of layers in a .h5 file. Label layer are stored in a sparse representation
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Duway Nicolas Lesmes Leon
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.2.dev13
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    07 April 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    GNU GPL v3.0
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &lt;3.9
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/PlatyMatch"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    PlatyMatch
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    \`PlatyMatch\` allows registration of volumetric images of embryos by establishing correspondences between cells
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Manan Lalit
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.0.2
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    03 May 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    BSD-3
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.6
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/napari_video"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    napari_video
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    napari plugin for reading videos.
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Jan Clemens
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.2.6
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    16 March 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  />
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.6
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  />
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/cellfinder-napari"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    cellfinder-napari
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    Efficient cell detection in large images
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Adam Tyson
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.0.9
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    27 April 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    GPL-3.0
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.6
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/napari-svg"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    napari-svg
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    A plugin for reading and writing svg files with napari
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Nicholas Sofroniew
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.1.5
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    01 May 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    BSD-3
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.7
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/napari-yapic-prediction"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    napari-yapic-prediction
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    Napari widget plugin to perform yapic model segmentation prediction in the napari window
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Duway Nicolas Lesmes Leon
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.1.dev78
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    21 April 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    GNU GPL v3.0
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.6
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/napari-demo"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    napari-demo
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    demo plugin
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Ziyang Liu
+                  </li>
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Justin T. Kiggins
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.0.2
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    26 April 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    BSD-3
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.6
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/ome-zarr"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    ome-zarr
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    Implementation of images in Zarr files.
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    The Open Microscopy Team
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.0.18
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    24 April 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  />
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.6
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/napari-brainreg"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    napari-brainreg
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    Visualise brainreg registration output
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Adam Tyson
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.2.3
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    13 November 2020
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    MIT
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.6
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/napari-itk-io"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    napari-itk-io
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    File IO with itk for napari
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Matt McCormick
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.1.0
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    28 April 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    Apache Software License 2.0
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.6
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/napari-imc"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    napari-imc
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    Imaging Mass Cytometry (IMC) file type support for napari
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Jonas Windhager
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.5.3
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    15 March 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    MIT
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.7
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/napari-mri"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    napari-mri
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    A simple plugin to use with napari for 3D-viewing of                  Magnetic Resonance Imaging file formats
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    SUSMITA SAHA
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.1.0
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    20 March 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  />
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.7
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/napari-properties-viewer"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    napari-properties-viewer
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    A viewer for napari layer properties
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Kevin Yamauchi
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.0.1
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    28 April 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    BSD-3
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.6
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/napari-medical-image-formats"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    napari-medical-image-formats
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    A Plugin in order to read medical image formats such as DICOM and NIfTI
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Marc Boucsein, Marc Buckmakowski
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.3.6
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    24 April 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    BSD-3
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.7
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/misic-napari-plugin"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    misic-napari-plugin
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    segmentation of bacteria
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    lcb-iam-pswap-le
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.1.1
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    09 April 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    MIT
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.6
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/napari-dv"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    napari-dv
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    Deltavision/MRC file reader for napari
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Talley Lambert
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.2.5
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    27 January 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    MIT
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.6
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/nd2-dask"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    nd2-dask
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    Plugin to load nd2 data into napari
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Draga Doncila Pop
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.0.5
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    03 February 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    BSD-3
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.6
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/napari-czifile2"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    napari-czifile2
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    Carl Zeiss Image (.czi) file support for napari
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Jonas Windhager
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.2.1
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    17 April 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    MIT
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.7
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/napari-dzi-zarr"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    napari-dzi-zarr
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    An experimental plugin for viewing Deep Zoom Images (DZI) with napari and zarr.
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Trevor Manz
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.1.2
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    06 April 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    BSD-3
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.6
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/napari-animation"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    napari-animation
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    A plugin to make animations with napari
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Nicholas Sofroniew, Alister Burt, Guillaume Witz, Faris Abouakil, Talley Lambert
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.0.1rc5
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    03 May 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    BSD 3-Clause
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.7
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/napari-minimal-plugin"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    napari-minimal-plugin
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    A minimal plugin
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Manan Lalit
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.0.1
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    02 May 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    BSD-3
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.6
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/napari-cellfinder"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    napari-cellfinder
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    Visualise cellfinder results with napari
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Adam Tyson
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.2.1
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    14 January 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    MIT
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.6
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/napari-nikon-nd2"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    napari-nikon-nd2
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    Opens Nikon ND2 files into napari.
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Chris Wood
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.1.3
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    03 February 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    Apache Software License 2.0
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.6
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/napari-em-reader"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    napari-em-reader
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    A napari plugin to read .em files
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Lorenzo Gaifas
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.1.0
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    23 February 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    BSD-3
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.6
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/elastix-napari"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    elastix-napari
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    A toolbox for rigid and nonrigid registration of images.
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Viktor van der Valk
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.1.3
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    16 April 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    Apache Software License 2.0
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.6
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/PartSeg"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    PartSeg
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    PartSeg is python GUI for bio imaging analysis especially nucleus analysis,
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Grzegorz Bokota
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.13.4
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    17 April 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    BSD-3-Clause
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.7
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/brainglobe-napari-io"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    brainglobe-napari-io
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    Read and write files from the BrainGlobe neuroanatomy suite
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Adam Tyson
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.0.2
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    12 March 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    GPL-3.0
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.6
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/napari-aicsimageio"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    napari-aicsimageio
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    AICSImageIO bindings for napari
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Jackson Maxfield Brown
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.2.0
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    13 December 2020
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    BSD-3-Clause
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.7
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  />
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/napari-lazy-openslide"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    napari-lazy-openslide
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    A plugin to lazily load multiscale whole-slide images with openslide and dask.
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Trevor Manz
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.2.0
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    30 January 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    BSD-3
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.6
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/napari-btrack-reader"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    napari-btrack-reader
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    A plugin to load btrack files
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Alan R. Lowe
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.1.0
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    05 November 2020
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    BSD-3
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.6
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/cellpose-napari"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    cellpose-napari
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    a generalist algorithm for anatomical segmentation
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Carsen Stringer
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.1.3
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    02 May 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    BSD-3
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.6
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    All
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+          <a
+            class="col-span-2 screen-1425:col-span-3 py-5 border-t-2 border-black hover:bg-napari-hover-gray"
+            href="/plugins/brainreg-segment"
+          >
+            <article
+              class="grid gap-x-6 md:gap-x-12 screen-600:grid-cols-2 screen-1425:grid-cols-napari-3"
+              data-testid="searchResult"
+            >
+              <div
+                class="screen-1425:col-span-2 flex flex-col justify-between"
+              >
+                <div>
+                  <h4
+                    class="inline font-bold text-lg"
+                    data-testid="searchResultName"
+                  >
+                    brainreg-segment
+                  </h4>
+                  <p
+                    class="mt-2"
+                    data-testid="searchResultSummary"
+                  >
+                    Manual segmentation of 3D brain structures in a common anatomical space
+                  </p>
+                </div>
+                <ul
+                  class="mt-5 text-xs"
+                >
+                  <li
+                    class="my-2 font-bold"
+                    data-testid="searchResultAuthor"
+                  >
+                    Adam Tyson, Horst Obenhaus
+                  </li>
+                </ul>
+              </div>
+              <ul
+                class="mt-4 screen-600:m-0 space-y-1 text-sm"
+              >
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    0.2.7
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    release date: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    26 April 2021
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    license: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  />
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    Python version: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    &gt;=3.7
+                  </span>
+                </li>
+                <li
+                  class="grid grid-cols-[auto,1fr]"
+                >
+                  <h5
+                    class="inline whitespace-nowrap"
+                  >
+                    operating system: 
+                  </h5>
+                  <span
+                    class="font-bold ml-1"
+                  >
+                    Windows 10, Linux
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </a>
+        </div>
+      </section>
     </div>
   </div>
   <div

--- a/client/src/global.scss
+++ b/client/src/global.scss
@@ -9,13 +9,12 @@ html {
   @apply overflow-y-scroll;
 
   /*
-    Use viewport width for fluid typography. This value is calculated based
-    on the ratio between the starting font size and the minimum content width to ensure proper scaling.
-    The minimum font size is from the design spec, and the maximum font size
-    is set to the user's preferred font size set by their browser settings.
+    Use viewport width for fluid typography. The minimum font size is from the
+    design spec, and the maximum font size is set to the user's preferred font
+    size set by their browser settings.
 
-    Texts, margins, and paddings should use the `text-<size>` Tailwind classes or rem / em units in
-    CSS to ensure the font size is more accessible.
+    Texts, margins, and paddings should use the `text-<size>` Tailwind classes
+    or rem / em units in CSS to ensure the font size is more accessible.
 
     https://blog.logrocket.com/the-elements-of-responsive-typography
   */

--- a/client/src/global.scss
+++ b/client/src/global.scss
@@ -1,5 +1,4 @@
-$min-font-size: 11px;
-$min-content: 300px; // smallest breakpoint in the theme
+@import '@/utils/styles';
 
 html {
   /*
@@ -20,11 +19,7 @@ html {
 
     https://blog.logrocket.com/the-elements-of-responsive-typography
   */
-  font-size: clamp(
-    #{$min-font-size},
-    #{$min-font-size / $min-content * 100vw},
-    100%
-  );
+  font-size: viewport-clamp(11px, 100%);
 
   /*
     Use smooth transition when scrolling between different parts of the page.

--- a/client/src/global.scss
+++ b/client/src/global.scss
@@ -22,6 +22,16 @@ html {
   font-size: viewport-clamp(11px, 100%);
 
   /*
+    Awful hack to get clamp resizing working in Safari 14:
+    https://stackoverflow.com/a/65093383
+
+    We need to use a really small value because we want to keep the viewport
+    unit. If we use `0vw` directly, SASS will automatically remove the unit:
+    https://stackoverflow.com/questions/63965489/safari-14-min-max-clamp-not-working-with-vw-and-px-values#comment116930866_65093383
+  */
+  min-height: 0.0001vw;
+
+  /*
     Use smooth transition when scrolling between different parts of the page.
 
     TODO This currently has no support in Safari, so we'll probably have to

--- a/client/src/utils/styles.scss
+++ b/client/src/utils/styles.scss
@@ -3,7 +3,8 @@
 $min-content: strip(theme('screens.screen-300'));
 
 /**
- * Function for clamping a min and max value scaled based on
+ * Function for clamping a min and max value scaled based on the ratio between
+ * the min value and the min content width to ensure proper scaling.
  */
 @function viewport-clamp($min-value, $max-value) {
   $value: clamp(

--- a/client/src/utils/styles.scss
+++ b/client/src/utils/styles.scss
@@ -1,0 +1,16 @@
+/* stylelint-disable at-rule-no-unknown */
+
+$min-content: strip(theme('screens.screen-300'));
+
+/**
+ * Function for clamping a min and max value scaled based on
+ */
+@function viewport-clamp($min-value, $max-value) {
+  $value: clamp(
+    #{$min-value},
+    calc(strip(#{$min-value}) / #{$min-content} * 100vw),
+    #{$max-value}
+  );
+
+  @return $value;
+}

--- a/client/src/utils/styles.scss
+++ b/client/src/utils/styles.scss
@@ -14,3 +14,9 @@ $min-content: strip(theme('screens.screen-300'));
 
   @return $value;
 }
+/**
+ * Function for calculating the rem value for another value.
+ */
+@function calculate-rem($value) {
+  @return $value / 16px * 1rem;
+}

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -8393,6 +8393,14 @@ postcss-sorting@^5.0.1:
     lodash "^4.17.14"
     postcss "^7.0.17"
 
+postcss-strip-units@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-strip-units/-/postcss-strip-units-2.0.1.tgz#53d279b348f385f51db674b6e1f994617ba195ad"
+  integrity sha512-2SVcTibIombPsjhKym8z2pFbsIH28TDvXvyUPyvTUr9d32cn8mg2mviuNgkdXxnPtqD6VHWBxSGSkUCcduikPA==
+  dependencies:
+    postcss "^6.0.14"
+    reduce-function-call "^1.0.1"
+
 postcss-syntax@^0.36.2:
   version "0.36.2"
   resolved "https://registry.yarnpkg.com/postcss-syntax/-/postcss-syntax-0.36.2.tgz#f08578c7d95834574e5593a82dfbfa8afae3b51c"
@@ -8427,7 +8435,7 @@ postcss@8.1.7:
     nanoid "^3.1.16"
     source-map "^0.6.1"
 
-postcss@^6.0.1, postcss@^6.0.9:
+postcss@^6.0.1, postcss@^6.0.14, postcss@^6.0.9:
   version "6.0.23"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
   integrity sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==
@@ -8950,6 +8958,13 @@ reduce-css-calc@^2.1.8:
   dependencies:
     css-unit-converter "^1.1.1"
     postcss-value-parser "^3.3.0"
+
+reduce-function-call@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.3.tgz#60350f7fb252c0a67eb10fd4694d16909971300f"
+  integrity sha512-Hl/tuV2VDgWgCSEeWMLwxLZqX7OK59eU1guxXsRKTAyeYimivsKdtcV4fu3r710tpG5GmDKDhQ0HSZLExnNmyQ==
+  dependencies:
+    balanced-match "^1.0.0"
 
 refractor@^3.2.0:
   version "3.3.1"


### PR DESCRIPTION
## Description

This PR includes a few fixes for styling issues on the plugin search page.

## Changes

- Viewport clamping moved to its own function (thank you @kne42 for the initial code!)
- Fix issue with clamping on Safari: https://stackoverflow.com/a/65093383
- Add explicit height to logo to reduce unnecessary margins above and below the logo
- Fix list spacing for last item on landing page
- Fix grid layout weird grid layout glitch issue
- Adds plugin count to `Browse plugins` title

- Divider between filter and sort

## Demos

Demo Link: https://napari-hub-filter-ui-state-demo.vercel.app/

### Explicit Logo Height

The previous fix was adding `height: 100%`, but this has unintended issues on Safari.

#### Before

![image](https://user-images.githubusercontent.com/2176050/120850327-2088c800-c52c-11eb-9d8e-369a6d60d6da.png)

#### After

![image](https://user-images.githubusercontent.com/2176050/120850409-401ff080-c52c-11eb-852e-9b08f85450d2.png)

### Landing Page List Item Fix

The spacing for the last item was too long compared to the rest of the list items.

#### Before

![image](https://user-images.githubusercontent.com/2176050/120850472-5928a180-c52c-11eb-8513-59f78675990d.png)

#### After

![image](https://user-images.githubusercontent.com/2176050/120850514-6776bd80-c52c-11eb-82d7-3ede0ede6b04.png)


### Grid Layout Glitch Fix

#### Before

https://user-images.githubusercontent.com/2176050/120850221-fd5e1880-c52b-11eb-8b5f-099f7c9922c6.mp4

#### After

https://user-images.githubusercontent.com/2176050/120850224-fe8f4580-c52b-11eb-839a-4b5d5d35e3e4.mp4

