### PR TITLE
Render GitHub videos in Markdown

### DIFF
--- a/client/src/components/common/Markdown/Markdown.test.tsx
+++ b/client/src/components/common/Markdown/Markdown.test.tsx
@@ -1,8 +1,12 @@
-import { render } from '@testing-library/react';
+import { cleanup, render } from '@testing-library/react';
 
 import { Markdown } from './Markdown';
 
 describe('<Markdown />', () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
   it('should match snapshot', () => {
     const { asFragment } = render(<Markdown># Hello World</Markdown>);
     expect(asFragment()).toMatchSnapshot();
@@ -16,27 +20,39 @@ describe('<Markdown />', () => {
   });
 
   it('should render GitHub videos in markdown', () => {
-    const { queryByTestId } = render(
-      <Markdown>
-        https://user-images.githubusercontent.com/example.mp4
-      </Markdown>,
-    );
-    expect(queryByTestId('markdownVideo')).toBeTruthy();
+    const testCases = [
+      'https://user-images.githubusercontent.com/example.mp4',
+      'https://user-images.githubusercontent.com/example.mov',
+    ];
+
+    testCases.forEach((input) => {
+      const { queryByTestId } = render(<Markdown>{input}</Markdown>);
+      expect(queryByTestId('markdownVideo')).toBeTruthy();
+      cleanup();
+    });
   });
 
   it('should not render non-GitHub videos in markdown', () => {
-    const { queryByTestId } = render(
-      <Markdown>https://example.com/example.mp4</Markdown>,
-    );
-    expect(queryByTestId('markdownVideo')).toBeFalsy();
+    const testCases = [
+      'https://example.com/example.mp4',
+      'https://example.com/example.mov',
+    ];
+
+    testCases.forEach((input) => {
+      const { queryByTestId } = render(<Markdown>{input}</Markdown>);
+      expect(queryByTestId('markdownVideo')).toBeFalsy();
+    });
   });
 
   it('should not render GitHub videos in paragraphs', () => {
-    const { queryByTestId } = render(
-      <Markdown>
-        Foo bar https://user-images.githubusercontent.com/example.mp4
-      </Markdown>,
-    );
-    expect(queryByTestId('markdownVideo')).toBeFalsy();
+    const testCases = [
+      'foo bar https://user-images.githubusercontent.com/example.mp4',
+      'https://user-images.githubusercontent.com/example.mov hello world',
+    ];
+
+    testCases.forEach((input) => {
+      const { queryByTestId } = render(<Markdown>{input}</Markdown>);
+      expect(queryByTestId('markdownVideo')).toBeFalsy();
+    });
   });
 });

--- a/client/src/components/common/Markdown/Markdown.test.tsx
+++ b/client/src/components/common/Markdown/Markdown.test.tsx
@@ -14,4 +14,20 @@ describe('<Markdown />', () => {
     );
     expect(queryByText('Hello World')).toBeFalsy();
   });
+
+  it('should render GitHub videos in markdown', () => {
+    const { queryByTestId } = render(
+      <Markdown>
+        https://user-images.githubusercontent.com/example.mp4
+      </Markdown>,
+    );
+    expect(queryByTestId('markdownVideo')).toBeTruthy();
+  });
+
+  it('should not render non-GitHub videos in markdown', () => {
+    const { queryByTestId } = render(
+      <Markdown>https://example.com/example.mp4</Markdown>,
+    );
+    expect(queryByTestId('markdownVideo')).toBeFalsy();
+  });
 });

--- a/client/src/components/common/Markdown/Markdown.test.tsx
+++ b/client/src/components/common/Markdown/Markdown.test.tsx
@@ -3,10 +3,6 @@ import { cleanup, render } from '@testing-library/react';
 import { Markdown } from './Markdown';
 
 describe('<Markdown />', () => {
-  beforeEach(() => {
-    cleanup();
-  });
-
   it('should match snapshot', () => {
     const { asFragment } = render(<Markdown># Hello World</Markdown>);
     expect(asFragment()).toMatchSnapshot();

--- a/client/src/components/common/Markdown/Markdown.test.tsx
+++ b/client/src/components/common/Markdown/Markdown.test.tsx
@@ -30,4 +30,13 @@ describe('<Markdown />', () => {
     );
     expect(queryByTestId('markdownVideo')).toBeFalsy();
   });
+
+  it('should not render GitHub videos in paragraphs', () => {
+    const { queryByTestId } = render(
+      <Markdown>
+        Foo bar https://user-images.githubusercontent.com/example.mp4
+      </Markdown>,
+    );
+    expect(queryByTestId('markdownVideo')).toBeFalsy();
+  });
 });

--- a/client/src/components/common/Markdown/Markdown.tsx
+++ b/client/src/components/common/Markdown/Markdown.tsx
@@ -6,6 +6,7 @@ import removeComments from 'remark-remove-comments';
 
 import styles from './Markdown.module.scss';
 import { MarkdownCode } from './MarkdownCode';
+import { MarkdownParagraph } from './MarkdownParagraph';
 import { MarkdownTOC } from './MarkdownTOC';
 
 interface Props {
@@ -38,6 +39,7 @@ const REHYPE_PLUGINS = [
 export function Markdown({ className, children, disableHeader }: Props) {
   const components: TransformOptions['components'] = {
     code: MarkdownCode,
+    p: MarkdownParagraph,
   };
 
   if (disableHeader) {

--- a/client/src/components/common/Markdown/MarkdownParagraph.tsx
+++ b/client/src/components/common/Markdown/MarkdownParagraph.tsx
@@ -7,7 +7,7 @@ interface Props {
   children?: ReactNode;
 }
 
-const ALLOWED_VIDEO_REGEX = /https:\/\/(user-images\.githubusercontent)\.com.*mp4/;
+const ALLOWED_VIDEO_REGEX = /https:\/\/(user-images\.githubusercontent)\.com.*(mp4|mov)/;
 
 /**
  * Component for rendering a paragraph element, or a video element if the
@@ -33,9 +33,12 @@ export function MarkdownParagraph({ className, children }: Props) {
     if (match) {
       result = (
         // eslint-disable-next-line jsx-a11y/media-has-caption
-        <video data-testid="markdownVideo" className={className} controls>
-          <source type="video/mp4" src={href} />
-        </video>
+        <video
+          data-testid="markdownVideo"
+          className={className}
+          controls
+          src={href}
+        />
       );
     }
   }

--- a/client/src/components/common/Markdown/MarkdownParagraph.tsx
+++ b/client/src/components/common/Markdown/MarkdownParagraph.tsx
@@ -1,0 +1,44 @@
+import { ReactNode } from 'react';
+
+import { isReactElement } from '@/utils';
+
+interface Props {
+  className?: string;
+  children?: ReactNode;
+}
+
+const ALLOWED_VIDEO_REGEX = /https:\/\/(user-images\.githubusercontent)\.com.*mp4/;
+
+/**
+ * Component for rendering a paragraph element, or a video element if the
+ * content is a GitHub video link.
+ */
+export function MarkdownParagraph({ className, children }: Props) {
+  let result: ReactNode;
+
+  if (
+    Array.isArray(children) &&
+    // GitHub only renders video links as videos if it's the only child in the
+    // paragraph AST. To be consistent with this, we need to check that the link
+    // node is the only node.
+    children.length === 1 &&
+    isReactElement(children[0]) &&
+    // Check that node is a link
+    children[0].type === 'a'
+  ) {
+    const [child] = children;
+    const { href } = child.props as { href: string };
+    const match = ALLOWED_VIDEO_REGEX.exec(href);
+
+    if (match) {
+      result = (
+        // eslint-disable-next-line jsx-a11y/media-has-caption
+        <video data-testid="markdownVideo" className={className} controls>
+          <source type="video/mp4" src={href} />
+        </video>
+      );
+    }
+  }
+
+  return result ?? <p className={className}>{children}</p>;
+}

--- a/client/src/utils/index.ts
+++ b/client/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './format';
 export * from './logger';
 export * from './performance';
+export * from './react';

--- a/client/src/utils/react.test.tsx
+++ b/client/src/utils/react.test.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react';
+
+import { isReactElement } from './react';
+
+describe('isReactElement()', () => {
+  it('should return true for react element', () => {
+    const testCases: ReactNode[] = [
+      <h1>hello</h1>,
+      <p>world</p>,
+      <span>foobar</span>,
+      <>
+        <p>hello</p>
+      </>,
+    ];
+
+    testCases.forEach((input) => expect(isReactElement(input)).toBeTruthy());
+  });
+
+  it('shoud return false for non-react element', () => {
+    const testCases: ReactNode[] = [[], 'hello', null, false];
+    testCases.forEach((input) => expect(isReactElement(input)).toBeFalsy());
+  });
+});

--- a/client/src/utils/react.ts
+++ b/client/src/utils/react.ts
@@ -1,0 +1,14 @@
+import { ReactNode } from 'react';
+import { ReactElement } from 'react-markdown';
+
+/**
+ * Checks if a React node is an element. An element is an instantiated
+ * component.
+ *
+ * @param node The React node
+ * @returns True if node is an element
+ */
+export function isReactElement(node: ReactNode): node is ReactElement {
+  const element = node as ReactElement | null | undefined;
+  return !!(element?.type && element?.props);
+}


### PR DESCRIPTION
## Description

This PR sets up rendering videos from GitHub in Markdown. This works by using a custom paragraph component that renders a video element only when the content is a link.

## Demos

The demo links below show different use cases for videos:

1. Non-GitHub videos: These should render as links
2. GitHub videos: These should render as `<video>` elements
3. GitHub videos in paragraphs: These should render as links to be consistent with GitHub

### [Markdown in GitHub](https://github.com/chanzuckerberg/napari-hub/blob/jeremy/markdown-video-demo/client/README.md)

![image](https://user-images.githubusercontent.com/2176050/121446142-c468de00-c947-11eb-8fab-c897efd9dcec.png)

### [Markdown in napari hub](https://napari-hub-render-markdown-video-demo.vercel.app/plugins/napari-compressed-labels-io)

![image](https://user-images.githubusercontent.com/2176050/121445935-53c1c180-c947-11eb-9007-61bb0bdc52c4.png)
