### PR TITLE
relax github url matching to also use other names than "source code"

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -16,7 +16,7 @@ on:
 
 defaults:
   run:
-    working-directory: /
+    working-directory: backend/
 
 jobs:
   # Runs pytest for backend code
@@ -28,5 +28,11 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
 
-      - name: pytest
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+
+      - name: Run tests
         run : pytest

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,0 +1,32 @@
+# Workflow for running backend tests for PRs and main branch
+
+name: Backend Tests
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'backend/**'
+  pull_request:
+    branches:
+      - '**'
+    paths:
+      - 'backend/**'
+
+defaults:
+  run:
+    working-directory: /
+
+jobs:
+  # Runs pytest for backend code
+  tests:
+    name: pytest
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+
+      - name: pytest
+        run : pytest

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -78,6 +78,9 @@ jobs:
           - name: tsc
             run: yarn type-check
 
+          - name: pytest
+            run: pytest
+
   # Run E2E tests on different browsers.
   e2e:
     needs: tests

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -78,9 +78,6 @@ jobs:
           - name: tsc
             run: yarn type-check
 
-          - name: pytest
-            run: pytest
-
   # Run E2E tests on different browsers.
   e2e:
     needs: tests

--- a/backend/_tests/test_lambda.py
+++ b/backend/_tests/test_lambda.py
@@ -134,8 +134,11 @@ def test_github_get_url():
     plugins = {"info": {"project_urls": {"Source Code": "test1"}}}
     assert("test1" == get_download_url(plugins))
 
-    plugins = {"info": {"project_urls": {"Random": "https://"}}}
+    plugins = {"info": {"project_urls": {"Random": "https://random.com"}}}
     assert(get_download_url(plugins) is None)
 
-    plugins = {"info": {"project_urls": {"Random": "https://github.com/napari/napari/issues"}}}
-    assert("https://github.com/napari/napari" == get_download_url(plugins))
+    plugins = {"info": {"project_urls": {"Random": "https://github.com/org"}}}
+    assert(get_download_url(plugins) is None)
+
+    plugins = {"info": {"project_urls": {"Random": "https://github.com/org/repo/random"}}}
+    assert("https://github.com/org/repo" == get_download_url(plugins))

--- a/backend/_tests/test_lambda.py
+++ b/backend/_tests/test_lambda.py
@@ -1,9 +1,10 @@
 from unittest import mock
-import importlib
 import requests
 from requests.exceptions import HTTPError
 
-api = importlib.import_module("backend.lambda")
+from backend.napari import get_plugin
+from backend.napari import get_plugins
+from backend.napari import get_download_url
 
 
 class FakeResponse:
@@ -98,7 +99,7 @@ plugin = """
     'requests.get', return_value=FakeResponse(data=plugin_list)
 )
 def test_get_plugins(mock_get):
-    result = api.get_plugins(None)
+    result = get_plugins()
     assert len(result) == 2
     assert result['package1'] == "0.2.7"
     assert result['package2'] == "0.1.0"
@@ -107,7 +108,7 @@ def test_get_plugins(mock_get):
     'requests.get', return_value=FakeResponse(data=plugin)
 )
 def test_get_plugin(mock_get):
-    result = api.get_plugin("test")
+    result = get_plugin("test")
     assert(result["name"] == "test")
     assert(result["summary"] == "A test plugin")
     assert(result["description"] == "description")
@@ -126,4 +127,15 @@ def test_get_plugin(mock_get):
     assert(result["support"] == "")
     assert(result["report_issues"] == "")
     assert(result["twitter"] == "")
-    assert(result["code_repository"] == "")
+    assert(result["code_repository"] == "https://github.com/test/test")
+
+
+def test_github_get_url():
+    plugins = {"info": {"project_urls": {"Source Code": "test1"}}}
+    assert("test1" == get_download_url(plugins))
+
+    plugins = {"info": {"project_urls": {"Random": "https://"}}}
+    assert(get_download_url(plugins) is None)
+
+    plugins = {"info": {"project_urls": {"Random": "https://github.com/napari/napari/issues"}}}
+    assert("https://github.com/napari/napari" == get_download_url(plugins))

--- a/backend/napari.py
+++ b/backend/napari.py
@@ -160,6 +160,27 @@ def get_extra_metadata(download_url: str) -> dict:
     return extra_metadata
 
 
+def get_download_url(plugin: dict) -> [str, None]:
+    """
+    Get download url for github.
+
+    :param plugin: plugin metadata dictionary
+    :return: download url if one is available, else None
+    """
+    project_urls = get_attribute(plugin, ["info", "project_urls"])
+    if project_urls:
+        source_code_url = get_attribute(project_urls, ["Source Code"])
+        if source_code_url:
+            return source_code_url
+        elif isinstance(project_urls, dict):
+            for key, url in project_urls.items():
+                if url.startswith("https://github.com"):
+                    return url
+            return None
+    else:
+        return None
+
+
 def format_plugin(plugin: dict) -> dict:
     """
     Format the plugin dictionary to extra relevant information.
@@ -169,7 +190,7 @@ def format_plugin(plugin: dict) -> dict:
     """
     version = get_attribute(plugin, ["info", "version"])
 
-    download_url = get_attribute(plugin, ["info", "project_urls", "Source Code"])
+    download_url = get_download_url(plugin)
 
     extra_metadata = {}
     project_urls = {}

--- a/backend/napari.py
+++ b/backend/napari.py
@@ -38,7 +38,7 @@ index_subset = {'name', 'summary', 'description', 'description_content_type',
 s3 = boto3.resource('s3', endpoint_url=endpoint_url)
 s3_client = boto3.client("s3", endpoint_url=endpoint_url)
 cache_ttl = timedelta(minutes=cache_ttl)
-
+github_pattern = re.compile("https://github\\.com/([^/]+)/([^/]+)")
 
 app = Flask(__name__)
 
@@ -175,7 +175,7 @@ def get_download_url(plugin: dict) -> [str, None]:
         elif isinstance(project_urls, dict):
             for key, url in project_urls.items():
                 if url.startswith("https://github.com"):
-                    return url
+                    return github_pattern.match(url).group(0)
     return None
 
 

--- a/backend/napari.py
+++ b/backend/napari.py
@@ -175,7 +175,9 @@ def get_download_url(plugin: dict) -> [str, None]:
         elif isinstance(project_urls, dict):
             for key, url in project_urls.items():
                 if url.startswith("https://github.com"):
-                    return github_pattern.match(url).group(0)
+                    match = github_pattern.match(url)
+                    if match:
+                        return github_pattern.match(url).group(0)
     return None
 
 

--- a/backend/napari.py
+++ b/backend/napari.py
@@ -176,9 +176,7 @@ def get_download_url(plugin: dict) -> [str, None]:
             for key, url in project_urls.items():
                 if url.startswith("https://github.com"):
                     return url
-            return None
-    else:
-        return None
+    return None
 
 
 def format_plugin(plugin: dict) -> dict:


### PR DESCRIPTION
relaxed the matching pattern for GitHub links to not only use "Souce Code" but also other links, in case people do not register GitHub link in that tag.

old behavior: https://staging.napari-hub.org/plugins/affinder
new behavior: https://zliu-frontend.dev.imaging.cziscience.com/plugins/affinder