### PR TITLE
Fix Plausible not working on staging / prod deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Deploy Changes
         shell: bash
         env:
+          ENV: prod
           TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
         run: |
           pip install --upgrade pip
@@ -57,9 +58,9 @@ jobs:
       - name: Deploy Changes
         shell: bash
         env:
+          ENV: staging
           TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
         run: |
           pip install --upgrade pip
           pip install -r .happy/requirements.txt
           scripts/happy --profile="" --env staging update staging
-

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -9,6 +9,7 @@ RUN yarn install
 
 # Build for production
 COPY . /app
+ARG ENV
 RUN yarn build
 
 # Application image

--- a/client/next.config.js
+++ b/client/next.config.js
@@ -42,7 +42,9 @@ module.exports = withMDX({
         // Environment variable for enabling plausible analytics. By default,
         // analytics are enabled for production and staging deployments, but can
         // be enabled manually for testing.
-        PLAUSIBLE: ['prod', 'staging'].includes(process.env.ENV),
+        PLAUSIBLE: JSON.stringify(
+          ['prod', 'staging'].includes(process.env.ENV),
+        ),
       }),
     );
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
         - HAPPY_COMMIT
         - HAPPY_BRANCH
         - HAPPY_TAG
+        - ENV
     restart: always
     depends_on:
       - backend


### PR DESCRIPTION
## Description

This should fix Plausible not working in staging / prod. The `ENV` variable is required at build time for the frontend, so we need to pass it in the deployment workflow.