### PR TITLE
ensure python versions are sorted

### DIFF
--- a/client/src/context/search/filter.utils.ts
+++ b/client/src/context/search/filter.utils.ts
@@ -27,7 +27,7 @@ export function getDefaultState(): FilterFormState {
       windows: false,
     },
 
-    pythonVersions: SUPPORTED_PYTHON_VERSIONS.reduce(
+    pythonVersions: SUPPORTED_PYTHON_VERSIONS.sort().reduce(
       (state, version) => set(state, [version], false),
       {} as FilterFormState['pythonVersions'],
     ),


### PR DESCRIPTION
We may want to add a build step to automatically populate `SUPPORTED_PYTHON_VERSIONS`. 

We will need to provide a custom comparison function if we want to non-uniform version numbers (e.g. `3` and `3.9.5`).