### PR TITLE
Plugin name filter

### DIFF
--- a/backend/_tests/test_lambda.py
+++ b/backend/_tests/test_lambda.py
@@ -107,7 +107,10 @@ def test_get_plugins(mock_get):
 @mock.patch(
     'requests.get', return_value=FakeResponse(data=plugin)
 )
-def test_get_plugin(mock_get):
+@mock.patch(
+    'backend.napari.get_plugins', return_value={'test': '0.0.1'}
+)
+def test_get_plugin(mock_get, mock_plugins):
     result = get_plugin("test")
     assert(result["name"] == "test")
     assert(result["summary"] == "A test plugin")
@@ -128,6 +131,16 @@ def test_get_plugin(mock_get):
     assert(result["report_issues"] == "")
     assert(result["twitter"] == "")
     assert(result["code_repository"] == "https://github.com/test/test")
+
+
+@mock.patch(
+    'requests.get', return_value=FakeResponse(data=plugin)
+)
+@mock.patch(
+    'backend.napari.get_plugins', return_value={'not_test': '0.0.1'}
+)
+def test_get_invalid_plugin(mock_get, mock_plugins):
+    assert({} == get_plugin("test"))
 
 
 def test_github_get_url():

--- a/backend/napari.py
+++ b/backend/napari.py
@@ -283,13 +283,16 @@ def get_plugin(plugin: str, version: str = None) -> dict:
     :param version: version of the plugin
     :return: plugin metadata dictionary
     """
-    if version is None:
-        # TODO when version is None, how do we get a cached file?
-        url = f"https://pypi.org/pypi/{plugin}/json"
-    else:
-        if cache_available(f'cache/{plugin}/{version}.json', None):
-            return get_cache(f'cache/{plugin}/{version}.json')
-        url = f"https://pypi.org/pypi/{plugin}/{version}/json"
+    plugins = get_plugins()
+    if plugin not in plugins:
+        return {}
+    elif version is None:
+        version = plugins[plugin]
+
+    if cache_available(f'cache/{plugin}/{version}.json', None):
+        return get_cache(f'cache/{plugin}/{version}.json')
+
+    url = f"https://pypi.org/pypi/{plugin}/{version}/json"
     try:
         response = requests.get(url)
         if response.status_code != requests.codes.ok:


### PR DESCRIPTION
Filter out invalid packages from backend

invalid plugin won't show up any more: https://plugin-filter-frontend.dev.imaging.cziscience.com/plugins/napari
compared to https://staging.napari-hub.org/plugins/napari

pending on front end to redirect empty page to 404 page