### PR TITLE
fix footer spacing

### DIFF
--- a/client/src/components/Footer/Footer.tsx
+++ b/client/src/components/Footer/Footer.tsx
@@ -54,6 +54,8 @@ function FooterLinks() {
  *
  * We use margin instead of flex gap because
  * iOS Safari <14.6 does not support it
+ *
+ * TODO: revert to using flex wrap + flex gap when iOS 14.6 isn't so new
  */
 export function Footer() {
   return (
@@ -69,8 +71,11 @@ export function Footer() {
     >
       <div
         className={clsx(
+          // sizing
           'w-full flex-1',
+          // layout
           'flex flex-row items-center justify-start',
+          // spacing
           'mb-6 screen-655:mb-0 screen-655:mr-12',
         )}
       >

--- a/client/src/components/Footer/Footer.tsx
+++ b/client/src/components/Footer/Footer.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { ComponentType } from 'react';
 
 import { Link } from '@/components/common';
@@ -28,7 +29,14 @@ function FooterLinks() {
     <>
       {FOOTER_LINKS.map((item) => (
         <Link
-          className="whitespace-nowrap font-semibold text-sm flex flex-row items-center"
+          className={clsx(
+            // font style
+            'whitespace-nowrap font-semibold text-sm',
+            // alignment if icon present
+            item.icon && 'flex flex-row items-center',
+            // spacing (TODO: replace with flex-gap once iOS 14.6 is old)
+            'mr-6 last:mr-0',
+          )}
           key={item.link}
           href={item.link}
           newTab={item.newTab}
@@ -43,19 +51,37 @@ function FooterLinks() {
 
 /**
  * Footer component has your footer links and icons
+ *
+ * We use margin instead of flex gap because
+ * iOS Safari <14.6 does not support it
  */
 export function Footer() {
   return (
-    <div className="flex flex-row flex-wrap justify-items-center gap-6 bg-napari-primary p-6 screen-495:pl-12">
-      <div className="w-full flex-1 flex flex-row items-center gap-6 justify-start">
+    <div
+      className={clsx(
+        // layout
+        'flex flex-col screen-655:flex-row justify-items-center',
+        // color
+        'bg-napari-primary',
+        // spacing
+        'p-6 screen-495:px-12',
+      )}
+    >
+      <div
+        className={clsx(
+          'w-full flex-1',
+          'flex flex-row items-center justify-start',
+          'mb-6 screen-655:mb-0 screen-655:mr-12',
+        )}
+      >
         <FooterLinks />
       </div>
-      <div className="flex flex-row flex-grow w-min justify-end gap-2">
-        <Link href="https://napari.org" newTab>
+      <div className="flex flex-row flex-grow w-min justify-end self-end">
+        <Link href="https://napari.org" className="mr-2" newTab>
           <NapariLogo className="w-8 h-8" alt="Go to napari main website." />
         </Link>
         <div className="border-r-[1px] border-black" />
-        <Link href="https://chanzuckerberg.com" newTab>
+        <Link href="https://chanzuckerberg.com" className="ml-2" newTab>
           <CZI
             className="w-8 h-8"
             alt="Go to Chan Zuckerberg Initiative main website."

--- a/client/src/components/Footer/__snapshots__/Footer.test.tsx.snap
+++ b/client/src/components/Footer/__snapshots__/Footer.test.tsx.snap
@@ -3,37 +3,37 @@
 exports[`<Footer /> should match snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="flex flex-row flex-wrap justify-items-center gap-6 bg-napari-primary p-6 screen-495:pl-12"
+    class="flex flex-col screen-655:flex-row justify-items-center bg-napari-primary p-6 screen-495:px-12"
   >
     <div
-      class="w-full flex-1 flex flex-row items-center gap-6 justify-start"
+      class="w-full flex-1 flex flex-row items-center justify-start mb-6 screen-655:mb-0 screen-655:mr-12"
     >
       <a
-        class="whitespace-nowrap font-semibold text-sm flex flex-row items-center"
+        class="whitespace-nowrap font-semibold text-sm mr-6 last:mr-0"
         href="/about"
       >
         About
       </a>
       <a
-        class="whitespace-nowrap font-semibold text-sm flex flex-row items-center"
+        class="whitespace-nowrap font-semibold text-sm mr-6 last:mr-0"
         href="/faq"
       >
         FAQ
       </a>
       <a
-        class="whitespace-nowrap font-semibold text-sm flex flex-row items-center"
+        class="whitespace-nowrap font-semibold text-sm mr-6 last:mr-0"
         href="/privacy"
       >
         Privacy policy
       </a>
       <a
-        class="whitespace-nowrap font-semibold text-sm flex flex-row items-center"
+        class="whitespace-nowrap font-semibold text-sm mr-6 last:mr-0"
         href="/contact"
       >
         Contact
       </a>
       <a
-        class="whitespace-nowrap font-semibold text-sm flex flex-row items-center"
+        class="whitespace-nowrap font-semibold text-sm flex flex-row items-center mr-6 last:mr-0"
         href="https://github.com/chanzuckerberg/napari-hub"
         rel="noreferrer"
         target="_blank"
@@ -55,9 +55,10 @@ exports[`<Footer /> should match snapshot 1`] = `
       </a>
     </div>
     <div
-      class="flex flex-row flex-grow w-min justify-end gap-2"
+      class="flex flex-row flex-grow w-min justify-end self-end"
     >
       <a
+        class="mr-2"
         href="https://napari.org"
         rel="noreferrer"
         target="_blank"
@@ -194,6 +195,7 @@ exports[`<Footer /> should match snapshot 1`] = `
         class="border-r-[1px] border-black"
       />
       <a
+        class="ml-2"
         href="https://chanzuckerberg.com"
         rel="noreferrer"
         target="_blank"

--- a/client/src/components/Layout/__snapshots__/Layout.test.tsx.snap
+++ b/client/src/components/Layout/__snapshots__/Layout.test.tsx.snap
@@ -245,37 +245,37 @@ exports[`<Layout /> should match snapshot 1`] = `
       </div>
     </div>
     <div
-      class="flex flex-row flex-wrap justify-items-center gap-6 bg-napari-primary p-6 screen-495:pl-12"
+      class="flex flex-col screen-655:flex-row justify-items-center bg-napari-primary p-6 screen-495:px-12"
     >
       <div
-        class="w-full flex-1 flex flex-row items-center gap-6 justify-start"
+        class="w-full flex-1 flex flex-row items-center justify-start mb-6 screen-655:mb-0 screen-655:mr-12"
       >
         <a
-          class="whitespace-nowrap font-semibold text-sm flex flex-row items-center"
+          class="whitespace-nowrap font-semibold text-sm mr-6 last:mr-0"
           href="/about"
         >
           About
         </a>
         <a
-          class="whitespace-nowrap font-semibold text-sm flex flex-row items-center"
+          class="whitespace-nowrap font-semibold text-sm mr-6 last:mr-0"
           href="/faq"
         >
           FAQ
         </a>
         <a
-          class="whitespace-nowrap font-semibold text-sm flex flex-row items-center"
+          class="whitespace-nowrap font-semibold text-sm mr-6 last:mr-0"
           href="/privacy"
         >
           Privacy policy
         </a>
         <a
-          class="whitespace-nowrap font-semibold text-sm flex flex-row items-center"
+          class="whitespace-nowrap font-semibold text-sm mr-6 last:mr-0"
           href="/contact"
         >
           Contact
         </a>
         <a
-          class="whitespace-nowrap font-semibold text-sm flex flex-row items-center"
+          class="whitespace-nowrap font-semibold text-sm flex flex-row items-center mr-6 last:mr-0"
           href="https://github.com/chanzuckerberg/napari-hub"
           rel="noreferrer"
           target="_blank"
@@ -297,9 +297,10 @@ exports[`<Layout /> should match snapshot 1`] = `
         </a>
       </div>
       <div
-        class="flex flex-row flex-grow w-min justify-end gap-2"
+        class="flex flex-row flex-grow w-min justify-end self-end"
       >
         <a
+          class="mr-2"
           href="https://napari.org"
           rel="noreferrer"
           target="_blank"
@@ -436,6 +437,7 @@ exports[`<Layout /> should match snapshot 1`] = `
           class="border-r-[1px] border-black"
         />
         <a
+          class="ml-2"
           href="https://chanzuckerberg.com"
           rel="noreferrer"
           target="_blank"

--- a/client/src/components/PluginSearch/__snapshots__/PluginSearch.test.tsx.snap
+++ b/client/src/components/PluginSearch/__snapshots__/PluginSearch.test.tsx.snap
@@ -5774,37 +5774,37 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
       </div>
     </div>
     <div
-      class="flex flex-row flex-wrap justify-items-center gap-6 bg-napari-primary p-6 screen-495:pl-12"
+      class="flex flex-col screen-655:flex-row justify-items-center bg-napari-primary p-6 screen-495:px-12"
     >
       <div
-        class="w-full flex-1 flex flex-row items-center gap-6 justify-start"
+        class="w-full flex-1 flex flex-row items-center justify-start mb-6 screen-655:mb-0 screen-655:mr-12"
       >
         <a
-          class="whitespace-nowrap font-semibold text-sm flex flex-row items-center"
+          class="whitespace-nowrap font-semibold text-sm mr-6 last:mr-0"
           href="/about"
         >
           About
         </a>
         <a
-          class="whitespace-nowrap font-semibold text-sm flex flex-row items-center"
+          class="whitespace-nowrap font-semibold text-sm mr-6 last:mr-0"
           href="/faq"
         >
           FAQ
         </a>
         <a
-          class="whitespace-nowrap font-semibold text-sm flex flex-row items-center"
+          class="whitespace-nowrap font-semibold text-sm mr-6 last:mr-0"
           href="/privacy"
         >
           Privacy policy
         </a>
         <a
-          class="whitespace-nowrap font-semibold text-sm flex flex-row items-center"
+          class="whitespace-nowrap font-semibold text-sm mr-6 last:mr-0"
           href="/contact"
         >
           Contact
         </a>
         <a
-          class="whitespace-nowrap font-semibold text-sm flex flex-row items-center"
+          class="whitespace-nowrap font-semibold text-sm flex flex-row items-center mr-6 last:mr-0"
           href="https://github.com/chanzuckerberg/napari-hub"
           rel="noreferrer"
           target="_blank"
@@ -5826,9 +5826,10 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
         </a>
       </div>
       <div
-        class="flex flex-row flex-grow w-min justify-end gap-2"
+        class="flex flex-row flex-grow w-min justify-end self-end"
       >
         <a
+          class="mr-2"
           href="https://napari.org"
           rel="noreferrer"
           target="_blank"
@@ -5965,6 +5966,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
           class="border-r-[1px] border-black"
         />
         <a
+          class="ml-2"
           href="https://chanzuckerberg.com"
           rel="noreferrer"
           target="_blank"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -9481,13 +9481,6 @@ release-zalgo@^1.0.0:
   dependencies:
     es6-error "^4.0.1"
 
-remark-breaks@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/remark-breaks/-/remark-breaks-2.0.2.tgz#55fdec6c7da84f659aa7fdb1aa95b632870cee8d"
-  integrity sha512-LsQnPPQ7Fzp9RTjj4IwdEmjPOr9bxe9zYKWhs9ZQOg9hMg8rOfeeqQ410cvVdIK87Famqza1CKRxNkepp2EvUA==
-  dependencies:
-    unist-util-visit "^2.0.0"
-
 remark-footnotes@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/remark-footnotes/-/remark-footnotes-2.0.0.tgz"


### PR DESCRIPTION
fix footer spacing on iOS devices since <14.6 does not support flex gap. we can revert to flex wrap + flex gap in maybe a year or so once 14.6 isn't so new

also fixes the footer's right margin size

includes some change to yarn.lock, not really sure why but git insisted on it

[relevant issue](https://airtable.com/tblNxANme1LbVQqq1/viwISga6FERUatih1/recJEqrx8ycySH9v5?blocks=hide)

https://user-images.githubusercontent.com/29165011/123176181-da8e9800-d437-11eb-8e0a-f57f4fdf4a6e.mov

