### PR TITLE
make accordion divider not disappear on expansion

### DIFF
--- a/client/src/components/common/Accordion/Accordian.module.scss
+++ b/client/src/components/common/Accordion/Accordian.module.scss
@@ -9,6 +9,12 @@
     opacity: 1;
   }
 
+  &.expanded + & {
+    &::before {
+      display: initial;
+    }
+  }
+
   &::before {
     background-color: #000;
   }


### PR DESCRIPTION
previously, the divider of the next accordion would disappear when the previous accordion was expanded

special thanks to @codemonkey800 for deep diving into the material ui codebase because this was really unintuitive to solve :)

![Screen Shot 2021-06-24 at 3 44 29 PM](https://user-images.githubusercontent.com/29165011/123341720-4f7ad400-d503-11eb-9497-8004615268e4.png)
![Screen Shot 2021-06-24 at 3 44 38 PM](https://user-images.githubusercontent.com/29165011/123341727-5275c480-d503-11eb-87a7-a858d294076c.png)
