### PR TITLE
Remove dev status filter

### DIFF
--- a/client/src/components/PluginSearch/PluginFilterByForm.tsx
+++ b/client/src/components/PluginSearch/PluginFilterByForm.tsx
@@ -35,11 +35,12 @@ function FilterForm() {
       state: filter?.state.operatingSystems,
       setState: filter?.setOperatingSystem,
     },
-    {
-      title: 'Development status',
-      state: filter?.state.developmentStatus,
-      setState: filter?.setDevelopmentStatus,
-    },
+    // TODO Uncomment when we figure out what to do with the dev status filter
+    // {
+    //   title: 'Development status',
+    //   state: filter?.state.developmentStatus,
+    //   setState: filter?.setDevelopmentStatus,
+    // },
     {
       title: 'License',
       state: filter?.state.license,

--- a/client/src/components/PluginSearch/__snapshots__/PluginSearch.test.tsx.snap
+++ b/client/src/components/PluginSearch/__snapshots__/PluginSearch.test.tsx.snap
@@ -1136,64 +1136,6 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                                 class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
                                 data-testid="title"
                               >
-                                Development status
-                              </legend>
-                              <div
-                                class="MuiFormGroup-root gap-2"
-                              >
-                                <label
-                                  class="MuiFormControlLabel-root items-start m-0"
-                                  data-testid="input"
-                                >
-                                  <span
-                                    aria-disabled="false"
-                                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
-                                  >
-                                    <span
-                                      class="MuiIconButton-label"
-                                    >
-                                      <input
-                                        class="PrivateSwitchBase-input-4"
-                                        data-indeterminate="false"
-                                        type="checkbox"
-                                        value="false"
-                                      />
-                                      <svg
-                                        class="w-4 h-4"
-                                        fill="none"
-                                        height="14"
-                                        viewBox="0 0 14 14"
-                                        width="14"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <title>
-                                          unchecked checkbox
-                                        </title>
-                                        <rect
-                                          height="13"
-                                          stroke="black"
-                                          width="13"
-                                          x="0.5"
-                                          y="0.5"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </span>
-                                  <span
-                                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                                  >
-                                    Only show stable plugins
-                                  </span>
-                                </label>
-                              </div>
-                            </fieldset>
-                            <fieldset
-                              class="MuiFormControl-root"
-                            >
-                              <legend
-                                class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
-                                data-testid="title"
-                              >
                                 License
                               </legend>
                               <div
@@ -1556,64 +1498,6 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                         class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
                       >
                         Windows
-                      </span>
-                    </label>
-                  </div>
-                </fieldset>
-                <fieldset
-                  class="MuiFormControl-root"
-                >
-                  <legend
-                    class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
-                    data-testid="title"
-                  >
-                    Development status
-                  </legend>
-                  <div
-                    class="MuiFormGroup-root gap-2"
-                  >
-                    <label
-                      class="MuiFormControlLabel-root items-start m-0"
-                      data-testid="input"
-                    >
-                      <span
-                        aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
-                      >
-                        <span
-                          class="MuiIconButton-label"
-                        >
-                          <input
-                            class="PrivateSwitchBase-input-4"
-                            data-indeterminate="false"
-                            type="checkbox"
-                            value="false"
-                          />
-                          <svg
-                            class="w-4 h-4"
-                            fill="none"
-                            height="14"
-                            viewBox="0 0 14 14"
-                            width="14"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title>
-                              unchecked checkbox
-                            </title>
-                            <rect
-                              height="13"
-                              stroke="black"
-                              width="13"
-                              x="0.5"
-                              y="0.5"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                      <span
-                        class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                      >
-                        Only show stable plugins
                       </span>
                     </label>
                   </div>


### PR DESCRIPTION
## Description

Drops the dev status filter from the search page. Since we may consider using this field in the future for filtering, I'm only uncommenting the code for the UI and maintaining the state logic.

## Demo

#### Before

![image](https://user-images.githubusercontent.com/2176050/123837743-10ac9b80-d8c0-11eb-9c41-725810f1cd8d.png)

#### After

![image](https://user-images.githubusercontent.com/2176050/123837827-26ba5c00-d8c0-11eb-8def-b5a4e1838d2f.png)
