### PR TITLE
Right nav stickiness

### DIFF
--- a/client/src/components/PluginDetails/PluginDetails.tsx
+++ b/client/src/components/PluginDetails/PluginDetails.tsx
@@ -87,8 +87,8 @@ function PluginRightColumn() {
 
   return (
     <Media greaterThanOrEqual="2xl">
+      {/*  Keep CTA button and TOC on screen when scrolling on 2xl. */}
       <div className="sticky top-12">
-        {/*  Keep button on screen when scrolling on 2xl. */}
         <CallToActionButton />
 
         <Markdown.TOC

--- a/client/src/components/PluginDetails/PluginDetails.tsx
+++ b/client/src/components/PluginDetails/PluginDetails.tsx
@@ -87,19 +87,22 @@ function PluginRightColumn() {
 
   return (
     <Media greaterThanOrEqual="2xl">
-      {/*  Keep button on screen when scrolling on 2xl. */}
-      <CallToActionButton className="fixed" />
+      <div className="sticky top-12">
+        {/*  Keep button on screen when scrolling on 2xl. */}
+        <CallToActionButton />
 
-      <Markdown.TOC
-        className="mt-24"
-        markdown={plugin.description}
-        onClick={(section) => {
-          plausible('Description Nav', {
-            section,
-            plugin: plugin.name,
-          });
-        }}
-      />
+        <Markdown.TOC
+          className="mt-9"
+          markdown={plugin.description}
+          onClick={(section) => {
+            plausible('Description Nav', {
+              section,
+              plugin: plugin.name,
+            });
+          }}
+          free
+        />
+      </div>
     </Media>
   );
 }

--- a/client/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
+++ b/client/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
@@ -1500,114 +1500,118 @@ the coverage at least stays the same before you submit a pull request.
     class="fresnel-container fresnel-greaterThanOrEqual-2xl "
   >
     <div
-      class="absolute min-w-napari-xs"
-    />
-    <button
-      class="fixed bg-napari-primary h-12 w-full lg:max-w-napari-col"
-      type="button"
+      class="sticky top-12"
     >
-      Install
-    </button>
-    <ul
-      class="mt-24 flex flex-col border-l border-black fixed"
-    >
-      <li
-        class="flex pl-6 h-6 border-l-4 my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
-        data-active="false"
-        data-testid="tocItem"
+      <div
+        class="absolute min-w-napari-xs"
+      />
+      <button
+        class="bg-napari-primary h-12 w-full lg:max-w-napari-col"
+        type="button"
       >
-        <a
-          class=""
-          href="#description"
-        >
-          Description
-        </a>
-      </li>
-      <li
-        class="flex pl-6 h-6 border-l-4 my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
-        data-active="false"
-        data-testid="tocItem"
+        Install
+      </button>
+      <ul
+        class="mt-9 flex flex-col border-l border-black"
       >
-        <a
-          class=""
-          href="#writers"
+        <li
+          class="flex pl-6 h-6 border-l-4 my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
+          data-active="false"
+          data-testid="tocItem"
         >
-          Writers
-        </a>
-      </li>
-      <li
-        class="flex pl-6 h-6 border-l-4 my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
-        data-active="false"
-        data-testid="tocItem"
-      >
-        <a
-          class=""
-          href="#readers"
+          <a
+            class=""
+            href="#description"
+          >
+            Description
+          </a>
+        </li>
+        <li
+          class="flex pl-6 h-6 border-l-4 my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
+          data-active="false"
+          data-testid="tocItem"
         >
-          Readers
-        </a>
-      </li>
-      <li
-        class="flex pl-6 h-6 border-l-4 my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
-        data-active="false"
-        data-testid="tocItem"
-      >
-        <a
-          class=""
-          href="#zmeta"
+          <a
+            class=""
+            href="#writers"
+          >
+            Writers
+          </a>
+        </li>
+        <li
+          class="flex pl-6 h-6 border-l-4 my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
+          data-active="false"
+          data-testid="tocItem"
         >
-          .zmeta
-        </a>
-      </li>
-      <li
-        class="flex pl-6 h-6 border-l-4 my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
-        data-active="false"
-        data-testid="tocItem"
-      >
-        <a
-          class=""
-          href="#installation"
+          <a
+            class=""
+            href="#readers"
+          >
+            Readers
+          </a>
+        </li>
+        <li
+          class="flex pl-6 h-6 border-l-4 my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
+          data-active="false"
+          data-testid="tocItem"
         >
-          Installation
-        </a>
-      </li>
-      <li
-        class="flex pl-6 h-6 border-l-4 my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
-        data-active="false"
-        data-testid="tocItem"
-      >
-        <a
-          class=""
-          href="#contributing"
+          <a
+            class=""
+            href="#zmeta"
+          >
+            .zmeta
+          </a>
+        </li>
+        <li
+          class="flex pl-6 h-6 border-l-4 my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
+          data-active="false"
+          data-testid="tocItem"
         >
-          Contributing
-        </a>
-      </li>
-      <li
-        class="flex pl-6 h-6 border-l-4 my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
-        data-active="false"
-        data-testid="tocItem"
-      >
-        <a
-          class=""
-          href="#license"
+          <a
+            class=""
+            href="#installation"
+          >
+            Installation
+          </a>
+        </li>
+        <li
+          class="flex pl-6 h-6 border-l-4 my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
+          data-active="false"
+          data-testid="tocItem"
         >
-          License
-        </a>
-      </li>
-      <li
-        class="flex pl-6 h-6 border-l-4 my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-black"
-        data-active="true"
-        data-testid="tocItem"
-      >
-        <a
-          class="font-bold"
-          href="#issues"
+          <a
+            class=""
+            href="#contributing"
+          >
+            Contributing
+          </a>
+        </li>
+        <li
+          class="flex pl-6 h-6 border-l-4 my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
+          data-active="false"
+          data-testid="tocItem"
         >
-          Issues
-        </a>
-      </li>
-    </ul>
+          <a
+            class=""
+            href="#license"
+          >
+            License
+          </a>
+        </li>
+        <li
+          class="flex pl-6 h-6 border-l-4 my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-black"
+          data-active="true"
+          data-testid="tocItem"
+        >
+          <a
+            class="font-bold"
+            href="#issues"
+          >
+            Issues
+          </a>
+        </li>
+      </ul>
+    </div>
   </div>
 </div>
 `;

--- a/client/src/components/common/TableOfContents/TableOfContents.tsx
+++ b/client/src/components/common/TableOfContents/TableOfContents.tsx
@@ -38,7 +38,7 @@ export function TableOfContents({ className, onClick, headers, free }: Props) {
         className,
         'flex flex-col',
         'border-l border-black',
-        !free && 'fixed',
+        !free && 'sticky top-12',
       )}
     >
       {headers.map((header) => {

--- a/client/src/components/common/TableOfContents/__snapshots__/TableOfContents.test.tsx.snap
+++ b/client/src/components/common/TableOfContents/__snapshots__/TableOfContents.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Table of Contents should match snapshot 1`] = `
 <DocumentFragment>
   <ul
-    class="flex flex-col border-l border-black fixed"
+    class="flex flex-col border-l border-black sticky top-12"
   >
     <li
       class="flex pl-6 h-6 border-l-4 my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-black"

--- a/client/src/global.scss
+++ b/client/src/global.scss
@@ -2,13 +2,6 @@
 
 html {
   /*
-    Enable scrollbar for the entire page by default. This is to prevent
-    layout shift when switching between pages that have content long enough /
-    not long enough for a scrollbar.
-  */
-  @apply overflow-y-scroll;
-
-  /*
     Use viewport width for fluid typography. The minimum font size is from the
     design spec, and the maximum font size is set to the user's preferred font
     size set by their browser settings.


### PR DESCRIPTION
## Description

Fixes the stickiness for the right nav in the plugin and markdown pages so that the right nav sticks only when its `50px` from the top of the screen after scrolling.

## Demos

### Plugin Page

https://right-nav-stickiness-frontend.dev.imaging.cziscience.com/plugins/napari-btrack-reader

https://user-images.githubusercontent.com/2176050/123850261-a64f2780-d8ce-11eb-9244-c44dcee5bae2.mp4

### Markdown Pages

https://right-nav-stickiness-frontend.dev.imaging.cziscience.com/about

https://user-images.githubusercontent.com/2176050/123850254-a3543700-d8ce-11eb-9209-086edf7f5a9f.mp4
