### PR TITLE
fix vertical spacing for filters and view project data

### DIFF
--- a/client/src/components/PluginDetails/PluginDetails.tsx
+++ b/client/src/components/PluginDetails/PluginDetails.tsx
@@ -21,7 +21,7 @@ function PluginCenterColumn() {
   const { plugin } = usePluginState();
 
   return (
-    <article className="w-full col-span-2 xl:col-span-3">
+    <article className="w-full col-span-2 screen-875:col-span-3">
       <h1 className="font-bold text-4xl">{plugin.name}</h1>
       <h2 className="font-semibold my-6 text-lg">{plugin.summary}</h2>
 
@@ -34,7 +34,7 @@ function PluginCenterColumn() {
           'lg:flex-row lg:items-center',
 
           // Margins
-          'my-6 md:my-12',
+          'my-6 screen-495:mt-12 screen-600:mb-12',
         )}
         lessThan="3xl"
       >
@@ -51,14 +51,14 @@ function PluginCenterColumn() {
               Top margins: This is used for smaller layouts because the CTA
               button is above the metadata link.
             */
-            'mt-6 md:mt-12 lg:mt-0',
+            'mt-6 screen-600:mt-0',
 
             /*
               Left margins: This is used when the CTA and metadata link are
               inline.  The margin is removed when the CTA moves to the right
-              column on 2xl layouts.
+              column on 1150px layouts.
             */
-            'lg:ml-12 2xl:ml-0',
+            'screen-600:ml-12 screen-1150:ml-0',
           )}
           href="#pluginMetadata"
         >

--- a/client/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
+++ b/client/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
@@ -242,7 +242,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
     </div>
   </div>
   <article
-    class="w-full col-span-2 xl:col-span-3"
+    class="w-full col-span-2 screen-875:col-span-3"
   >
     <h1
       class="font-bold text-4xl"
@@ -255,7 +255,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       Plugin exploring different options for reading and writing compressed and portable labels layers in napari.
     </h2>
     <div
-      class="fresnel-container fresnel-lessThan-3xl flex flex-col lg:flex-row lg:items-center my-6 md:my-12"
+      class="fresnel-container fresnel-lessThan-3xl flex flex-col lg:flex-row lg:items-center my-6 screen-495:mt-12 screen-600:mb-12"
     >
       <div
         class="absolute min-w-napari-xs"
@@ -267,7 +267,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
         Install
       </button>
       <a
-        class="underline hover:text-napari-primary mt-6 md:mt-12 lg:mt-0 lg:ml-12 2xl:ml-0"
+        class="underline hover:text-napari-primary mt-6 screen-600:mt-0 screen-600:ml-12 screen-1150:ml-0"
         href="#pluginMetadata"
       >
         View project data

--- a/client/src/components/PluginSearch/PluginFilterByForm.tsx
+++ b/client/src/components/PluginSearch/PluginFilterByForm.tsx
@@ -49,7 +49,7 @@ function FilterForm() {
   ];
 
   return (
-    <div className="grid grid-cols-1 gap-6 screen-600:grid-cols-2 screen-875:grid-cols-1">
+    <div className="grid grid-cols-1 screen-600:grid-cols-2 screen-875:grid-cols-1">
       {/* Only show label on larger screens. This is because the Accordion already includes a title. */}
       <Media greaterThanOrEqual="screen-875">
         <FormLabel
@@ -63,6 +63,7 @@ function FilterForm() {
 
       {sections.map((section) => (
         <PluginFilterBySection
+          className="mt-6"
           key={section.title}
           title={section.title}
           filters={Object.entries(section.state ?? {}).map(

--- a/client/src/components/PluginSearch/PluginFilterBySection.tsx
+++ b/client/src/components/PluginSearch/PluginFilterBySection.tsx
@@ -34,7 +34,7 @@ export function PluginFilterBySection({ className, title, filters }: Props) {
       >
         {title}
       </FormLabel>
-      <FormGroup className="gap-2">
+      <FormGroup>
         {filters.map((filter) => (
           <FormControlLabel
             className="items-start m-0"
@@ -43,7 +43,7 @@ export function PluginFilterBySection({ className, title, filters }: Props) {
                 value={filter.enabled}
                 checked={filter.enabled}
                 onChange={(event) => filter.setEnabled(event.target.checked)}
-                className="text-black fill-current py-1 pr-2 pl-0"
+                className="text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
                 color="default"
                 icon={<CheckboxIcon className="w-4 h-4" />}
                 checkedIcon={<CheckboxIcon checked className="w-4 h-4" />}

--- a/client/src/components/PluginSearch/__snapshots__/PluginSearch.test.tsx.snap
+++ b/client/src/components/PluginSearch/__snapshots__/PluginSearch.test.tsx.snap
@@ -832,13 +832,13 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                           class="MuiAccordionDetails-root p-0 flex-col"
                         >
                           <div
-                            class="grid grid-cols-1 gap-6 screen-600:grid-cols-2 screen-875:grid-cols-1"
+                            class="grid grid-cols-1 screen-600:grid-cols-2 screen-875:grid-cols-1"
                           >
                             <div
                               class="fresnel-container fresnel-greaterThanOrEqual-screen-875 "
                             />
                             <fieldset
-                              class="MuiFormControl-root"
+                              class="MuiFormControl-root mt-6"
                             >
                               <legend
                                 class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
@@ -847,7 +847,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                                 Python versions
                               </legend>
                               <div
-                                class="MuiFormGroup-root gap-2"
+                                class="MuiFormGroup-root"
                               >
                                 <label
                                   class="MuiFormControlLabel-root items-start m-0"
@@ -855,7 +855,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                                 >
                                   <span
                                     aria-disabled="false"
-                                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
                                   >
                                     <span
                                       class="MuiIconButton-label"
@@ -899,7 +899,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                                 >
                                   <span
                                     aria-disabled="false"
-                                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
                                   >
                                     <span
                                       class="MuiIconButton-label"
@@ -943,7 +943,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                                 >
                                   <span
                                     aria-disabled="false"
-                                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
                                   >
                                     <span
                                       class="MuiIconButton-label"
@@ -984,7 +984,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                               </div>
                             </fieldset>
                             <fieldset
-                              class="MuiFormControl-root"
+                              class="MuiFormControl-root mt-6"
                             >
                               <legend
                                 class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
@@ -993,7 +993,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                                 Operating system
                               </legend>
                               <div
-                                class="MuiFormGroup-root gap-2"
+                                class="MuiFormGroup-root"
                               >
                                 <label
                                   class="MuiFormControlLabel-root items-start m-0"
@@ -1001,7 +1001,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                                 >
                                   <span
                                     aria-disabled="false"
-                                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
                                   >
                                     <span
                                       class="MuiIconButton-label"
@@ -1045,7 +1045,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                                 >
                                   <span
                                     aria-disabled="false"
-                                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
                                   >
                                     <span
                                       class="MuiIconButton-label"
@@ -1089,7 +1089,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                                 >
                                   <span
                                     aria-disabled="false"
-                                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
                                   >
                                     <span
                                       class="MuiIconButton-label"
@@ -1130,7 +1130,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                               </div>
                             </fieldset>
                             <fieldset
-                              class="MuiFormControl-root"
+                              class="MuiFormControl-root mt-6"
                             >
                               <legend
                                 class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
@@ -1139,7 +1139,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                                 License
                               </legend>
                               <div
-                                class="MuiFormGroup-root gap-2"
+                                class="MuiFormGroup-root"
                               >
                                 <label
                                   class="MuiFormControlLabel-root items-start m-0"
@@ -1147,7 +1147,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                                 >
                                   <span
                                     aria-disabled="false"
-                                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
                                   >
                                     <span
                                       class="MuiIconButton-label"
@@ -1199,7 +1199,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
               class="fresnel-container fresnel-greaterThanOrEqual-screen-875 "
             >
               <div
-                class="grid grid-cols-1 gap-6 screen-600:grid-cols-2 screen-875:grid-cols-1"
+                class="grid grid-cols-1 screen-600:grid-cols-2 screen-875:grid-cols-1"
               >
                 <div
                   class="fresnel-container fresnel-greaterThanOrEqual-screen-875 "
@@ -1211,7 +1211,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                   </legend>
                 </div>
                 <fieldset
-                  class="MuiFormControl-root"
+                  class="MuiFormControl-root mt-6"
                 >
                   <legend
                     class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
@@ -1220,7 +1220,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                     Python versions
                   </legend>
                   <div
-                    class="MuiFormGroup-root gap-2"
+                    class="MuiFormGroup-root"
                   >
                     <label
                       class="MuiFormControlLabel-root items-start m-0"
@@ -1228,7 +1228,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                     >
                       <span
                         aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
                       >
                         <span
                           class="MuiIconButton-label"
@@ -1272,7 +1272,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                     >
                       <span
                         aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
                       >
                         <span
                           class="MuiIconButton-label"
@@ -1316,7 +1316,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                     >
                       <span
                         aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
                       >
                         <span
                           class="MuiIconButton-label"
@@ -1357,7 +1357,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                   </div>
                 </fieldset>
                 <fieldset
-                  class="MuiFormControl-root"
+                  class="MuiFormControl-root mt-6"
                 >
                   <legend
                     class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
@@ -1366,7 +1366,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                     Operating system
                   </legend>
                   <div
-                    class="MuiFormGroup-root gap-2"
+                    class="MuiFormGroup-root"
                   >
                     <label
                       class="MuiFormControlLabel-root items-start m-0"
@@ -1374,7 +1374,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                     >
                       <span
                         aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
                       >
                         <span
                           class="MuiIconButton-label"
@@ -1418,7 +1418,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                     >
                       <span
                         aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
                       >
                         <span
                           class="MuiIconButton-label"
@@ -1462,7 +1462,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                     >
                       <span
                         aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
                       >
                         <span
                           class="MuiIconButton-label"
@@ -1503,7 +1503,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                   </div>
                 </fieldset>
                 <fieldset
-                  class="MuiFormControl-root"
+                  class="MuiFormControl-root mt-6"
                 >
                   <legend
                     class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
@@ -1512,7 +1512,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                     License
                   </legend>
                   <div
-                    class="MuiFormGroup-root gap-2"
+                    class="MuiFormGroup-root"
                   >
                     <label
                       class="MuiFormControlLabel-root items-start m-0"
@@ -1520,7 +1520,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                     >
                       <span
                         aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0"
+                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
                       >
                         <span
                           class="MuiIconButton-label"


### PR DESCRIPTION
- replace flex gap with margins to fix filter spacing on iOS <14.6 ([issue](https://airtable.com/tblNxANme1LbVQqq1/viwISga6FERUatih1/recRDohaIItWODvcl?blocks=hide))
- fix view project data vertical spacing ([issue](https://airtable.com/tblNxANme1LbVQqq1/viwISga6FERUatih1/rec6i6mFOJT1Xng5y?blocks=hide))

demo: https://kira-sandbox-frontend.dev.imaging.cziscience.com

### view project data

#### @494px
<img width="515" alt="Screen Shot 2021-06-29 at 9 01 18 PM" src="https://user-images.githubusercontent.com/29165011/123901513-ee4a6a80-d91f-11eb-81ac-8f8ed1931901.png">

#### @495px
<img width="508" alt="Screen Shot 2021-06-29 at 9 01 31 PM" src="https://user-images.githubusercontent.com/29165011/123901525-f4404b80-d91f-11eb-9f0f-3ccae7ca189e.png">

#### @600px
<img width="606" alt="Screen Shot 2021-06-29 at 9 02 02 PM" src="https://user-images.githubusercontent.com/29165011/123901553-ff937700-d91f-11eb-9473-044a8729abbd.png">
