### PR TITLE
add cert dependency for validation so adding cert to lb won't fail

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -97,7 +97,7 @@ module backend_lambda {
     "BUCKET_PATH" = ""
     "GOOGLE_APPLICATION_CREDENTIALS" = "./credentials.json"
     "SLACK_URL" = local.slack_url
-    "ZULIP_CREDENTIALS" = local.zulip_credentials
+    "ZULIP_CREDENTIALS  " = local.zulip_credentials
     "GITHUB_CLIENT_ID" = local.github_client_id
     "GITHUB_CLIENT_SECRET" = local.github_client_secret
   }
@@ -210,6 +210,7 @@ resource aws_acm_certificate_validation cert {
 }
 
 resource aws_lb_listener_certificate cert {
+  depends_on      = [aws_acm_certificate_validation.cert]
   listener_arn    = local.frontend_listener_arn
   certificate_arn = aws_acm_certificate.cert.arn
 }

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -97,7 +97,7 @@ module backend_lambda {
     "BUCKET_PATH" = ""
     "GOOGLE_APPLICATION_CREDENTIALS" = "./credentials.json"
     "SLACK_URL" = local.slack_url
-    "ZULIP_CREDENTIALS  " = local.zulip_credentials
+    "ZULIP_CREDENTIALS" = local.zulip_credentials
     "GITHUB_CLIENT_ID" = local.github_client_id
     "GITHUB_CLIENT_SECRET" = local.github_client_secret
   }


### PR DESCRIPTION
This is to fix certificate linkage failure before the cert is validated that Jeremy was seeing on dev environments occasionally

There was a race condition where the cert was not validated before trying to add to load balancer when aws would complain about such addition