### PR TITLE
Client-side skeleton loader

### DIFF
--- a/frontend/.babelrc.js
+++ b/frontend/.babelrc.js
@@ -19,6 +19,7 @@ function getMUIImportsPlugin(name) {
     '@material-ui/core',
     '@material-ui/icons',
     '@material-ui/styles',
+    '@material-ui/lab',
   ];
 
   return [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,8 +26,9 @@
   },
   "dependencies": {
     "@artsy/fresnel": "^1.4.0",
-    "@material-ui/core": "^4.11.4",
+    "@material-ui/core": "^4.12.1",
     "@material-ui/icons": "^4.11.2",
+    "@material-ui/lab": "^4.0.0-alpha.60",
     "@material-ui/styles": "^4.11.4",
     "@mdx-js/loader": "^1.6.22",
     "@mdx-js/react": "^1.6.22",

--- a/frontend/src/components/AppBar/AppBarLinks.tsx
+++ b/frontend/src/components/AppBar/AppBarLinks.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import { Link } from '@/components/common';
 import { useSearchState } from '@/context/search';
 import { LinkInfo } from '@/types';
+import { setSearchScrollY } from '@/utils';
 
 interface CommonProps {
   vertical?: boolean;
@@ -49,11 +50,17 @@ export function AppBarLinks({ className, items, vertical }: Props) {
         className="whitespace-nowrap"
         // Redirect to home page
         href="/"
-        // Clear search related query parameter data if the user is currently
-        // on the search page. Without this, the `useQueryParameter()` hook
-        // will re-set the query parameter with the current query in the
-        // search bar.
-        onClick={() => search?.setQuery('')}
+        onClick={() => {
+          // Clear search related query parameter data if the user is currently
+          // on the search page. Without this, the `useQueryParameter()` hook
+          // will re-set the query parameter with the current query in the
+          // search bar.
+          search?.setQuery('');
+
+          // When navigating back to the home page from the home link, reset
+          // `scrollY` so that the user starts from the top of the page.
+          setSearchScrollY(0);
+        }}
       >
         napari <strong>hub</strong>
       </Link>

--- a/frontend/src/components/PluginDetails/CallToActionButton.tsx
+++ b/frontend/src/components/PluginDetails/CallToActionButton.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { usePluginState } from '@/context/plugin';
 import { usePlausible } from '@/hooks';
 
+import { SkeletonLoader } from '../common';
 import { InstallModal } from './InstallModal';
 
 interface Props {
@@ -19,30 +20,37 @@ export function CallToActionButton({ className }: Props) {
   const plausible = usePlausible();
   const [visible, setVisible] = useState(false);
 
+  const dimensionsClassName = 'h-12 w-full screen-600:max-w-napari-col';
+
   return (
-    <>
-      <InstallModal onClose={() => setVisible(false)} visible={visible} />
+    <SkeletonLoader
+      className={dimensionsClassName}
+      render={() => (
+        <>
+          <InstallModal onClose={() => setVisible(false)} visible={visible} />
 
-      <button
-        className={clsx(
-          className,
+          <button
+            className={clsx(
+              className,
 
-          // Button color
-          'bg-napari-primary',
+              // Button color
+              'bg-napari-primary',
 
-          // Dimensions
-          'h-12 w-full lg:max-w-napari-col',
-        )}
-        onClick={() => {
-          setVisible(true);
-          plausible('Install', {
-            plugin: plugin.name,
-          });
-        }}
-        type="button"
-      >
-        Install
-      </button>
-    </>
+              // Dimensions
+              dimensionsClassName,
+            )}
+            onClick={() => {
+              setVisible(true);
+              plausible('Install', {
+                plugin: plugin.name,
+              });
+            }}
+            type="button"
+          >
+            Install
+          </button>
+        </>
+      )}
+    />
   );
 }

--- a/frontend/src/components/PluginDetails/PluginDetails.tsx
+++ b/frontend/src/components/PluginDetails/PluginDetails.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 
-import { ColumnLayout, Markdown } from '@/components/common';
+import { ColumnLayout, Markdown, SkeletonLoader } from '@/components/common';
 import { Media, MediaFragment } from '@/components/common/media';
 import { usePluginState } from '@/context/plugin';
 import { usePlausible } from '@/hooks';
@@ -22,8 +22,17 @@ function PluginCenterColumn() {
 
   return (
     <article className="w-full col-span-2 screen-875:col-span-3">
-      <h1 className="font-bold text-4xl">{plugin.name}</h1>
-      <h2 className="font-semibold my-6 text-lg">{plugin.summary}</h2>
+      <SkeletonLoader
+        className="h-12"
+        render={() => <h1 className="font-bold text-4xl">{plugin.name}</h1>}
+      />
+
+      <SkeletonLoader
+        className="h-6 my-6"
+        render={() => (
+          <h2 className="font-semibold my-6 text-lg">{plugin.summary}</h2>
+        )}
+      />
 
       <Media
         className={clsx(
@@ -42,37 +51,52 @@ function PluginCenterColumn() {
           <CallToActionButton />
         </MediaFragment>
 
-        <a
-          className={clsx(
-            // Text styling
-            'underline hover:text-napari-primary',
+        <SkeletonLoader
+          className="screen-600:ml-12 screen-1150:ml-0 mt-6 screen-600:mt-0 h-8 w-24"
+          render={() => (
+            <a
+              className={clsx(
+                // Text styling
+                'underline hover:text-napari-primary',
 
-            /*
-              Top margins: This is used for smaller layouts because the CTA
-              button is above the metadata link.
-            */
-            'mt-6 screen-600:mt-0',
+                /*
+                  Top margins: This is used for smaller layouts because the CTA
+                  button is above the metadata link.
+                */
+                'mt-6 screen-600:mt-0',
 
-            /*
-              Left margins: This is used when the CTA and metadata link are
-              inline.  The margin is removed when the CTA moves to the right
-              column on 1150px layouts.
-            */
-            'screen-600:ml-12 screen-1150:ml-0',
+                /*
+                  Left margins: This is used when the CTA and metadata link are
+                  inline.  The margin is removed when the CTA moves to the right
+                  column on 1150px layouts.
+                */
+                'screen-600:ml-12 screen-1150:ml-0',
+              )}
+              href="#pluginMetadata"
+            >
+              View project data
+            </a>
           )}
-          href="#pluginMetadata"
-        >
-          View project data
-        </a>
+        />
       </Media>
 
-      <SupportInfo className="mb-6 md:mb-12" />
+      <SkeletonLoader
+        className="h-[228px] my-6"
+        render={() => <SupportInfo className="mb-6 screen-495:mb-12" />}
+      />
 
-      <Markdown className="mb-10" disableHeader>
-        {plugin.description}
-      </Markdown>
+      <SkeletonLoader
+        className="h-[600px] mb-10"
+        render={() => (
+          <Markdown className="mb-10" disableHeader>
+            {plugin.description}
+          </Markdown>
+        )}
+      />
 
-      <CallToActionButton className="mb-6 md:mb-12 2xl:mb-20" />
+      <div className="mb-6 screen-495:mb-12 screen-1150:mb-20">
+        <CallToActionButton />
+      </div>
 
       <MediaFragment lessThan="3xl">
         <PluginMetadata />
@@ -91,16 +115,21 @@ function PluginRightColumn() {
       <div className="sticky top-12">
         <CallToActionButton />
 
-        <Markdown.TOC
-          className="mt-9"
-          markdown={plugin.description}
-          onClick={(section) => {
-            plausible('Description Nav', {
-              section,
-              plugin: plugin.name,
-            });
-          }}
-          free
+        <SkeletonLoader
+          className="h-56 mt-9"
+          render={() => (
+            <Markdown.TOC
+              className="mt-9"
+              markdown={plugin.description}
+              onClick={(section) => {
+                plausible('Description Nav', {
+                  section,
+                  plugin: plugin.name,
+                });
+              }}
+              free
+            />
+          )}
         />
       </div>
     </Media>

--- a/frontend/src/components/PluginDetails/PluginMetadata.tsx
+++ b/frontend/src/components/PluginDetails/PluginMetadata.tsx
@@ -1,13 +1,12 @@
 import clsx from 'clsx';
 import { ReactNode } from 'react-markdown';
 
-import { Divider } from '@/components/common';
+import { Divider, SkeletonLoader } from '@/components/common';
 import { MediaFragment } from '@/components/common/media';
 import { usePluginState } from '@/context/plugin';
 import { formatDate } from '@/utils';
 
 import { MetadataList } from './MetadataList';
-import { MetadataItem } from './PluginDetails.types';
 
 interface GithubMetadataItem {
   title: string;
@@ -100,47 +99,69 @@ function PluginMetadataBase({
 }: PluginMetadataBaseProps) {
   const { plugin } = usePluginState();
 
-  const projectItems: MetadataItem[] = [
-    {
-      title: 'Version',
-      value: plugin.version,
-    },
-    {
-      title: 'Release date',
-      value: formatDate(plugin.release_date),
-    },
-    {
-      title: 'First released',
-      value: formatDate(plugin.first_released),
-    },
-    {
-      title: 'Development status',
-      value: plugin.development_status.map((status) =>
-        status.replace('Development Status :: ', ''),
-      ),
-    },
-    {
-      title: 'License',
-      value: plugin.license,
-    },
-  ];
+  const projectMetadata = (
+    <SkeletonLoader
+      className="h-56"
+      render={() => (
+        <MetadataList
+          inline={inline}
+          items={[
+            {
+              title: 'Version',
+              value: plugin.version,
+            },
+            {
+              title: 'Release date',
+              value: formatDate(plugin.release_date),
+            },
+            {
+              title: 'First released',
+              value: formatDate(plugin.first_released),
+            },
+            {
+              title: 'Development status',
+              value: plugin.development_status.map((status) =>
+                status.replace('Development Status :: ', ''),
+              ),
+            },
+            {
+              title: 'License',
+              value: plugin.license,
+            },
+          ]}
+        />
+      )}
+    />
+  );
 
-  const requirementItems: MetadataItem[] = [
-    {
-      title: 'Python versions supported',
-      value: plugin.python_version,
-    },
-    {
-      title: 'Operating system',
-      value: plugin.operating_system.map((operatingSystem) =>
-        operatingSystem.replace('Operating System :: ', ''),
-      ),
-    },
-    {
-      title: 'Requirements',
-      value: plugin.requirements.filter((req) => !req.includes('; extra == ')),
-    },
-  ];
+  const requirementMetadata = (
+    <SkeletonLoader
+      className="h-56"
+      render={() => (
+        <MetadataList
+          inline={inline}
+          items={[
+            {
+              title: 'Python versions supported',
+              value: plugin.python_version,
+            },
+            {
+              title: 'Operating system',
+              value: plugin.operating_system.map((operatingSystem) =>
+                operatingSystem.replace('Operating System :: ', ''),
+              ),
+            },
+            {
+              title: 'Requirements',
+              value: plugin.requirements.filter(
+                (req) => !req.includes('; extra == '),
+              ),
+            },
+          ]}
+        />
+      )}
+    />
+  );
 
   return (
     <div
@@ -159,11 +180,18 @@ function PluginMetadataBase({
         '3xl:grid-cols-1',
       )}
     >
-      <MetadataList inline={inline} items={projectItems} />
+      {projectMetadata}
       {divider}
-      <PluginGithubData />
+      <SkeletonLoader
+        className={clsx(
+          'h-40',
+          'screen-875:mx-6 screen-875:h-full',
+          'screen-1425:mx-0 screen-1425:h-40',
+        )}
+        render={() => <PluginGithubData />}
+      />
       {divider}
-      <MetadataList inline={inline} items={requirementItems} />
+      {requirementMetadata}
     </div>
   );
 }

--- a/frontend/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
+++ b/frontend/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
@@ -258,7 +258,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       class="fresnel-container fresnel-lessThan-3xl flex flex-col lg:flex-row lg:items-center my-6 screen-495:mt-12 screen-600:mb-12"
     >
       <button
-        class="fresnel-lessThan-2xl bg-napari-primary h-12 w-full lg:max-w-napari-col"
+        class="fresnel-lessThan-2xl bg-napari-primary h-12 w-full screen-600:max-w-napari-col"
         type="button"
       >
         Install
@@ -274,7 +274,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       class="fresnel-container fresnel-greaterThanOrEqual-xl "
     >
       <ul
-        class="text-black bg-gray-100 p-5 mb-6 md:mb-12 list-none grid grid-cols-3"
+        class="text-black bg-gray-100 p-5 mb-6 screen-495:mb-12 list-none grid grid-cols-3"
       >
         <li
           class="mb-4 text-sm"
@@ -562,7 +562,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       class="fresnel-container fresnel-lessThan-xl "
     >
       <ul
-        class="text-black bg-gray-100 p-5 mb-6 md:mb-12 list-none"
+        class="text-black bg-gray-100 p-5 mb-6 screen-495:mb-12 list-none"
       >
         <li
           class="mb-4 text-sm"
@@ -1251,12 +1251,16 @@ the coverage at least stays the same before you submit a pull request.
          along with a detailed description.
       </p>
     </div>
-    <button
-      class="mb-6 md:mb-12 2xl:mb-20 bg-napari-primary h-12 w-full lg:max-w-napari-col"
-      type="button"
+    <div
+      class="mb-6 screen-495:mb-12 screen-1150:mb-20"
     >
-      Install
-    </button>
+      <button
+        class="bg-napari-primary h-12 w-full screen-600:max-w-napari-col"
+        type="button"
+      >
+        Install
+      </button>
+    </div>
     <div
       class="fresnel-lessThan-3xl fresnel-lessThan-3xl grid xl:grid-cols-3 3xl:grid-cols-1"
       id="pluginMetadata"
@@ -1497,7 +1501,7 @@ the coverage at least stays the same before you submit a pull request.
       class="sticky top-12"
     >
       <button
-        class="bg-napari-primary h-12 w-full lg:max-w-napari-col"
+        class="bg-napari-primary h-12 w-full screen-600:max-w-napari-col"
         type="button"
       >
         Install

--- a/frontend/src/components/PluginSearch/PluginFilterByForm.tsx
+++ b/frontend/src/components/PluginSearch/PluginFilterByForm.tsx
@@ -1,6 +1,6 @@
 import { FormLabel } from '@material-ui/core';
 
-import { Accordion } from '@/components/common';
+import { Accordion, SkeletonLoader } from '@/components/common';
 import { Media } from '@/components/common/media';
 import { useSearchState } from '@/context/search';
 
@@ -91,10 +91,15 @@ export function PluginFilterByForm() {
   return (
     <>
       <Media lessThan="screen-875">
-        <Accordion title="Filter By">{form}</Accordion>
+        <SkeletonLoader
+          className="h-12 mt-6"
+          render={() => <Accordion title="Filter By">{form}</Accordion>}
+        />
       </Media>
 
-      <Media greaterThanOrEqual="screen-875">{form}</Media>
+      <Media greaterThanOrEqual="screen-875">
+        <SkeletonLoader className="h-[400px]" render={() => form} />
+      </Media>
     </>
   );
 }

--- a/frontend/src/components/PluginSearch/PluginSearch.test.tsx
+++ b/frontend/src/components/PluginSearch/PluginSearch.test.tsx
@@ -12,6 +12,11 @@ import pluginIndex from '@/fixtures/index.json';
 
 import { PluginSearch } from './PluginSearch';
 
+jest.mock('@/utils/search', () => ({
+  getSearchScrollY: jest.fn(),
+  scrollToSearchBar: jest.fn(),
+}));
+
 function mockSearch(query = '') {
   type Replace = NextRouter['replace'];
   const replace = jest

--- a/frontend/src/components/PluginSearch/PluginSearch.test.tsx
+++ b/frontend/src/components/PluginSearch/PluginSearch.test.tsx
@@ -12,11 +12,6 @@ import pluginIndex from '@/fixtures/index.json';
 
 import { PluginSearch } from './PluginSearch';
 
-jest.mock('@/utils/search', () => ({
-  getSearchScrollY: jest.fn(),
-  scrollToSearchBar: jest.fn(),
-}));
-
 function mockSearch(query = '') {
   type Replace = NextRouter['replace'];
   const replace = jest

--- a/frontend/src/components/PluginSearch/PluginSearch.tsx
+++ b/frontend/src/components/PluginSearch/PluginSearch.tsx
@@ -11,11 +11,11 @@ import { PluginSearchResultList } from './PluginSearchResultList';
  */
 export function PluginSearch() {
   return (
-    <div className="flex flex-col min-h-screen">
+    <div className="flex flex-col">
       <AppBarLanding />
       <PluginSearchBar />
 
-      <div className="flex-grow">
+      <div className="flex-grow min-h-screen">
         <ColumnLayout
           className="p-6 md:p-12"
           classes={{

--- a/frontend/src/components/PluginSearch/PluginSearchBar.tsx
+++ b/frontend/src/components/PluginSearch/PluginSearchBar.tsx
@@ -1,26 +1,14 @@
-import { useEffect, useRef } from 'react';
-
 import { SearchBar } from '@/components';
 import { ColumnLayout, SkeletonLoader } from '@/components/common';
+import { SEARCH_BAR_ID } from '@/constants/search';
 
 /**
  * Component that renders the landing page search bar.
  */
 export function PluginSearchBar() {
-  const { search } = useSearchState() ?? {};
-  const searchBarRef = useRef<HTMLDivElement | null>(null);
-
-  // Scroll to search container when the search changes.
-  useEffect(() => {
-    if (search?.query) {
-      const alignTop = true;
-      searchBarRef.current?.scrollIntoView?.(alignTop);
-    }
-  }, [search]);
-
   return (
     <ColumnLayout
-      innerRef={searchBarRef}
+      id={SEARCH_BAR_ID}
       className="bg-napari-light h-36 items-center px-6 md:px-12"
       classes={{
         // Use 3-column layout instead of 4-column.

--- a/frontend/src/components/PluginSearch/PluginSearchBar.tsx
+++ b/frontend/src/components/PluginSearch/PluginSearchBar.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useRef } from 'react';
 
 import { SearchBar } from '@/components';
-import { ColumnLayout } from '@/components/common';
-import { useSearchState } from '@/context/search';
+import { ColumnLayout, SkeletonLoader } from '@/components/common';
 
 /**
  * Component that renders the landing page search bar.
@@ -36,7 +35,12 @@ export function PluginSearchBar() {
           Search for a plugin by keyword or author
         </h2>
 
-        <SearchBar aria-describedby="plugin-search-title" large />
+        <SkeletonLoader
+          className="h-7"
+          render={() => (
+            <SearchBar aria-describedby="plugin-search-title" large />
+          )}
+        />
       </div>
     </ColumnLayout>
   );

--- a/frontend/src/components/PluginSearch/PluginSearchResult.tsx
+++ b/frontend/src/components/PluginSearch/PluginSearchResult.tsx
@@ -1,7 +1,8 @@
 import clsx from 'clsx';
 import { isEmpty } from 'lodash';
 
-import { Link, TextHighlighter } from '@/components/common';
+import { Link, SkeletonLoader, TextHighlighter } from '@/components/common';
+import { useLoadingState } from '@/context/loading';
 import { SearchResultMatch } from '@/context/search';
 import { PluginIndexData } from '@/types';
 import { formatDate, formatOperatingSystem } from '@/utils';
@@ -84,29 +85,33 @@ function getDescriptionPreview(
  * Component for rendering a plugin search result.
  */
 export function PluginSearchResult({ className, matches, plugin }: Props) {
+  const isLoading = useLoadingState();
+
   // TODO consolidate with PluginGithubData component in PluginMetadata.tsx
-  const items: SearchResultItem[] = [
-    {
-      label: 'version',
-      value: plugin.version,
-    },
-    {
-      label: 'release date',
-      value: formatDate(plugin.release_date),
-    },
-    {
-      label: 'license',
-      value: plugin.license,
-    },
-    {
-      label: 'Python version',
-      value: plugin.python_version,
-    },
-    {
-      label: 'operating system',
-      value: plugin.operating_system.map(formatOperatingSystem).join(', '),
-    },
-  ];
+  const items: SearchResultItem[] = isLoading
+    ? []
+    : [
+        {
+          label: 'version',
+          value: plugin.version,
+        },
+        {
+          label: 'release date',
+          value: formatDate(plugin.release_date),
+        },
+        {
+          label: 'license',
+          value: plugin.license,
+        },
+        {
+          label: 'Python version',
+          value: plugin.python_version,
+        },
+        {
+          label: 'operating system',
+          value: plugin.operating_system.map(formatOperatingSystem).join(', '),
+        },
+      ];
 
   const isSearching = !isEmpty(matches);
 
@@ -124,14 +129,8 @@ export function PluginSearchResult({ className, matches, plugin }: Props) {
     );
   }
 
-  return (
-    <Link
-      className={clsx(
-        className,
-        'py-5 border-t-2 border-black hover:bg-napari-hover-gray',
-      )}
-      href={`/plugins/${plugin.name}`}
-    >
+  function renderResult() {
+    return (
       <article
         data-testid="searchResult"
         className={clsx(
@@ -148,26 +147,37 @@ export function PluginSearchResult({ className, matches, plugin }: Props) {
               className="inline font-bold text-lg"
               data-testid="searchResultName"
             >
-              {renderText(plugin.name, matches.name?.match)}
+              <SkeletonLoader
+                render={() => renderText(plugin.name, matches.name?.match)}
+              />
             </h4>
 
             {/* Plugin summary */}
             <p className="mt-2" data-testid="searchResultSummary">
-              {renderText(plugin.summary, matches.summary?.match)}
+              <SkeletonLoader
+                className="h-12"
+                render={() =>
+                  renderText(plugin.summary, matches.summary?.match)
+                }
+              />
             </p>
           </div>
 
           {/* Plugin authors */}
           <ul className="mt-5 text-xs">
-            {plugin.authors.map((author) => (
-              <li
-                className="my-2 font-bold"
-                key={author.name}
-                data-testid="searchResultAuthor"
-              >
-                {renderText(author.name, matches[author.name]?.match)}
-              </li>
-            ))}
+            <SkeletonLoader
+              render={() =>
+                plugin.authors.map((author) => (
+                  <li
+                    className="my-2 font-bold"
+                    key={author.name}
+                    data-testid="searchResultAuthor"
+                  >
+                    {renderText(author.name, matches[author.name]?.match)}
+                  </li>
+                ))
+              }
+            />
           </ul>
 
           {/* Search preview of plugin description. */}
@@ -183,24 +193,45 @@ export function PluginSearchResult({ className, matches, plugin }: Props) {
 
         {/* Plugin metadata */}
         <ul className="mt-4 screen-600:m-0 space-y-1 text-sm">
-          {items.map((item) => (
-            <li
-              key={`${item.label}-${item.value}`}
-              className="grid grid-cols-[auto,1fr]"
-            >
-              <h5 className="inline whitespace-nowrap">{item.label}: </h5>
-              <span
-                className={clsx(
-                  'ml-1',
-                  item.value ? 'font-bold' : 'text-napari-gray',
-                )}
-              >
-                {item.value || 'information not submitted'}
-              </span>
-            </li>
-          ))}
+          <SkeletonLoader
+            className="h-full"
+            render={() =>
+              items.map((item) => (
+                <li
+                  key={`${item.label}-${item.value}`}
+                  className="grid grid-cols-[auto,1fr]"
+                >
+                  <h5 className="inline whitespace-nowrap">{item.label}: </h5>
+                  <span
+                    className={clsx(
+                      'ml-1',
+                      item.value ? 'font-bold' : 'text-napari-gray',
+                    )}
+                  >
+                    {item.value || 'information not submitted'}
+                  </span>
+                </li>
+              ))
+            }
+          />
         </ul>
       </article>
+    );
+  }
+
+  const resultClassName = clsx(className, 'py-5 border-t-2 border-black');
+
+  // Convert to link when loading so that user can't click on result.
+  if (isLoading) {
+    return <div className={resultClassName}>{renderResult()}</div>;
+  }
+
+  return (
+    <Link
+      className={clsx(resultClassName, 'hover:bg-napari-hover-gray')}
+      href={`/plugins/${plugin.name}`}
+    >
+      {renderResult()}
     </Link>
   );
 }

--- a/frontend/src/components/PluginSearch/PluginSearchResultList.tsx
+++ b/frontend/src/components/PluginSearch/PluginSearchResultList.tsx
@@ -1,21 +1,45 @@
 import clsx from 'clsx';
 import { isEmpty } from 'lodash';
 
-import { useSearchState } from '@/context/search';
+import { ColumnLayout, SkeletonLoader } from '@/components/common';
+import { useLoadingState } from '@/context/loading';
+import { SearchResult, useSearchState } from '@/context/search';
+import { PluginIndexData } from '@/types';
 
-import { ColumnLayout } from '../common';
 import { FilterChips } from './FilterChips';
 import { PluginSearchResult } from './PluginSearchResult';
 
+const SKELETON_RESULT_COUNT = 8;
+
+/**
+ * Returns a constant array of fake search results for loading purposes.
+ */
+function getSkeletonResults() {
+  return [...Array<SearchResult>(SKELETON_RESULT_COUNT)].map((_, idx) => ({
+    matches: {},
+    index: 0,
+    plugin: { name: `fake-plugin-${idx}` } as PluginIndexData,
+  }));
+}
+
 export function PluginSearchResultList() {
+  const isLoading = useLoadingState();
   const { filter, results = [] } = useSearchState() ?? {};
+  const searchResults = isLoading ? getSkeletonResults() : results;
 
   return (
     <section className="col-span-2 screen-1425:col-span-3">
       <h3
-        className={clsx('font-bold text-xl', isEmpty(filter?.chips) && 'mb-5')}
+        className={clsx(
+          'flex items-center font-bold text-xl',
+          isEmpty(filter?.chips) && 'mb-5',
+        )}
       >
-        Browse plugins: {results.length}
+        Browse plugins:{' '}
+        <SkeletonLoader
+          className="ml-2 w-6 inline-block"
+          render={() => results.length}
+        />
       </h3>
 
       <FilterChips className="my-5" />
@@ -28,9 +52,9 @@ export function PluginSearchResultList() {
           gap: 'gap-x-6 md:gap-x-12',
         }}
       >
-        {results.map(({ plugin, matches }) => (
+        {searchResults.map(({ plugin, matches }) => (
           <PluginSearchResult
-            className={clsx('col-span-2', 'screen-1425:col-span-3')}
+            className="col-span-2 screen-1425:col-span-3"
             key={plugin.name}
             plugin={plugin}
             matches={matches}

--- a/frontend/src/components/PluginSearch/PluginSearchResultList.tsx
+++ b/frontend/src/components/PluginSearch/PluginSearchResultList.tsx
@@ -5,17 +5,17 @@ import { ColumnLayout, SkeletonLoader } from '@/components/common';
 import { useLoadingState } from '@/context/loading';
 import { SearchResult, useSearchState } from '@/context/search';
 import { PluginIndexData } from '@/types';
+import { getSkeletonResultCount } from '@/utils';
 
 import { FilterChips } from './FilterChips';
 import { PluginSearchResult } from './PluginSearchResult';
-
-const SKELETON_RESULT_COUNT = 8;
 
 /**
  * Returns a constant array of fake search results for loading purposes.
  */
 function getSkeletonResults() {
-  return [...Array<SearchResult>(SKELETON_RESULT_COUNT)].map((_, idx) => ({
+  const count = getSkeletonResultCount();
+  return [...Array<SearchResult>(count)].map((_, idx) => ({
     matches: {},
     index: 0,
     plugin: { name: `fake-plugin-${idx}` } as PluginIndexData,

--- a/frontend/src/components/PluginSearch/PluginSortByForm.tsx
+++ b/frontend/src/components/PluginSearch/PluginSortByForm.tsx
@@ -8,7 +8,7 @@ import {
 import clsx from 'clsx';
 import { motion } from 'framer-motion';
 
-import { Accordion } from '@/components/common';
+import { Accordion, SkeletonLoader } from '@/components/common';
 import { MediaFragment } from '@/components/common/media';
 import { SearchSortType, useSearchState } from '@/context/search';
 
@@ -103,10 +103,15 @@ export function PluginSortByForm() {
   return (
     <>
       <MediaFragment lessThan="screen-875">
-        <Accordion title="Sort By">{form}</Accordion>
+        <SkeletonLoader
+          className="h-12"
+          render={() => <Accordion title="Sort By">{form}</Accordion>}
+        />
       </MediaFragment>
 
-      <MediaFragment greaterThanOrEqual="screen-875">{form}</MediaFragment>
+      <MediaFragment greaterThanOrEqual="screen-875">
+        <SkeletonLoader className="h-40" render={() => form} />
+      </MediaFragment>
     </>
   );
 }

--- a/frontend/src/components/PluginSearch/__snapshots__/PluginSearch.test.tsx.snap
+++ b/frontend/src/components/PluginSearch/__snapshots__/PluginSearch.test.tsx.snap
@@ -244,6 +244,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
     </header>
     <div
       class="bg-napari-light h-36 items-center px-6 md:px-12 grid justify-center gap-6 md:gap-12 grid-cols-2 screen-875:grid-cols-napari-3 screen-1150:grid-cols-napari-3 screen-1425:grid-cols-napari-5"
+      id="search-bar"
     >
       <div
         class="col-span-2 screen-875:col-span-3 screen-1425:col-start-2"
@@ -298,7 +299,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
           class="col-span-2 screen-875:col-span-1 mb-6 screen-875:m-0"
         >
           <div
-            class="MuiPaper-root MuiAccordion-root shadow-none fresnel-lessThan-screen-875 MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiPaper-root MuiAccordion-root shadow-none MuiAccordion-rounded MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
               aria-disabled="false"
@@ -355,7 +356,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
               </div>
             </div>
             <div
-              class="MuiCollapse-container MuiCollapse-hidden"
+              class="MuiCollapse-root MuiCollapse-hidden"
               style="min-height: 0px;"
             >
               <div
@@ -816,7 +817,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                   </div>
                 </div>
                 <div
-                  class="MuiCollapse-container MuiCollapse-hidden"
+                  class="MuiCollapse-root MuiCollapse-hidden"
                   style="min-height: 0px;"
                 >
                   <div
@@ -1568,7 +1569,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
           class="col-span-2 screen-1425:col-span-3"
         >
           <h3
-            class="font-bold text-xl mb-5"
+            class="flex items-center font-bold text-xl mb-5"
           >
             Browse plugins: 36
           </h3>

--- a/frontend/src/components/PluginSearch/__snapshots__/PluginSearch.test.tsx.snap
+++ b/frontend/src/components/PluginSearch/__snapshots__/PluginSearch.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<PluginSearch /> should match snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="flex flex-col min-h-screen"
+    class="flex flex-col"
   >
     <header
       class="bg-napari-primary p-6 screen-495:p-12 grid justify-center gap-x-6 md:gap-x-12 grid-cols-2 screen-875:grid-cols-napari-3 screen-1150:grid-cols-napari-3 screen-1425:grid-cols-napari-5"
@@ -290,7 +290,7 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
       </div>
     </div>
     <div
-      class="flex-grow"
+      class="flex-grow min-h-screen"
     >
       <div
         class="p-6 md:p-12 grid justify-center gap-x-6 md:gap-x-12 grid-cols-2 screen-875:grid-cols-napari-3 screen-1150:grid-cols-napari-3 screen-1425:grid-cols-napari-5"

--- a/frontend/src/components/SearchBar/SearchBar.tsx
+++ b/frontend/src/components/SearchBar/SearchBar.tsx
@@ -8,7 +8,7 @@ import {
   SearchQueryParams,
   useSearchState,
 } from '@/context/search';
-import { setSearchScrollY } from '@/utils';
+import { scrollToSearchBar, setSearchScrollY } from '@/utils';
 
 import styles from './SearchBar.module.scss';
 
@@ -79,6 +79,7 @@ export function SearchBar({ large, ...props }: Props) {
 
       if (searchQuery) {
         setQuery?.(searchQuery);
+        scrollToSearchBar({ behavior: 'smooth' });
       } else {
         clearQuery?.();
       }

--- a/frontend/src/components/SearchBar/SearchBar.tsx
+++ b/frontend/src/components/SearchBar/SearchBar.tsx
@@ -72,11 +72,11 @@ export function SearchBar({ large, ...props }: Props) {
     // Search state is only available on search enabled pages.
     const isSearchPage = results !== undefined;
 
-    if (isSearchPage) {
-      // Reset `scrollY` value so that the browser can scroll to the search
-      // bar after searching.
-      setSearchScrollY(0);
+    // Reset `scrollY` value so that the browser can scroll to the search
+    // bar after searching.
+    setSearchScrollY(0);
 
+    if (isSearchPage) {
       if (searchQuery) {
         setQuery?.(searchQuery);
         scrollToSearchBar({ behavior: 'smooth' });

--- a/frontend/src/components/SearchBar/SearchBar.tsx
+++ b/frontend/src/components/SearchBar/SearchBar.tsx
@@ -8,6 +8,7 @@ import {
   SearchQueryParams,
   useSearchState,
 } from '@/context/search';
+import { setSearchScrollY } from '@/utils';
 
 import styles from './SearchBar.module.scss';
 
@@ -72,6 +73,10 @@ export function SearchBar({ large, ...props }: Props) {
     const isSearchPage = results !== undefined;
 
     if (isSearchPage) {
+      // Reset `scrollY` value so that the browser can scroll to the search
+      // bar after searching.
+      setSearchScrollY(0);
+
       if (searchQuery) {
         setQuery?.(searchQuery);
       } else {

--- a/frontend/src/components/common/SkeletonLoader/SkeletonLoader.test.tsx
+++ b/frontend/src/components/common/SkeletonLoader/SkeletonLoader.test.tsx
@@ -1,0 +1,31 @@
+import { render } from '@testing-library/react';
+
+import { LoadingStateProvider } from '@/context/loading';
+
+import { SkeletonLoader } from './SkeletonLoader';
+
+describe('<SkeletonLoader />', () => {
+  const text = 'Hello, World!';
+
+  it('should match snapshot', () => {
+    let component = render(<SkeletonLoader render={() => <h1>{text}</h1>} />);
+    expect(component.asFragment()).toMatchSnapshot();
+
+    component = render(
+      <LoadingStateProvider loading={false}>
+        <SkeletonLoader render={() => <h1>{text}</h1>} />
+      </LoadingStateProvider>,
+    );
+    expect(component.asFragment()).toMatchSnapshot();
+  });
+
+  it('should render skeleton when loading', () => {
+    const component = render(
+      <LoadingStateProvider loading>
+        <SkeletonLoader render={() => <h1>{text}</h1>} />
+      </LoadingStateProvider>,
+    );
+
+    expect(component.getByTestId('skeleton-loader')).toBeDefined();
+  });
+});

--- a/frontend/src/components/common/SkeletonLoader/SkeletonLoader.tsx
+++ b/frontend/src/components/common/SkeletonLoader/SkeletonLoader.tsx
@@ -1,0 +1,33 @@
+import { Skeleton } from '@material-ui/lab';
+import { ReactNode } from 'react';
+
+import { useLoadingState } from '@/context/loading';
+
+interface Props {
+  /**
+   * Class to apply to Skeleton loader.
+   */
+  className?: string;
+
+  /**
+   * Render function that returns the node to render when not loading.
+   *
+   * https://reactjs.org/docs/render-props.html
+   */
+  render(): ReactNode;
+}
+
+/**
+ * Component that renders a skeleton loader when the global loading state is `true`.
+ */
+export function SkeletonLoader({ className, render }: Props) {
+  const isLoading = useLoadingState();
+  if (!isLoading) return <>{render()}</>;
+  return (
+    <Skeleton
+      className={className}
+      data-testid="skeleton-loader"
+      variant="rect"
+    />
+  );
+}

--- a/frontend/src/components/common/SkeletonLoader/__snapshots__/SkeletonLoader.test.tsx.snap
+++ b/frontend/src/components/common/SkeletonLoader/__snapshots__/SkeletonLoader.test.tsx.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<SkeletonLoader /> should match snapshot 1`] = `
+<DocumentFragment>
+  <h1>
+    Hello, World!
+  </h1>
+</DocumentFragment>
+`;
+
+exports[`<SkeletonLoader /> should match snapshot 2`] = `
+<DocumentFragment>
+  <h1>
+    Hello, World!
+  </h1>
+</DocumentFragment>
+`;

--- a/frontend/src/components/common/SkeletonLoader/index.ts
+++ b/frontend/src/components/common/SkeletonLoader/index.ts
@@ -1,0 +1,1 @@
+export * from './SkeletonLoader';

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -5,5 +5,6 @@ export * from './ErrorMessage';
 export * from './Link';
 export * from './Markdown';
 export * from './Overlay';
+export * from './SkeletonLoader';
 export * from './TableOfContents';
 export * from './TextHighlighter';

--- a/frontend/src/constants/search.ts
+++ b/frontend/src/constants/search.ts
@@ -1,0 +1,10 @@
+/**
+ * ID used for the plugin search bar on the home page.
+ */
+export const SEARCH_BAR_ID = 'search-bar';
+
+/**
+ * Key used for storing vertical scroll value on the search page. See `_app.tsx`
+ * and `AppBarLinks.tsx` for implementation details.
+ */
+export const SEARCH_SCROLL_Y_KEY = 'search-scroll-y';

--- a/frontend/src/constants/search.ts
+++ b/frontend/src/constants/search.ts
@@ -2,9 +2,3 @@
  * ID used for the plugin search bar on the home page.
  */
 export const SEARCH_BAR_ID = 'search-bar';
-
-/**
- * Key used for storing vertical scroll value on the search page. See `_app.tsx`
- * and `AppBarLinks.tsx` for implementation details.
- */
-export const SEARCH_SCROLL_Y_KEY = 'search-scroll-y';

--- a/frontend/src/context/loading.tsx
+++ b/frontend/src/context/loading.tsx
@@ -1,0 +1,28 @@
+import { createContext, ReactNode, useContext } from 'react';
+
+const LoadingStateContext = createContext<boolean>(false);
+
+interface Props {
+  loading: boolean;
+  children: ReactNode;
+}
+
+/**
+ * Provider for providing global loading state to a component tree.
+ */
+export function LoadingStateProvider({ children, loading }: Props) {
+  return (
+    <LoadingStateContext.Provider value={loading}>
+      {children}
+    </LoadingStateContext.Provider>
+  );
+}
+
+/**
+ * Returns the global loading state.
+ *
+ * @returns The loading state.
+ */
+export function useLoadingState(): boolean {
+  return useContext(LoadingStateContext);
+}

--- a/frontend/src/context/search/constants.ts
+++ b/frontend/src/context/search/constants.ts
@@ -23,3 +23,9 @@ export enum SearchQueryParams {
   Search = 'search',
   Sort = 'sort',
 }
+
+/**
+ * Small buffer for skeleton results because the heights for the skeleton
+ * results are not the same as the actual results.
+ */
+export const SKELETON_RESULT_COUNT_BUFFER = 5;

--- a/frontend/src/context/search/index.ts
+++ b/frontend/src/context/search/index.ts
@@ -1,3 +1,3 @@
 export * from './constants';
 export * from './search.context';
-export type { SearchResultMatch } from './search.types';
+export type { SearchResult, SearchResultMatch } from './search.types';

--- a/frontend/src/context/search/search.context.tsx
+++ b/frontend/src/context/search/search.context.tsx
@@ -4,7 +4,7 @@ import { ReactNode } from 'react-markdown';
 import { PluginIndexData } from '@/types';
 
 import { useFilters } from './filter.hooks';
-import { useSearch, useSearchSetSortType } from './search.hooks';
+import { useSearch, useSearchEffects } from './search.hooks';
 import { useSort } from './sort.hooks';
 import { SearchState } from './types';
 
@@ -31,7 +31,7 @@ export function PluginSearchProvider({ children, pluginIndex }: Props) {
   const { filterForm, filteredResults } = useFilters(results);
   const { sortForm, sortedResults } = useSort(filteredResults);
 
-  useSearchSetSortType(searchForm.query, sortForm);
+  useSearchEffects(searchForm.query, sortForm);
 
   return (
     <PluginSearchStateContext.Provider

--- a/frontend/src/context/search/search.context.tsx
+++ b/frontend/src/context/search/search.context.tsx
@@ -31,7 +31,11 @@ export function PluginSearchProvider({ children, pluginIndex }: Props) {
   const { filterForm, filteredResults } = useFilters(results);
   const { sortForm, sortedResults } = useSort(filteredResults);
 
-  useSearchEffects(searchForm.query, sortForm);
+  useSearchEffects({
+    sortForm,
+    query: searchForm.query,
+    results: sortedResults,
+  });
 
   return (
     <PluginSearchStateContext.Provider

--- a/frontend/src/context/search/search.hooks.test.ts
+++ b/frontend/src/context/search/search.hooks.test.ts
@@ -11,7 +11,7 @@ import {
   SearchQueryParams,
   SearchSortType,
 } from './constants';
-import { useSearch, useSearchSetSortType } from './search.hooks';
+import { useSearch, useSearchEffects } from './search.hooks';
 import { SearchEngine, SearchResult } from './search.types';
 import type { SortForm } from './sort.hooks';
 
@@ -89,7 +89,7 @@ describe('useSearch()', () => {
   });
 });
 
-describe('useSearchSetSortType()', () => {
+describe('useSearchEffects()', () => {
   let form: SortForm;
   const oldLocation = window.location;
 
@@ -111,19 +111,19 @@ describe('useSearchSetSortType()', () => {
   }
 
   it('should set sort type to relevance on intial load', () => {
-    renderHook(() => useSearchSetSortType('video', form));
+    renderHook(() => useSearchEffects('video', form));
     expect(form.setSortType).toHaveBeenCalled();
   });
 
   it('should not set sort type to relevance when user has sort type on initial load', () => {
     mockSortType(SearchSortType.PluginName);
-    renderHook(() => useSearchSetSortType('video', form));
+    renderHook(() => useSearchEffects('video', form));
     expect(form.setSortType).not.toHaveBeenCalled();
   });
 
   it('should set sort type to relevance when user enters query', () => {
     let query = '';
-    const { rerender } = renderHook(() => useSearchSetSortType(query, form));
+    const { rerender } = renderHook(() => useSearchEffects(query, form));
     expect(form.setSortType).not.toHaveBeenCalled();
 
     query = 'video';
@@ -133,7 +133,7 @@ describe('useSearchSetSortType()', () => {
 
   it('should set sort type to default when user clears query and sort type is relevance', () => {
     let query = 'video';
-    const { rerender } = renderHook(() => useSearchSetSortType(query, form));
+    const { rerender } = renderHook(() => useSearchEffects(query, form));
 
     query = '';
     rerender();
@@ -143,7 +143,7 @@ describe('useSearchSetSortType()', () => {
   it('should maintain sort type when user clears query and sort type is not relevance', () => {
     mockSortType(SearchSortType.PluginName);
     let query = 'video';
-    const { rerender } = renderHook(() => useSearchSetSortType(query, form));
+    const { rerender } = renderHook(() => useSearchEffects(query, form));
 
     query = '';
     rerender();

--- a/frontend/src/context/search/search.hooks.ts
+++ b/frontend/src/context/search/search.hooks.ts
@@ -1,4 +1,3 @@
-import { debounce } from 'lodash';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { usePrevious } from 'react-use';
 import { StringParam, useQueryParam, withDefault } from 'use-query-params';
@@ -13,6 +12,7 @@ import {
   DEFAULT_SORT_TYPE,
   SearchQueryParams,
   SearchSortType,
+  SKELETON_RESULT_COUNT_BUFFER,
 } from './constants';
 import { FuseSearchEngine } from './engines';
 import { SearchEngine, SearchResult } from './search.types';
@@ -152,11 +152,7 @@ function getSortParameter() {
   return url.searchParams.get(SearchQueryParams.Sort);
 }
 
-// Debounce `setSkeletonResultCount()` because there may be multiple state
-// re-renders in quick succession where `result.length` doesn't change.
-const debouncedSetSkeletonResultCount = debounce(setSkeletonResultCount, 300);
-
-interface UseSearchEffectsOptions {
+export interface UseSearchEffectsOptions {
   query: string | undefined;
   sortForm: SortForm;
   results: SearchResult[];
@@ -204,8 +200,6 @@ export function useSearchEffects({
   }, [sortForm, query]);
 
   useEffect(() => {
-    // Add a small buffer because the heights for the skeleton results are not
-    // the same as the actual results.
-    debouncedSetSkeletonResultCount(results.length + 5);
+    setSkeletonResultCount(results.length + SKELETON_RESULT_COUNT_BUFFER);
   }, [results]);
 }

--- a/frontend/src/context/search/search.hooks.ts
+++ b/frontend/src/context/search/search.hooks.ts
@@ -4,6 +4,7 @@ import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
 import { useActiveURLParameter, usePlausible } from '@/hooks';
 import { PluginIndexData } from '@/types';
+import { getSearchScrollY, scrollToSearchBar } from '@/utils';
 import { Logger } from '@/utils/logger';
 import { measureExecution } from '@/utils/performance';
 
@@ -160,10 +161,7 @@ function getSortParameter() {
  * @param query The query string
  * @param form The sort form
  */
-export function useSearchSetSortType(
-  query: string | undefined,
-  form: SortForm,
-) {
+export function useSearchEffects(query: string | undefined, form: SortForm) {
   // Ref used to determine if user is searching or not. This ref is `true` when
   // `query` is a non-empty string, and `false` when `query` is an empty string.
   // This is used to reduce calls to `form.setSortType()` when the `form` object changes.
@@ -180,6 +178,15 @@ export function useSearchSetSortType(
       // already set using some other value.
       if (!initialLoadRef.current || !getSortParameter()) {
         form.setSortType(SearchSortType.Relevance);
+      }
+
+      const scrollY = getSearchScrollY();
+      // The value is `0` on initial load and when the user submits a search query.
+      if (scrollY === 0) {
+        scrollToSearchBar({
+          // Smooth scroll to search bar when user submits a search query.
+          behavior: initialLoadRef.current ? 'auto' : 'smooth',
+        });
       }
 
       isSearchingRef.current = true;

--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -22,15 +22,6 @@ html {
     https://stackoverflow.com/questions/63965489/safari-14-min-max-clamp-not-working-with-vw-and-px-values#comment116930866_65093383
   */
   min-height: 0.0001vw;
-
-  /*
-    Use smooth transition when scrolling between different parts of the page.
-
-    TODO This currently has no support in Safari, so we'll probably have to
-    implement a solution in TypeScript.
-    https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior
-  */
-  scroll-behavior: smooth;
 }
 
 body {

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './useActiveURLParameter';
+export * from './usePageTransitions';
 export * from './usePlausible';

--- a/frontend/src/hooks/usePageTransitions.ts
+++ b/frontend/src/hooks/usePageTransitions.ts
@@ -55,17 +55,17 @@ export function usePageTransitions() {
     scrollYRef.current = window.scrollY;
   }, []);
 
-  function addScrollHandler() {
-    scrollYRef.current = 0;
-    shouldScrollRef.current = true;
-    document.addEventListener('scroll', loadingScrollHandler);
-  }
-
-  function removeScrollHandler() {
-    document.removeEventListener('scroll', loadingScrollHandler);
-  }
-
   useEffect(() => {
+    function addScrollHandler() {
+      scrollYRef.current = 0;
+      shouldScrollRef.current = true;
+      document.addEventListener('scroll', loadingScrollHandler);
+    }
+
+    function removeScrollHandler() {
+      document.removeEventListener('scroll', loadingScrollHandler);
+    }
+
     function onLoading(url: string, { shallow }: RouteEvent) {
       if (shallow) return;
 

--- a/frontend/src/hooks/usePageTransitions.ts
+++ b/frontend/src/hooks/usePageTransitions.ts
@@ -89,13 +89,7 @@ export function usePageTransitions() {
         //
         // https://mzl.la/36x9rzG
         requestAnimationFrame(() => {
-          // This function gets the distance using `offsetTop`, which will cause
-          // a reflow. While this is usually bad for animations, it's fine here
-          // because we're using `requestAnimationFrame()` for scheduling
-          // instead of animation, so the function is only being called once per
-          // page load.
-          const distanceFromTop = getSearchBarDistanceFromTop();
-          window.scroll(0, Math.min(scrollY, distanceFromTop));
+          window.scroll(0, scrollY);
 
           // Schedule scroll handler registration for next frame so that above
           // scroll doesn't trigger a scroll event.
@@ -119,19 +113,7 @@ export function usePageTransitions() {
       removeScrollHandler();
 
       if (isSearchPage(url)) {
-        setTimeout(() => {
-          const scrollY = getSearchScrollY();
-
-          if (window.scrollY !== scrollY && shouldScrollRef.current) {
-            // Schedule scroll on macrotask queue for execution later. This is
-            // required because at runtime, the DOM hasn't finished loading yet
-            // for the current page.
-            window.scroll({
-              top: scrollY,
-              behavior: 'smooth',
-            });
-          }
-        });
+        console.log('finished loading search page');
       } else if (isPluginPage(url)) {
         // Scroll to current scroll position while plugin page was loading. If
         // the user didn't scroll at all, this will be 0.

--- a/frontend/src/hooks/usePageTransitions.ts
+++ b/frontend/src/hooks/usePageTransitions.ts
@@ -155,7 +155,7 @@ export function usePageTransitions() {
       router.events.off('routeChangeComplete', onFinishLoading);
       router.events.off('routeChangeError', onError);
     };
-  }, [addScrollHandler, removeScrollHandler, router]);
+  }, [loadingScrollHandler, router]);
 
   return { loading, nextUrl };
 }

--- a/frontend/src/hooks/usePageTransitions.ts
+++ b/frontend/src/hooks/usePageTransitions.ts
@@ -1,12 +1,7 @@
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import {
-  getSearchBarDistanceFromTop,
-  getSearchScrollY,
-  Logger,
-  setSearchScrollY,
-} from '@/utils';
+import { getSearchScrollY, Logger, setSearchScrollY } from '@/utils';
 import { isPluginPage, isSearchPage } from '@/utils/page';
 
 const logger = new Logger('usePageTransitions.ts');
@@ -112,9 +107,7 @@ export function usePageTransitions() {
 
       removeScrollHandler();
 
-      if (isSearchPage(url)) {
-        console.log('finished loading search page');
-      } else if (isPluginPage(url)) {
+      if (isPluginPage(url)) {
         // Scroll to current scroll position while plugin page was loading. If
         // the user didn't scroll at all, this will be 0.
         window.scroll(0, scrollYRef.current);

--- a/frontend/src/hooks/usePageTransitions.ts
+++ b/frontend/src/hooks/usePageTransitions.ts
@@ -82,7 +82,7 @@ export function usePageTransitions() {
         // render. As a result, this avoids flickering between the top of the
         // page and the `scrollY` location.
         //
-        // https://mzl.la/36x9rzG
+        // https://mzl.la/2UvTwz4
         requestAnimationFrame(() => {
           window.scroll(0, scrollY);
 

--- a/frontend/src/hooks/usePageTransitions.ts
+++ b/frontend/src/hooks/usePageTransitions.ts
@@ -1,0 +1,153 @@
+import { useRouter } from 'next/router';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  getSearchBarDistanceFromTop,
+  getSearchScrollY,
+  Logger,
+  setSearchScrollY,
+} from '@/utils';
+import { isPluginPage, isSearchPage } from '@/utils/page';
+
+const logger = new Logger('usePageTransitions.ts');
+
+/**
+ * Event data for route transitions.
+ * https://nextjs.org/docs/api-reference/next/router#routerevents
+ */
+interface RouteEvent {
+  // Boolean for if route fetched data
+  /**
+   * Boolean indicating if route fetched data or not:
+   */
+  shallow: boolean;
+}
+
+/**
+ * Hook to manage page transitions effects and state.
+ */
+export function usePageTransitions() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  // URL state for components to know what URL is currently loading.
+  const [nextUrl, setNextUrl] = useState('');
+
+  // Ref for indicating whether this is the first render or not.
+  const initialLoadRef = useRef(true);
+
+  // Ref for storing the current `scrollY` value.
+  const scrollYRef = useRef(0);
+
+  // Ref for indicating whether the browser should automatically scroll to the
+  // last scroll point.
+  const shouldScrollRef = useRef(true);
+
+  // Memoized scroll handler used for updating the scroll refs while the page is loading.
+  const loadingScrollHandler = useCallback(() => {
+    if (!initialLoadRef.current) {
+      shouldScrollRef.current = false;
+    }
+
+    initialLoadRef.current = false;
+    scrollYRef.current = window.scrollY;
+  }, []);
+
+  useEffect(() => {
+    function onLoading(url: string, { shallow }: RouteEvent) {
+      if (shallow) return;
+
+      // Save `scrollY` if navigating away from the search page.
+      if (isSearchPage(router) && !isSearchPage(url)) {
+        setSearchScrollY(window.scrollY);
+      }
+
+      if (isSearchPage(url)) {
+        const scrollY = getSearchScrollY();
+
+        // Schedule scroll for later execution. At runtime, the DOM is not yet
+        // ready, so layout hasn't been calculated for the page. Because of
+        // this, the distance from top will be `0`.
+        //
+        // The fix is to schedule for later execution using
+        // `requestAnimationFrame()`. This will call the function before
+        // painting and layout, allowing us to set scroll the before the first
+        // render. As a result, this avoids flickering between the top of the
+        // page and the `scrollY` location.
+        //
+        // https://mzl.la/36x9rzG
+        requestAnimationFrame(() => {
+          // This function gets the distance using `offsetTop`, which will cause
+          // a reflow. While this is usually bad for animations, it's fine here
+          // because we're using `requestAnimationFrame()` for scheduling
+          // instead of animation, so the function is only being called once per
+          // page load.
+          const distanceFromTop = getSearchBarDistanceFromTop();
+          window.scroll(0, Math.min(scrollY, distanceFromTop));
+
+          // Schedule scroll handler registration as separate task so that above
+          // scroll doesn't trigger a scroll event.
+          setTimeout(() => {
+            shouldScrollRef.current = true;
+            document.addEventListener('scroll', loadingScrollHandler);
+          });
+        });
+      } else if (isPluginPage(url)) {
+        // Scroll to top of the plugin page loader.
+        window.scroll(0, 0);
+        shouldScrollRef.current = true;
+        document.addEventListener('scroll', loadingScrollHandler);
+      }
+
+      setNextUrl(url);
+      setLoading(true);
+    }
+
+    function onFinishLoading(url: string, { shallow }: RouteEvent) {
+      if (shallow) return;
+
+      if (isSearchPage(url)) {
+        const scrollY = getSearchScrollY();
+
+        if (window.scrollY !== scrollY && shouldScrollRef.current) {
+          // Schedule scroll on macrotask queue for execution later. This is
+          // required because at runtime, the DOM hasn't finished loading yet
+          // for the current page.
+          setTimeout(() =>
+            window.scroll({
+              top: scrollY,
+              behavior: 'smooth',
+            }),
+          );
+        }
+
+        document.removeEventListener('scroll', loadingScrollHandler);
+      } else if (isPluginPage(url)) {
+        document.removeEventListener('scroll', loadingScrollHandler);
+
+        // Scroll to current scroll position while plugin page was loading. If
+        // the user didn't scroll at all, this will be 0.
+        window.scroll(0, scrollYRef.current);
+      }
+
+      setLoading(false);
+    }
+
+    const onError = (error: Error, url: string, event: RouteEvent) => {
+      logger.error('Error loading route:', error);
+      onFinishLoading(url, event);
+    };
+
+    router.events.on('routeChangeStart', onLoading);
+    router.events.on('routeChangeComplete', onFinishLoading);
+    router.events.on('routeChangeError', onError);
+
+    return () => {
+      router.events.off('routeChangeStart', onLoading);
+      router.events.off('routeChangeComplete', onFinishLoading);
+      router.events.off('routeChangeError', onError);
+    };
+  }, [router, loadingScrollHandler]);
+
+  return { loading, nextUrl };
+}

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -12,18 +12,24 @@ import { StylesProvider, ThemeProvider } from '@material-ui/styles';
 import { AppProps } from 'next/app';
 import Head from 'next/head';
 import NextPlausibleProvider from 'next-plausible';
-import { ReactNode, useEffect, useRef } from 'react';
+import { ComponentType, ReactNode, useEffect, useRef } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
 import { Hydrate } from 'react-query/hydration';
 
 import { Layout } from '@/components';
 import { MediaContextProvider } from '@/components/common/media';
+import { LoadingStateProvider } from '@/context/loading';
+import { usePageTransitions } from '@/hooks';
+import SearchPage from '@/pages/index';
+import PluginPage from '@/pages/plugins/[name]';
 import { theme } from '@/theme';
+import { PluginData } from '@/types';
+import { isPluginPage, isSearchPage } from '@/utils/page';
 
-interface GetLayoutComponent {
+type GetLayoutComponent = ComponentType & {
   getLayout?(page: ReactNode): ReactNode;
-}
+};
 
 interface QueryProviderProps {
   children: ReactNode;
@@ -94,11 +100,50 @@ function PlausibleProvider({ children }: ProviderProps) {
 }
 
 export default function App({ Component, pageProps }: AppProps) {
-  // Render using custom layout if component exports one:
-  // https://adamwathan.me/2019/10/17/persistent-layout-patterns-in-nextjs/
-  const { getLayout } = Component as GetLayoutComponent;
-  let page: ReactNode = <Component {...pageProps} />;
-  page = getLayout?.(page) ?? <Layout>{page}</Layout>;
+  const { loading, nextUrl } = usePageTransitions();
+
+  /**
+   * Render using custom layout if component exports one:
+   * https://adamwathan.me/2019/10/17/persistent-layout-patterns-in-nextjs/
+   */
+  function withLayout(
+    node: ReactNode,
+    { getLayout }: GetLayoutComponent = Component,
+  ) {
+    return getLayout?.(node) ?? <Layout>{node}</Layout>;
+  }
+
+  /**
+   * Renders the appropriate loader component for a specific page.
+   */
+  function getLoaderComponent() {
+    const searchPageLoader = isSearchPage(nextUrl) && (
+      <LoadingStateProvider loading key="/">
+        <SearchPage index={[]} licenses={[]} />
+      </LoadingStateProvider>
+    );
+
+    const pluginPageLoader = isPluginPage(nextUrl) && (
+      <Layout>
+        <LoadingStateProvider loading key="/plugins">
+          <PluginPage plugin={{} as PluginData} />
+        </LoadingStateProvider>
+      </Layout>
+    );
+
+    const loaders = [searchPageLoader, pluginPageLoader];
+
+    if (!loaders.some(Boolean)) {
+      return null;
+    }
+
+    return loaders;
+  }
+
+  // Use loader if page is loading and next page has a loader component.
+  let loader: ReactNode;
+  const isLoading = loading && (loader = getLoaderComponent());
+  const page = isLoading ? loader : withLayout(<Component {...pageProps} />);
 
   return (
     <>

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import { AxiosError } from 'axios';
+import { debounce } from 'lodash';
 import Head from 'next/head';
-import { ReactNode } from 'react';
+import { ReactNode, useEffect } from 'react';
 
 import { hubAPI, spdxLicenseDataAPI } from '@/axios';
 import { ErrorMessage } from '@/components/common';
@@ -14,6 +15,7 @@ import {
 } from '@/context/spdx';
 import { URLParameterStateProvider } from '@/context/urlParameters';
 import { PluginIndexData } from '@/types';
+import { setSearchScrollY } from '@/utils/search';
 
 interface Props {
   licenses?: SpdxLicenseData[];
@@ -83,6 +85,19 @@ export async function getServerSideProps() {
 
 export default function Home({ error, index, licenses }: Props) {
   const isLoading = useLoadingState();
+
+  useEffect(() => {
+    function scrollHandler() {
+      setSearchScrollY(window.scrollY);
+    }
+
+    // Debounce scroll handler so that we don't overrun the main thread with
+    // `localStorage.set()` calls.
+    const debouncedScrollHandler = debounce(scrollHandler, 300);
+
+    document.addEventListener('scroll', debouncedScrollHandler);
+    return () => document.removeEventListener('scroll', debouncedScrollHandler);
+  }, []);
 
   return (
     <>

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -5,6 +5,7 @@ import { ReactNode } from 'react';
 import { hubAPI, spdxLicenseDataAPI } from '@/axios';
 import { ErrorMessage } from '@/components/common';
 import { PluginSearch } from '@/components/PluginSearch';
+import { useLoadingState } from '@/context/loading';
 import { PluginSearchProvider } from '@/context/search';
 import {
   SpdxLicenseData,
@@ -81,6 +82,8 @@ export async function getServerSideProps() {
 }
 
 export default function Home({ error, index, licenses }: Props) {
+  const isLoading = useLoadingState();
+
   return (
     <>
       <Head>
@@ -94,9 +97,18 @@ export default function Home({ error, index, licenses }: Props) {
         licenses && (
           <URLParameterStateProvider>
             <SpdxLicenseProvider licenses={licenses}>
-              <PluginSearchProvider pluginIndex={index}>
+              {/*
+                Don't render PluginSearchProvider while loading. For some
+                reason, rendering while loading leads to a bug that freezes the
+                entire UI.
+              */}
+              {isLoading ? (
                 <PluginSearch />
-              </PluginSearchProvider>
+              ) : (
+                <PluginSearchProvider pluginIndex={index}>
+                  <PluginSearch />
+                </PluginSearchProvider>
+              )}
             </SpdxLicenseProvider>
           </URLParameterStateProvider>
         )

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -3,8 +3,7 @@
  * Tailwind config can import it in a Node.js environment.
  */
 
-const createMuiTheme = require('@material-ui/core/styles/createMuiTheme')
-  .default;
+const createTheme = require('@material-ui/core/styles/createTheme').default;
 
 const colors = {
   primary: '#80d1ff',
@@ -42,7 +41,7 @@ const breakpoints = {
 
 const fontFamily = ['Barlow', 'sans-serif'];
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: colors.primary,

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './format';
 export * from './logger';
+export * from './page';
 export * from './performance';
 export * from './react';
 export * from './search';

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from './format';
 export * from './logger';
 export * from './performance';
 export * from './react';
+export * from './search';

--- a/frontend/src/utils/page.ts
+++ b/frontend/src/utils/page.ts
@@ -1,0 +1,19 @@
+import { NextRouter } from 'next/router';
+
+type UrlType = string | NextRouter;
+
+function getPathname(url: UrlType) {
+  if (typeof url === 'string') {
+    return new URL(url, 'http://localhost').pathname;
+  }
+
+  return url.pathname;
+}
+
+export function isSearchPage(url: UrlType): boolean {
+  return getPathname(url) === '/';
+}
+
+export function isPluginPage(url: UrlType): boolean {
+  return getPathname(url).includes('/plugins/');
+}

--- a/frontend/src/utils/search.ts
+++ b/frontend/src/utils/search.ts
@@ -1,4 +1,22 @@
-import { SEARCH_BAR_ID, SEARCH_SCROLL_Y_KEY } from '@/constants/search';
+import { SEARCH_BAR_ID } from '@/constants/search';
+
+/**
+ * Key used for storing vertical scroll value on the search page. See `_app.tsx`
+ * and `AppBarLinks.tsx` for implementation details.
+ */
+const SEARCH_SCROLL_Y_KEY = 'search-scroll-y';
+
+/**
+ * Key used for storing the number of skeleton results to render on the plugin
+ * search page when it's loading.
+ */
+const SEARCH_SKELETON_COUNT_KEY = 'search-skeleton-count';
+const SEARCH_DEFAULT_SKELETON_COUNT = 8;
+
+// Variables to store `localStorage` values in memory so that reads will only
+// query `localStorage` at once.
+let searchScrollY: number | undefined;
+let searchSkeletonResultCount: number | undefined;
 
 /**
  * Retrieves the last used `scrollY` value from when the user last visited the
@@ -7,10 +25,14 @@ import { SEARCH_BAR_ID, SEARCH_SCROLL_Y_KEY } from '@/constants/search';
  * @returns The `scrollY` value or 0 if undefined.
  */
 export function getSearchScrollY(): number {
-  return parseInt(
-    window.sessionStorage.getItem(SEARCH_SCROLL_Y_KEY) ?? '0',
-    10,
-  );
+  if (!searchScrollY) {
+    searchScrollY = parseInt(
+      window.sessionStorage.getItem(SEARCH_SCROLL_Y_KEY) ?? '0',
+      10,
+    );
+  }
+
+  return searchScrollY;
 }
 
 /**
@@ -22,7 +44,33 @@ export function getSearchScrollY(): number {
  * @param scrollY The current `scrollY` value
  */
 export function setSearchScrollY(scrollY: number): void {
+  searchScrollY = scrollY;
   window.sessionStorage.setItem(SEARCH_SCROLL_Y_KEY, String(scrollY));
+}
+
+/**
+ * Gets the number of results the search page should render while loading.
+ *
+ * @returns The result count.
+ */
+export function getSkeletonResultCount(): number {
+  if (!searchSkeletonResultCount) {
+    const value = window.sessionStorage.getItem(SEARCH_SKELETON_COUNT_KEY);
+    searchSkeletonResultCount = value ? +value : SEARCH_DEFAULT_SKELETON_COUNT;
+  }
+
+  return searchSkeletonResultCount;
+}
+
+/**
+ * Stores the current search result count to use for the skeleton count the next
+ * time the user loads the search page.
+ *
+ * @param count The result count.
+ */
+export function setSkeletonResultCount(count: number): void {
+  searchSkeletonResultCount = count;
+  window.sessionStorage.setItem(SEARCH_SKELETON_COUNT_KEY, String(count));
 }
 
 function getSearchBar() {

--- a/frontend/src/utils/search.ts
+++ b/frontend/src/utils/search.ts
@@ -45,7 +45,7 @@ export function getSearchScrollY(): number {
  *
  * @param scrollY The current `scrollY` value
  */
-export function setSearchScrollYBase(scrollY: number): void {
+export function setSearchScrollY(scrollY: number): void {
   searchScrollY = scrollY;
   window.sessionStorage.setItem(SEARCH_SCROLL_Y_KEY, String(scrollY));
 }

--- a/frontend/src/utils/search.ts
+++ b/frontend/src/utils/search.ts
@@ -1,0 +1,57 @@
+import { SEARCH_BAR_ID, SEARCH_SCROLL_Y_KEY } from '@/constants/search';
+
+/**
+ * Retrieves the last used `scrollY` value from when the user last visited the
+ * search page.
+ *
+ * @returns The `scrollY` value or 0 if undefined.
+ */
+export function getSearchScrollY(): number {
+  return parseInt(
+    window.sessionStorage.getItem(SEARCH_SCROLL_Y_KEY) ?? '0',
+    10,
+  );
+}
+
+/**
+ * Stores the current `scrollY` value used on the search page. This is used for
+ * going back to the last scroll location in case the user goes back from
+ * another page. This uses `sessionStorage` so that the value is only persistent
+ * for the current tab.
+ *
+ * @param scrollY The current `scrollY` value
+ */
+export function setSearchScrollY(scrollY: number): void {
+  window.sessionStorage.setItem(SEARCH_SCROLL_Y_KEY, String(scrollY));
+}
+
+function getSearchBar() {
+  return document.getElementById(SEARCH_BAR_ID);
+}
+
+/**
+ * Gets the distance between the top of the viewport and the search bar on the
+ * search page.
+ *
+ * @returns The distance.
+ */
+export function getSearchBarDistanceFromTop(): number {
+  const searchBar = getSearchBar();
+  return searchBar?.offsetTop ?? 0;
+}
+
+/**
+ * Scroll to the search bar on the search page. Smooth scrolling can be enabled
+ * using the `options.behavior` parameter in case smooth scrolling is better for
+ * UX for a particular feature.
+ *
+ * @param options Scrolling behavior options.
+ */
+export function scrollToSearchBar(options: ScrollOptions = {}): void {
+  const searchBar = getSearchBar();
+  searchBar?.scrollIntoView({
+    ...options,
+    inline: 'nearest',
+    block: 'start',
+  });
+}

--- a/frontend/src/utils/search.ts
+++ b/frontend/src/utils/search.ts
@@ -1,3 +1,5 @@
+import { debounce } from 'lodash';
+
 import { SEARCH_BAR_ID } from '@/constants/search';
 
 /**
@@ -43,7 +45,7 @@ export function getSearchScrollY(): number {
  *
  * @param scrollY The current `scrollY` value
  */
-export function setSearchScrollY(scrollY: number): void {
+export function setSearchScrollYBase(scrollY: number): void {
   searchScrollY = scrollY;
   window.sessionStorage.setItem(SEARCH_SCROLL_Y_KEY, String(scrollY));
 }
@@ -68,10 +70,16 @@ export function getSkeletonResultCount(): number {
  *
  * @param count The result count.
  */
-export function setSkeletonResultCount(count: number): void {
+function setSkeletonResultCountBase(count: number): void {
   searchSkeletonResultCount = count;
   window.sessionStorage.setItem(SEARCH_SKELETON_COUNT_KEY, String(count));
 }
+
+/**
+ * Debounced export for `setSkeletonResultCount()` since this function may be
+ * called multiple times a second due to state re-renders.
+ */
+export const setSkeletonResultCount = debounce(setSkeletonResultCountBase, 300);
 
 function getSearchBar() {
   return document.getElementById(SEARCH_BAR_ID);

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -677,14 +677,14 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@material-ui/core@^4.11.4":
-  version "4.11.4"
-  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.11.4.tgz"
-  integrity sha512-oqb+lJ2Dl9HXI9orc6/aN8ZIAMkeThufA5iZELf2LQeBn2NtjVilF5D2w7e9RpntAzDb4jK5DsVhkfOvFY/8fg==
+"@material-ui/core@^4.12.1":
+  version "4.12.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.12.1.tgz#ac8f081498047aa02bb6ee70b77c5dad6a2a6e73"
+  integrity sha512-C6hYsjkWCTfBx9FaqxhCZCITBagh7fyCKFtHyvO3tTOcBw6NJaktdhNZ2n82jQdQdgfFvg6OOxi7OOzsAdAcBQ==
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@material-ui/styles" "^4.11.4"
-    "@material-ui/system" "^4.11.3"
+    "@material-ui/system" "^4.12.1"
     "@material-ui/types" "5.1.0"
     "@material-ui/utils" "^4.11.2"
     "@types/react-transition-group" "^4.2.0"
@@ -701,6 +701,17 @@
   integrity sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==
   dependencies:
     "@babel/runtime" "^7.4.4"
+
+"@material-ui/lab@^4.0.0-alpha.60":
+  version "4.0.0-alpha.60"
+  resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-4.0.0-alpha.60.tgz#5ad203aed5a8569b0f1753945a21a05efa2234d2"
+  integrity sha512-fadlYsPJF+0fx2lRuyqAuJj7hAS1tLDdIEEdov5jlrpb5pp4b+mRDUqQTUxi4inRZHS1bEXpU8QWUhO6xX88aA==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/utils" "^4.11.2"
+    clsx "^1.0.4"
+    prop-types "^15.7.2"
+    react-is "^16.8.0 || ^17.0.0"
 
 "@material-ui/styles@^4.11.4":
   version "4.11.4"
@@ -724,10 +735,10 @@
     jss-plugin-vendor-prefixer "^10.5.1"
     prop-types "^15.7.2"
 
-"@material-ui/system@^4.11.3":
-  version "4.11.3"
-  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.11.3.tgz"
-  integrity sha512-SY7otguNGol41Mu2Sg6KbBP1ZRFIbFLHGK81y4KYbsV2yIcaEPOmsCK6zwWlp+2yTV3J/VwT6oSBARtGIVdXPw==
+"@material-ui/system@^4.12.1":
+  version "4.12.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.12.1.tgz#2dd96c243f8c0a331b2bb6d46efd7771a399707c"
+  integrity sha512-lUdzs4q9kEXZGhbN7BptyiS1rLNHe6kG9o8Y307HCvF4sQxbCgpL2qi+gUk+yI8a2DNk48gISEQxoxpgph0xIw==
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@material-ui/utils" "^4.11.2"


### PR DESCRIPTION
## Description

This PR adds [skeleton loaders](https://material-ui.com/components/skeleton/) for the plugin and search pages when navigating on the client-side. This will improve perceived performance when loading uncached pages because the user will now see a loading page almost immediately when loading the plugin or search page.

However, because the loader is only visible during client-side transitions, the performance of initial load is unaffected. I originally worked on a dynamic skeleton loader that would [fetch data on the client-side](https://github.com/chanzuckerberg/napari-hub/tree/jeremy/improve-initial-load-skel-loader), reducing the initial load to less than 100ms. But I realized later that this would [have an impact on SEO](https://www.if-so.com/dynamic-content-impact-on-seo/), so I'm deferring that improvement until we do the SEO and performance audit.

## Scrolling Behavior

Now that we're rendering a skeleton loader for the plugin and search page, the browser doesn't know where to scroll back once the content is loaded. To fix this, I needed to implement custom scroll behavior in [usePageTransitions()](https://github.com/chanzuckerberg/napari-hub/blob/jeremy/client-skel-loader/frontend/src/hooks/usePageTransitions.ts).

### Remove Global Smooth Scroll

The first thing I did was remove the CSS for global smooth scroll. I did this because smooth scrolling everything felt awkward while using the hub (and [others agree](https://css-tricks.com/downsides-of-smooth-scrolling/)). I think it makes more sense to make smooth scroll opt-in so that we use it when it makes sense for UX. Right now, the only place where I have smooth scrolling is when the user submits a search query.

### Automatic Scrolling on Load

When the page starts loading, the app will automatically scroll the user to a certain location depending on the page:

1. For the plugin page, the browser will scroll to the top of the page and stay there until it finished loading.
1. For the search page, the browser will:
    1. Scroll to the last location the user scrolled to if navigating back.
    1. Scroll to the top if clicking on the home link or when using the search bar.

### Cancel Automatic Scroll on User Scroll

If the user scrolls at any time while the page is loading, the page will cancel automatic scrolling so that the user isn't taken away from their current scroll location.

## Changes

- Added `<SkeletonLoader />`: Component for rendering a skeleton loader in place for a component while loading.
- Context for global loading state. This is used to provide shared load state for an entire component tree.
- Removes global smooth scroll. There are cases where it's better to have instant scroll vs smooth scroll, so now smooth scroll has been made opt-in
- Renamed `useSearchSetSortType()` to `useSearchEffects()` so that the hook is generalized for any type of effect that runs when the search query changes. 
- Enable client-side page transitions using [Next.js router events](https://nextjs.org/docs/api-reference/next/router#routerevents)
- Moved "scroll on query" from [\<PluginSearchBar /\>](https://github.com/chanzuckerberg/napari-hub/commit/c0534323e292dfdf4dc913d7d45b17a5145b17b5#diff-0e579ca2de3fe8a6ae41e6dbaf96f8bf0bb07bac2e1072e9a866d4d96aa3e7e9) to [useSearchEffects()`](https://github.com/chanzuckerberg/napari-hub/commit/c0534323e292dfdf4dc913d7d45b17a5145b17b5#diff-f93663b98e08abc1abea4cd93bbfe6bc57fd880b8f34b5dd11bb1f072413e2fe):
  - This fits better architecturally since it is a side effect for the search query state.
  - Fixes issue where search query scroll was overriding the page transition scroll.

## Demos

https://speed-up-hub-frontend.dev.imaging.cziscience.com

### Automatic Scrolling on Load

https://user-images.githubusercontent.com/2176050/125697829-c9efad8d-7d8d-4dc4-8440-c275c55389a5.mp4

### Cancel Automatic Scroll on Load

https://user-images.githubusercontent.com/2176050/125697841-fd461845-2e95-4cce-956d-dfe8f1fd3368.mp4

## Follow Ups

- I don't know how the CDN will behave with the skeleton loader. Since the CDN isn't enabled for dev environments, I'll have to run a smoke test on https://staging.napari-hub.org.