### PR TITLE
Redirect non-www to www

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -17,6 +17,9 @@ FROM node:16-alpine
 
 WORKDIR /app
 
+# Install supervisord for process management and ngninx for the web server.
+RUN apk update && apk add --no-cache supervisor nginx && mkdir /run/nginx
+
 # Install dependencies for production
 COPY package.json yarn.lock postinstall.js /app/
 ENV NODE_ENV=production
@@ -25,6 +28,8 @@ RUN yarn install
 # Copy application build to image
 COPY --from=builder /app/.next /app/.next
 COPY public /app/public
+COPY supervisord.conf /etc/supervisord.conf
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 8080
-ENTRYPOINT [ "yarn", "start" ]
+ENTRYPOINT [ "/usr/bin/supervisord", "-c", "/etc/supervisord.conf" ]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,16 @@
+server {
+  listen 8080;
+  server_name ~^www\.(?<server_host>.+)\.(?<domain>.+);
+
+  location / {
+    proxy_set_header X-Forwarded-For $remote_addr;
+    proxy_set_header Host $http_host;
+    proxy_pass http://localhost:8081;
+  }
+}
+
+server {
+  listen 8080;
+  server_name ~^(?<server_host>.+)\.(?<domain>.+);
+  return 301 https://www.$server_host.$domain$request_uri;
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "e2e:update": "yarn e2e --updateSnapshot",
     "postinstall": "node postinstall",
     "start": "next start -p 8080",
+    "start:prod": "next start -p 8081",
     "test": "jest -c jest/test.config.js",
     "test:watch": "yarn test --watch",
     "test:update": "yarn test --updateSnapshot",

--- a/frontend/supervisord.conf
+++ b/frontend/supervisord.conf
@@ -1,0 +1,9 @@
+[supervisord]
+nodaemon=true
+
+[program:nginx]
+command=/usr/sbin/nginx -g 'daemon off;'
+
+[program:next]
+command=/usr/local/bin/yarn start:prod
+directory=/app


### PR DESCRIPTION
## Descriptions

Closes #141

Sets up root domain redirection to `www` subdomain. This works by adding nginx as a reverse proxy for the Next.js application in the production Dockerfile. This allows us to set up the redirection independent of the application code and to maintain [automatic static optimization](https://nextjs.org/docs/advanced-features/automatic-static-optimization).

## Demo

**TODO Needs dev deployment**
