### PR TITLE
Fix search param encoding

### DIFF
--- a/frontend/src/components/SearchBar/SearchBar.tsx
+++ b/frontend/src/components/SearchBar/SearchBar.tsx
@@ -19,19 +19,6 @@ interface Props extends HTMLProps<HTMLFormElement> {
 }
 
 /**
- * Creates a new URL with the search query added.
- *
- * @param query The query string.
- * @returns The URL object.
- */
-function getURLWithSearchParam(query: string): URL {
-  const url = new URL(SEARCH_PAGE, window.location.origin);
-  url.searchParams.set(SearchQueryParams.Search, encodeURIComponent(query));
-
-  return url;
-}
-
-/**
  * Search bar component. This renders an input field with a underline and
  * magnifying glass icon to the right of the component. When the user enters a query,
  * one of two things can happen:
@@ -78,7 +65,13 @@ export function SearchBar({ large, ...props }: Props) {
         clearQuery?.();
       }
     } else {
-      const url = getURLWithSearchParam(searchQuery);
+      const url = {
+        pathname: SEARCH_PAGE,
+        query: {
+          // Params will be encoded automatically by Next.js.
+          [SearchQueryParams.Search]: searchQuery,
+        },
+      };
       await router.push(url);
     }
   }

--- a/frontend/src/hooks/useActiveURLParameter.ts
+++ b/frontend/src/hooks/useActiveURLParameter.ts
@@ -16,12 +16,16 @@ export function useActiveURLParameter<R extends string = string>(
   name: string,
 ): R | undefined {
   const router = useRouter();
-  let query = router.query[name] as string | undefined;
+  let value = router.query[name] as string | undefined;
 
-  if (!query && process.browser) {
+  if (!value && process.browser) {
     const url = new URL(window.location.href);
-    query = url.searchParams.get(name) ?? undefined;
+    value = url.searchParams.get(name) ?? undefined;
   }
 
-  return query as R;
+  if (value) {
+    value = decodeURIComponent(value);
+  }
+
+  return value as R;
 }


### PR DESCRIPTION
## Description

Closes #138

The Next.js router will [automatically encode's query parameters, but it doesn't decode them](https://stackoverflow.com/a/65421830). This explains why the string `cell counting` was being double-encoded to `cell%2%520detection`.

## Demo

1. Go to https://fix-spaces-frontend.dev.imaging.cziscience.com/plugins/affinder
1. Enter `cell counting` into the search bar and press `Enter`
1.  There should be one search result, the value for `?search` should be `cell%20counting`, and the search bar should have `cell counting`.

https://user-images.githubusercontent.com/2176050/126376768-8700b67e-60f9-45cc-81f1-b994a696c0bc.mp4
