### PR TITLE
disregard invalid headers in markdown ToC

### DIFF
--- a/frontend/src/components/common/Markdown/Markdown.utils.test.ts
+++ b/frontend/src/components/common/Markdown/Markdown.utils.test.ts
@@ -22,10 +22,11 @@ This is markdown
 ## Foo Bar
 `;
 
-const MARKDOWN_WITH_INVALID_HEADER = `
+const MARKDOWN_WITH_INVALID_HEADERS = `
 ## Foo
 ## ![image](./invalid.png)
 ## Bar
+## ![image](./invalid-2.jpg)
 `;
 
 describe('getHeadersFromMarkdown()', () => {
@@ -61,7 +62,7 @@ describe('getHeadersFromMarkdown()', () => {
   });
 
   it('should ignore invalid headers', () => {
-    const headers = getHeadersFromMarkdown(MARKDOWN_WITH_INVALID_HEADER);
+    const headers = getHeadersFromMarkdown(MARKDOWN_WITH_INVALID_HEADERS);
     const expected: TOCHeader[] = [
       {
         id: 'foo',

--- a/frontend/src/components/common/Markdown/Markdown.utils.test.ts
+++ b/frontend/src/components/common/Markdown/Markdown.utils.test.ts
@@ -22,6 +22,12 @@ This is markdown
 ## Foo Bar
 `;
 
+const MARKDOWN_WITH_INVALID_HEADER = `
+## Foo
+## ![image](./invalid.png)
+## Bar
+`;
+
 describe('getHeadersFromMarkdown()', () => {
   it('should return empty array for empty markdown', () => {
     const headers = getHeadersFromMarkdown('');
@@ -48,6 +54,22 @@ describe('getHeadersFromMarkdown()', () => {
       {
         id: 'foo-bar',
         text: 'Foo Bar',
+      },
+    ];
+
+    expect(headers).toEqual(expected);
+  });
+
+  it('should ignore invalid headers', () => {
+    const headers = getHeadersFromMarkdown(MARKDOWN_WITH_INVALID_HEADER);
+    const expected: TOCHeader[] = [
+      {
+        id: 'foo',
+        text: 'Foo',
+      },
+      {
+        id: 'bar',
+        text: 'Bar',
       },
     ];
 

--- a/frontend/src/components/common/Markdown/Markdown.utils.ts
+++ b/frontend/src/components/common/Markdown/Markdown.utils.ts
@@ -56,6 +56,7 @@ export function getHeadersFromMarkdown(markdown: string): TOCHeader[] {
   // Convert all H2 headings into TOCHeader objects.
   return children
     .filter((node): node is HeadingNode => node.tagName === TOC_HEADER_TAG)
+    .filter((node) => node.properties.id)
     .map<TOCHeader>((node) => ({
       id: node.properties.id,
       text: node.children[0].value,

--- a/frontend/src/components/common/Markdown/Markdown.utils.ts
+++ b/frontend/src/components/common/Markdown/Markdown.utils.ts
@@ -56,7 +56,7 @@ export function getHeadersFromMarkdown(markdown: string): TOCHeader[] {
   // Convert all H2 headings into TOCHeader objects.
   return children
     .filter((node): node is HeadingNode => node.tagName === TOC_HEADER_TAG)
-    .filter((node) => node.properties.id)
+    .filter((node) => node.children[0].value !== undefined)
     .map<TOCHeader>((node) => ({
       id: node.properties.id,
       text: node.children[0].value,


### PR DESCRIPTION
sometimes markdown can generate invalid headers, such as in issue #140. this excludes any headers missing an id from the ToC parser 