### PR TITLE
Fix contrast ratio for napari gray color

### DIFF
--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -9,7 +9,7 @@ const colors = {
   primary: '#80d1ff',
   hover: '#98daff',
   hoverGray: '#f7f7f7',
-  gray: '#808080',
+  gray: '#6f6f6f',
   light: '#d2efff',
   error: '#eb1000',
 };


### PR DESCRIPTION
## Description

Fixes the [contrast ratio issue](https://web.dev/color-contrast/) reported by Lighthouse for the napari hub by darkening the napari gray color.