### PR TITLE
Improve keyboard accessibilty

### DIFF
--- a/frontend/src/components/AppBar/AppBar.tsx
+++ b/frontend/src/components/AppBar/AppBar.tsx
@@ -19,7 +19,8 @@ export function AppBar() {
     <>
       <MenuDrawer
         items={APP_LINKS}
-        onMenuClose={() => setVisible(false)}
+        onClose={() => setVisible(false)}
+        onOpen={() => setVisible(true)}
         visible={visible}
       />
 

--- a/frontend/src/components/AppBar/__snapshots__/AppBar.test.tsx.snap
+++ b/frontend/src/components/AppBar/__snapshots__/AppBar.test.tsx.snap
@@ -3,59 +3,9 @@
 exports[`<AppBar /> should match snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="fixed top-0 right-0 flex flex-row items-start z-40 w-9/12 h-screen p-6 bg-black"
-    data-testid="menu"
-    style="transform: translateX(100%) translateZ(0);"
-  >
-    <ul
-      class="flex flex-auto flex-col"
-    >
-      <li
-        class="text-white item"
-        data-testid="drawerItem"
-      >
-        <a
-          href="/about"
-        >
-          About
-        </a>
-      </li>
-      <li
-        class="text-white item"
-        data-testid="drawerItem"
-      >
-        <a
-          href="/faq"
-        >
-          FAQ
-        </a>
-      </li>
-    </ul>
-    <button
-      class="flex"
-      data-testid="drawerClose"
-      type="button"
-    >
-      <svg
-        fill="none"
-        height="18"
-        viewBox="0 0 18 18"
-        width="18"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M1 1L17 17"
-          stroke="white"
-          stroke-width="2.35294"
-        />
-        <path
-          d="M17 1L1 17"
-          stroke="white"
-          stroke-width="2.35294"
-        />
-      </svg>
-    </button>
-  </div>
+    class="PrivateSwipeArea-root-1 PrivateSwipeArea-anchorRight-3"
+    style="width: 20px;"
+  />
   <header
     class="bg-napari-primary h-napari-app-bar justify-center items-center px-6 md:px-12 2xl:p-0 zero:grid-cols-[min-content,1fr] grid justify-center gap-6 md:gap-12 grid-cols-2 screen-875:grid-cols-napari-3 screen-1150:grid-cols-napari-4 screen-1425:grid-cols-napari-5"
   >

--- a/frontend/src/components/Layout/__snapshots__/Layout.test.tsx.snap
+++ b/frontend/src/components/Layout/__snapshots__/Layout.test.tsx.snap
@@ -6,59 +6,9 @@ exports[`<Layout /> should match snapshot 1`] = `
     class="flex flex-col min-h-screen"
   >
     <div
-      class="fixed top-0 right-0 flex flex-row items-start z-40 w-9/12 h-screen p-6 bg-black"
-      data-testid="menu"
-      style="transform: translateX(100%) translateZ(0);"
-    >
-      <ul
-        class="flex flex-auto flex-col"
-      >
-        <li
-          class="text-white item"
-          data-testid="drawerItem"
-        >
-          <a
-            href="/about"
-          >
-            About
-          </a>
-        </li>
-        <li
-          class="text-white item"
-          data-testid="drawerItem"
-        >
-          <a
-            href="/faq"
-          >
-            FAQ
-          </a>
-        </li>
-      </ul>
-      <button
-        class="flex"
-        data-testid="drawerClose"
-        type="button"
-      >
-        <svg
-          fill="none"
-          height="18"
-          viewBox="0 0 18 18"
-          width="18"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M1 1L17 17"
-            stroke="white"
-            stroke-width="2.35294"
-          />
-          <path
-            d="M17 1L1 17"
-            stroke="white"
-            stroke-width="2.35294"
-          />
-        </svg>
-      </button>
-    </div>
+      class="PrivateSwipeArea-root-1 PrivateSwipeArea-anchorRight-3"
+      style="width: 20px;"
+    />
     <header
       class="bg-napari-primary h-napari-app-bar justify-center items-center px-6 md:px-12 2xl:p-0 zero:grid-cols-[min-content,1fr] grid justify-center gap-6 md:gap-12 grid-cols-2 screen-875:grid-cols-napari-3 screen-1150:grid-cols-napari-4 screen-1425:grid-cols-napari-5"
     >

--- a/frontend/src/components/MenuDrawer/MenuDrawer.test.tsx
+++ b/frontend/src/components/MenuDrawer/MenuDrawer.test.tsx
@@ -23,12 +23,14 @@ describe('<MenuDrawer />', () => {
 
   const renderComponent = ({
     items = mockItems,
-    onMenuClose = noop,
+    onClose = noop,
+    onOpen = noop,
     visible = true,
   }: Partial<Props> = {}) => {
     const props = {
       items,
-      onMenuClose,
+      onClose,
+      onOpen,
       visible,
     } as Props;
 
@@ -53,12 +55,12 @@ describe('<MenuDrawer />', () => {
   });
 
   it('should call onClose when close button is clicked', () => {
-    const onMenuClose = jest.fn();
-    renderComponent({ onMenuClose, visible: true });
+    const onClose = jest.fn();
+    renderComponent({ onClose, visible: true });
 
     const closeButton = screen.getByTestId('drawerClose');
     fireEvent.click(closeButton);
 
-    expect(onMenuClose).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/MenuDrawer/MenuDrawer.tsx
+++ b/frontend/src/components/MenuDrawer/MenuDrawer.tsx
@@ -1,91 +1,53 @@
-import clsx from 'clsx';
-import { motion } from 'framer-motion';
-import { useRef } from 'react';
-import { useClickAway } from 'react-use';
+import { IconButton, SwipeableDrawer } from '@material-ui/core';
 
-import { Link, Overlay } from '@/components/common';
+import { Link } from '@/components/common';
 import { Close } from '@/components/common/icons';
 import { LinkInfo } from '@/types';
 
-import styles from './MenuDrawer.module.scss';
-
 interface Props {
   items: LinkInfo[];
-  onMenuClose: () => void;
+  onClose: () => void;
+  onOpen: () => void;
   visible: boolean;
 }
 
 /**
- * Navigation drawer that slides out from the right. An overlay is rendered
- * below the menu to emphasize the drawer being in view.
- *
- * The drawer closes automatically if the user clicks outside of the drawer.
- * This is handled using the `useClickAway()` hook:
- * https://git.io/JOmWl
+ * Navigation drawer that slides out from the right. The drawer can be opened by
+ * pressing the menu button or by swiping left from the right side of the
+ * screen. Conversely, the drawer can be closed by clicking the close button,
+ * swiping the drawer right, or clicking outside of the drawer area.
  */
-export function MenuDrawer({ items, onMenuClose, visible }: Props) {
-  const menuRef = useRef<HTMLDivElement | null>(null);
-  useClickAway(menuRef, onMenuClose);
-
+export function MenuDrawer({ items, onOpen, onClose, visible }: Props) {
   return (
-    <>
-      <Overlay visible={visible} />
+    <SwipeableDrawer
+      anchor="right"
+      classes={{ paper: 'bg-black flex-row w-9/12 p-6' }}
+      onClose={onClose}
+      onOpen={onOpen}
+      open={visible}
+      data-testid="menu"
+    >
+      <ul className="text-white flex-grow">
+        {items.map((item) => (
+          <li
+            className="mb-5 last:m-0"
+            key={item.title}
+            data-testid="drawerItem"
+          >
+            <Link href={item.link} onClick={onClose}>
+              {item.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
 
-      <motion.div
-        data-testid="menu"
-        animate={visible ? 'visible' : 'hidden'}
-        initial="hidden"
-        variants={{
-          hidden: { x: '100%' },
-          visible: { x: 0 },
-        }}
-        transition={{ type: 'tween', duration: 0.3, ease: 'easeInOut' }}
-        className={clsx(
-          // Fixed positioning to keep entire menu in viewport
-          'fixed top-0 right-0',
-
-          // Layout
-          'flex flex-row items-start',
-
-          // High z-index so that drawer overlays everything on the website
-          'z-40',
-
-          // Dimensions
-          'w-9/12 h-screen',
-
-          // Padding
-          'p-6',
-
-          // Color
-          'bg-black',
-        )}
-        ref={menuRef}
+      <IconButton
+        className="self-start p-0"
+        data-testid="drawerClose"
+        onClick={onClose}
       >
-        {/* Menu links */}
-        <ul className="flex flex-auto flex-col">
-          {items.map((item) => (
-            <li
-              className={clsx('text-white', styles.item)}
-              data-testid="drawerItem"
-              key={item.title}
-            >
-              <Link href={item.link} onClick={onMenuClose}>
-                {item.title}
-              </Link>
-            </li>
-          ))}
-        </ul>
-
-        {/* Close button */}
-        <button
-          className="flex"
-          data-testid="drawerClose"
-          onClick={onMenuClose}
-          type="button"
-        >
-          <Close />
-        </button>
-      </motion.div>
-    </>
+        <Close />
+      </IconButton>
+    </SwipeableDrawer>
   );
 }

--- a/frontend/src/components/MenuDrawer/__snapshots__/MenuDrawer.test.tsx.snap
+++ b/frontend/src/components/MenuDrawer/__snapshots__/MenuDrawer.test.tsx.snap
@@ -2,57 +2,84 @@
 
 exports[`<MenuDrawer /> should match snapshot 1`] = `
 <div
-  class="fixed top-0 right-0 flex flex-row items-start z-40 w-9/12 h-screen p-6 bg-black"
+  class="MuiDrawer-root MuiDrawer-modal"
   data-testid="menu"
-  style="transform: translateX(100%) translateZ(0);"
+  role="presentation"
+  style="position: fixed; z-index: 1300; right: 0px; bottom: 0px; top: 0px; left: 0px;"
 >
-  <ul
-    class="flex flex-auto flex-col"
+  <div
+    aria-hidden="true"
+    class="MuiBackdrop-root"
+    style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+  />
+  <div
+    data-test="sentinelStart"
+    tabindex="0"
+  />
+  <div
+    class="MuiPaper-root MuiDrawer-paper bg-black flex-row w-9/12 p-6 MuiDrawer-paperAnchorRight MuiPaper-elevation16"
+    tabindex="-1"
   >
-    <li
-      class="text-white item"
-      data-testid="drawerItem"
+    <ul
+      class="text-white flex-grow"
     >
-      <a
-        href="/foo"
+      <li
+        class="mb-5 last:m-0"
+        data-testid="drawerItem"
       >
-        foo
-      </a>
-    </li>
-    <li
-      class="text-white item"
-      data-testid="drawerItem"
-    >
-      <a
-        href="/bar"
+        <a
+          href="/foo"
+        >
+          foo
+        </a>
+      </li>
+      <li
+        class="mb-5 last:m-0"
+        data-testid="drawerItem"
       >
-        bar
-      </a>
-    </li>
-  </ul>
-  <button
-    class="flex"
-    data-testid="drawerClose"
-    type="button"
-  >
-    <svg
-      fill="none"
-      height="18"
-      viewBox="0 0 18 18"
-      width="18"
-      xmlns="http://www.w3.org/2000/svg"
+        <a
+          href="/bar"
+        >
+          bar
+        </a>
+      </li>
+    </ul>
+    <button
+      class="MuiButtonBase-root MuiIconButton-root self-start p-0"
+      data-testid="drawerClose"
+      tabindex="0"
+      type="button"
     >
-      <path
-        d="M1 1L17 17"
-        stroke="white"
-        stroke-width="2.35294"
+      <span
+        class="MuiIconButton-label"
+      >
+        <svg
+          fill="none"
+          height="18"
+          viewBox="0 0 18 18"
+          width="18"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M1 1L17 17"
+            stroke="white"
+            stroke-width="2.35294"
+          />
+          <path
+            d="M17 1L1 17"
+            stroke="white"
+            stroke-width="2.35294"
+          />
+        </svg>
+      </span>
+      <span
+        class="MuiTouchRipple-root"
       />
-      <path
-        d="M17 1L1 17"
-        stroke="white"
-        stroke-width="2.35294"
-      />
-    </svg>
-  </button>
+    </button>
+  </div>
+  <div
+    data-test="sentinelEnd"
+    tabindex="0"
+  />
 </div>
 `;

--- a/frontend/src/components/PluginDetails/PluginDetails.tsx
+++ b/frontend/src/components/PluginDetails/PluginDetails.tsx
@@ -21,7 +21,14 @@ function PluginCenterColumn() {
   const { plugin } = usePluginState();
 
   return (
-    <article className="w-full col-span-2 screen-875:col-span-3">
+    <article
+      className={clsx(
+        'w-full col-span-2 row-start-1',
+        'screen-875:col-span-3',
+        'screen-1150:col-start-1',
+        'screen-1425:col-start-2',
+      )}
+    >
       <SkeletonLoader
         className="h-12"
         render={() => <h1 className="font-bold text-4xl">{plugin.name}</h1>}
@@ -110,7 +117,10 @@ function PluginRightColumn() {
   const plausible = usePlausible();
 
   return (
-    <Media greaterThanOrEqual="2xl">
+    <Media
+      className="col-start-4 screen-1425:col-start-5"
+      greaterThanOrEqual="2xl"
+    >
       {/*  Keep CTA button and TOC on screen when scrolling on 2xl. */}
       <div className="sticky top-12">
         <CallToActionButton />
@@ -143,8 +153,17 @@ export function PluginDetails() {
   return (
     <ColumnLayout className="p-6 md:p-12 2xl:px-0" data-testid="pluginDetails">
       <PluginLeftColumn />
-      <PluginCenterColumn />
+      {/*
+        The markup for the right column is placed before the center column so
+        that keyboard navigation focuses on the right column before the main
+        column since the main column can be very long.
+
+        A good example of this is implemented on the W3C site:
+        https://www.w3.org/WAI/tutorials/menus/flyout. When tabbing through the
+        site, it focuses on the table of contents before the main content.
+      */}
       <PluginRightColumn />
+      <PluginCenterColumn />
     </ColumnLayout>
   );
 }

--- a/frontend/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
+++ b/frontend/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
@@ -241,8 +241,122 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       </ul>
     </div>
   </div>
+  <div
+    class="fresnel-container fresnel-greaterThanOrEqual-2xl col-start-4 screen-1425:col-start-5"
+  >
+    <div
+      class="sticky top-12"
+    >
+      <button
+        class="bg-napari-primary h-12 w-full screen-600:max-w-napari-col"
+        type="button"
+      >
+        Install
+      </button>
+      <ul
+        class="mt-9 flex flex-col border-l border-black"
+      >
+        <li
+          class="flex pl-6 border-l-4 min-h-6 h-auto my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
+          data-active="false"
+          data-testid="tocItem"
+        >
+          <a
+            class=""
+            href="#description"
+          >
+            Description
+          </a>
+        </li>
+        <li
+          class="flex pl-6 border-l-4 min-h-6 h-auto my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
+          data-active="false"
+          data-testid="tocItem"
+        >
+          <a
+            class=""
+            href="#writers"
+          >
+            Writers
+          </a>
+        </li>
+        <li
+          class="flex pl-6 border-l-4 min-h-6 h-auto my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
+          data-active="false"
+          data-testid="tocItem"
+        >
+          <a
+            class=""
+            href="#readers"
+          >
+            Readers
+          </a>
+        </li>
+        <li
+          class="flex pl-6 border-l-4 min-h-6 h-auto my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
+          data-active="false"
+          data-testid="tocItem"
+        >
+          <a
+            class=""
+            href="#zmeta"
+          >
+            .zmeta
+          </a>
+        </li>
+        <li
+          class="flex pl-6 border-l-4 min-h-6 h-auto my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
+          data-active="false"
+          data-testid="tocItem"
+        >
+          <a
+            class=""
+            href="#installation"
+          >
+            Installation
+          </a>
+        </li>
+        <li
+          class="flex pl-6 border-l-4 min-h-6 h-auto my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
+          data-active="false"
+          data-testid="tocItem"
+        >
+          <a
+            class=""
+            href="#contributing"
+          >
+            Contributing
+          </a>
+        </li>
+        <li
+          class="flex pl-6 border-l-4 min-h-6 h-auto my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
+          data-active="false"
+          data-testid="tocItem"
+        >
+          <a
+            class=""
+            href="#license"
+          >
+            License
+          </a>
+        </li>
+        <li
+          class="flex pl-6 border-l-4 min-h-6 h-auto my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-black"
+          data-active="true"
+          data-testid="tocItem"
+        >
+          <a
+            class="font-bold"
+            href="#issues"
+          >
+            Issues
+          </a>
+        </li>
+      </ul>
+    </div>
+  </div>
   <article
-    class="w-full col-span-2 screen-875:col-span-3"
+    class="w-full col-span-2 row-start-1 screen-875:col-span-3 screen-1150:col-start-1 screen-1425:col-start-2"
   >
     <h1
       class="font-bold text-4xl"
@@ -1494,119 +1608,5 @@ the coverage at least stays the same before you submit a pull request.
       </ul>
     </div>
   </article>
-  <div
-    class="fresnel-container fresnel-greaterThanOrEqual-2xl "
-  >
-    <div
-      class="sticky top-12"
-    >
-      <button
-        class="bg-napari-primary h-12 w-full screen-600:max-w-napari-col"
-        type="button"
-      >
-        Install
-      </button>
-      <ul
-        class="mt-9 flex flex-col border-l border-black"
-      >
-        <li
-          class="flex pl-6 border-l-4 min-h-6 h-auto my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
-          data-active="false"
-          data-testid="tocItem"
-        >
-          <a
-            class=""
-            href="#description"
-          >
-            Description
-          </a>
-        </li>
-        <li
-          class="flex pl-6 border-l-4 min-h-6 h-auto my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
-          data-active="false"
-          data-testid="tocItem"
-        >
-          <a
-            class=""
-            href="#writers"
-          >
-            Writers
-          </a>
-        </li>
-        <li
-          class="flex pl-6 border-l-4 min-h-6 h-auto my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
-          data-active="false"
-          data-testid="tocItem"
-        >
-          <a
-            class=""
-            href="#readers"
-          >
-            Readers
-          </a>
-        </li>
-        <li
-          class="flex pl-6 border-l-4 min-h-6 h-auto my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
-          data-active="false"
-          data-testid="tocItem"
-        >
-          <a
-            class=""
-            href="#zmeta"
-          >
-            .zmeta
-          </a>
-        </li>
-        <li
-          class="flex pl-6 border-l-4 min-h-6 h-auto my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
-          data-active="false"
-          data-testid="tocItem"
-        >
-          <a
-            class=""
-            href="#installation"
-          >
-            Installation
-          </a>
-        </li>
-        <li
-          class="flex pl-6 border-l-4 min-h-6 h-auto my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
-          data-active="false"
-          data-testid="tocItem"
-        >
-          <a
-            class=""
-            href="#contributing"
-          >
-            Contributing
-          </a>
-        </li>
-        <li
-          class="flex pl-6 border-l-4 min-h-6 h-auto my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
-          data-active="false"
-          data-testid="tocItem"
-        >
-          <a
-            class=""
-            href="#license"
-          >
-            License
-          </a>
-        </li>
-        <li
-          class="flex pl-6 border-l-4 min-h-6 h-auto my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-black"
-          data-active="true"
-          data-testid="tocItem"
-        >
-          <a
-            class="font-bold"
-            href="#issues"
-          >
-            Issues
-          </a>
-        </li>
-      </ul>
-    </div>
-  </div>
 </div>
 `;

--- a/frontend/src/components/PluginSearch/PluginFilterBySection.test.tsx
+++ b/frontend/src/components/PluginSearch/PluginFilterBySection.test.tsx
@@ -23,18 +23,18 @@ describe('Plugin filter-by section', () => {
       <PluginFilterBySection title={title} filters={filters} />,
     );
 
-    expect(getByTestId('title').innerHTML).toBe(title);
+    expect(getByTestId('filterCheckboxTitle').innerHTML).toBe(title);
 
-    const inputs = getAllByTestId('input');
+    const filterCheckboxes = getAllByTestId('filterCheckbox');
 
-    expect(inputs).toHaveLength(filters.length);
+    expect(filterCheckboxes).toHaveLength(filters.length);
 
-    (zip(filters, inputs) as Array<[FilterItem, HTMLElement]>).forEach(
-      ([filter, input]) => {
-        expect(input.lastElementChild?.innerHTML).toBe(filter.label);
-        expect(input.querySelector('input')?.checked).toBe(filter.enabled);
-      },
-    );
+    (zip(filters, filterCheckboxes) as Array<
+      [FilterItem, HTMLElement]
+    >).forEach(([filter, input]) => {
+      expect(input.lastElementChild?.innerHTML).toBe(filter.label);
+      expect(input.querySelector('input')?.checked).toBe(filter.enabled);
+    });
   });
 
   it('should call setEnabled when checked', () => {
@@ -55,17 +55,17 @@ describe('Plugin filter-by section', () => {
       <PluginFilterBySection title="test" filters={filters} />,
     );
 
-    const inputs = getAllByTestId('input');
+    const filterCheckboxes = getAllByTestId('filterCheckbox');
 
-    expect(inputs).toHaveLength(filters.length);
+    expect(filterCheckboxes).toHaveLength(filters.length);
 
-    (zip(filters, inputs) as Array<[FilterItem, HTMLElement]>).forEach(
-      ([filter, input]) => {
-        const checkbox = input.querySelector('input');
-        expect(checkbox).not.toBeUndefined();
-        fireEvent.click(checkbox as HTMLElement);
-        expect(filter.setEnabled).toHaveBeenCalledWith(!filter.enabled);
-      },
-    );
+    (zip(filters, filterCheckboxes) as Array<
+      [FilterItem, HTMLElement]
+    >).forEach(([filter, input]) => {
+      const checkbox = input.querySelector('input');
+      expect(checkbox).not.toBeUndefined();
+      fireEvent.click(checkbox as HTMLElement);
+      expect(filter.setEnabled).toHaveBeenCalledWith(!filter.enabled);
+    });
   });
 });

--- a/frontend/src/components/PluginSearch/PluginFilterBySection.tsx
+++ b/frontend/src/components/PluginSearch/PluginFilterBySection.tsx
@@ -1,10 +1,5 @@
-import {
-  Checkbox,
-  FormControl,
-  FormControlLabel,
-  FormGroup,
-  FormLabel,
-} from '@material-ui/core';
+import { Checkbox } from '@material-ui/core';
+import clsx from 'clsx';
 
 import { CheckboxIcon } from '@/components/common/icons';
 
@@ -20,46 +15,43 @@ interface Props {
   filters: FilterItem[];
 }
 
+function getCheckboxId(label: string) {
+  return `checkbox-${label}`;
+}
+
 /**
  * Component for the section of each filter type
  */
 export function PluginFilterBySection({ className, title, filters }: Props) {
   return (
-    <FormControl className={className} component="fieldset">
-      <FormLabel
-        component="legend"
+    <fieldset className={clsx(className, 'flex flex-col')}>
+      <legend
         className="font-semibold text-black text-sm mb-2"
-        data-testid="title"
-        focused={false}
+        data-testid="filterCheckboxTitle"
       >
         {title}
-      </FormLabel>
-      <FormGroup>
-        {filters.map((filter) => (
-          <FormControlLabel
-            className="items-start m-0"
-            control={
-              <Checkbox
-                value={filter.enabled}
-                checked={filter.enabled}
-                onChange={(event) => filter.setEnabled(event.target.checked)}
-                className="text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
-                color="default"
-                icon={<CheckboxIcon className="w-4 h-4" />}
-                checkedIcon={<CheckboxIcon checked className="w-4 h-4" />}
-                // Disable ripple to prevent weird issue on Chrome where
-                // clicking on the checkbox causes the next
-                // PluginFilterBySection component below to render an invisible
-                // title.
-                disableRipple
-              />
-            }
-            label={filter.label}
-            key={filter.label}
-            data-testid="input"
+      </legend>
+
+      {filters.map((filter) => (
+        <div
+          className="flex items-start"
+          key={filter.label}
+          data-testid="filterCheckbox"
+        >
+          <Checkbox
+            id={getCheckboxId(filter.label)}
+            value={filter.enabled}
+            checked={filter.enabled}
+            onChange={(event) => filter.setEnabled(event.target.checked)}
+            className="text-black fill-current -mt-1 -ml-2"
+            color="default"
+            icon={<CheckboxIcon className="w-4 h-4" />}
+            checkedIcon={<CheckboxIcon checked className="w-4 h-4" />}
           />
-        ))}
-      </FormGroup>
-    </FormControl>
+
+          <label htmlFor={getCheckboxId(filter.label)}>{filter.label}</label>
+        </div>
+      ))}
+    </fieldset>
   );
 }

--- a/frontend/src/components/PluginSearch/__snapshots__/PluginSearch.test.tsx.snap
+++ b/frontend/src/components/PluginSearch/__snapshots__/PluginSearch.test.tsx.snap
@@ -847,352 +847,368 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                               class="fresnel-container fresnel-greaterThanOrEqual-screen-875 "
                             />
                             <fieldset
-                              class="MuiFormControl-root mt-6"
+                              class="mt-6 flex flex-col"
                             >
                               <legend
-                                class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
-                                data-testid="title"
+                                class="font-semibold text-black text-sm mb-2"
+                                data-testid="filterCheckboxTitle"
                               >
                                 Python versions
                               </legend>
                               <div
-                                class="MuiFormGroup-root"
+                                class="flex items-start"
+                                data-testid="filterCheckbox"
                               >
-                                <label
-                                  class="MuiFormControlLabel-root items-start m-0"
-                                  data-testid="input"
+                                <span
+                                  aria-disabled="false"
+                                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current -mt-1 -ml-2"
                                 >
                                   <span
-                                    aria-disabled="false"
-                                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
+                                    class="MuiIconButton-label"
                                   >
-                                    <span
-                                      class="MuiIconButton-label"
+                                    <input
+                                      class="PrivateSwitchBase-input-4"
+                                      data-indeterminate="false"
+                                      id="checkbox-3.7"
+                                      type="checkbox"
+                                      value="false"
+                                    />
+                                    <svg
+                                      class="w-4 h-4"
+                                      fill="none"
+                                      height="14"
+                                      viewBox="0 0 14 14"
+                                      width="14"
+                                      xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <input
-                                        class="PrivateSwitchBase-input-4"
-                                        data-indeterminate="false"
-                                        type="checkbox"
-                                        value="false"
+                                      <title>
+                                        unchecked checkbox
+                                      </title>
+                                      <rect
+                                        height="13"
+                                        stroke="black"
+                                        width="13"
+                                        x="0.5"
+                                        y="0.5"
                                       />
-                                      <svg
-                                        class="w-4 h-4"
-                                        fill="none"
-                                        height="14"
-                                        viewBox="0 0 14 14"
-                                        width="14"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <title>
-                                          unchecked checkbox
-                                        </title>
-                                        <rect
-                                          height="13"
-                                          stroke="black"
-                                          width="13"
-                                          x="0.5"
-                                          y="0.5"
-                                        />
-                                      </svg>
-                                    </span>
+                                    </svg>
                                   </span>
                                   <span
-                                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                                  >
-                                    3.7
-                                  </span>
+                                    class="MuiTouchRipple-root"
+                                  />
+                                </span>
+                                <label
+                                  for="checkbox-3.7"
+                                >
+                                  3.7
                                 </label>
-                                <label
-                                  class="MuiFormControlLabel-root items-start m-0"
-                                  data-testid="input"
+                              </div>
+                              <div
+                                class="flex items-start"
+                                data-testid="filterCheckbox"
+                              >
+                                <span
+                                  aria-disabled="false"
+                                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current -mt-1 -ml-2"
                                 >
                                   <span
-                                    aria-disabled="false"
-                                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
+                                    class="MuiIconButton-label"
                                   >
-                                    <span
-                                      class="MuiIconButton-label"
+                                    <input
+                                      class="PrivateSwitchBase-input-4"
+                                      data-indeterminate="false"
+                                      id="checkbox-3.8"
+                                      type="checkbox"
+                                      value="false"
+                                    />
+                                    <svg
+                                      class="w-4 h-4"
+                                      fill="none"
+                                      height="14"
+                                      viewBox="0 0 14 14"
+                                      width="14"
+                                      xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <input
-                                        class="PrivateSwitchBase-input-4"
-                                        data-indeterminate="false"
-                                        type="checkbox"
-                                        value="false"
+                                      <title>
+                                        unchecked checkbox
+                                      </title>
+                                      <rect
+                                        height="13"
+                                        stroke="black"
+                                        width="13"
+                                        x="0.5"
+                                        y="0.5"
                                       />
-                                      <svg
-                                        class="w-4 h-4"
-                                        fill="none"
-                                        height="14"
-                                        viewBox="0 0 14 14"
-                                        width="14"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <title>
-                                          unchecked checkbox
-                                        </title>
-                                        <rect
-                                          height="13"
-                                          stroke="black"
-                                          width="13"
-                                          x="0.5"
-                                          y="0.5"
-                                        />
-                                      </svg>
-                                    </span>
+                                    </svg>
                                   </span>
                                   <span
-                                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                                  >
-                                    3.8
-                                  </span>
+                                    class="MuiTouchRipple-root"
+                                  />
+                                </span>
+                                <label
+                                  for="checkbox-3.8"
+                                >
+                                  3.8
                                 </label>
-                                <label
-                                  class="MuiFormControlLabel-root items-start m-0"
-                                  data-testid="input"
+                              </div>
+                              <div
+                                class="flex items-start"
+                                data-testid="filterCheckbox"
+                              >
+                                <span
+                                  aria-disabled="false"
+                                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current -mt-1 -ml-2"
                                 >
                                   <span
-                                    aria-disabled="false"
-                                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
+                                    class="MuiIconButton-label"
                                   >
-                                    <span
-                                      class="MuiIconButton-label"
+                                    <input
+                                      class="PrivateSwitchBase-input-4"
+                                      data-indeterminate="false"
+                                      id="checkbox-3.9"
+                                      type="checkbox"
+                                      value="false"
+                                    />
+                                    <svg
+                                      class="w-4 h-4"
+                                      fill="none"
+                                      height="14"
+                                      viewBox="0 0 14 14"
+                                      width="14"
+                                      xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <input
-                                        class="PrivateSwitchBase-input-4"
-                                        data-indeterminate="false"
-                                        type="checkbox"
-                                        value="false"
+                                      <title>
+                                        unchecked checkbox
+                                      </title>
+                                      <rect
+                                        height="13"
+                                        stroke="black"
+                                        width="13"
+                                        x="0.5"
+                                        y="0.5"
                                       />
-                                      <svg
-                                        class="w-4 h-4"
-                                        fill="none"
-                                        height="14"
-                                        viewBox="0 0 14 14"
-                                        width="14"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <title>
-                                          unchecked checkbox
-                                        </title>
-                                        <rect
-                                          height="13"
-                                          stroke="black"
-                                          width="13"
-                                          x="0.5"
-                                          y="0.5"
-                                        />
-                                      </svg>
-                                    </span>
+                                    </svg>
                                   </span>
                                   <span
-                                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                                  >
-                                    3.9
-                                  </span>
+                                    class="MuiTouchRipple-root"
+                                  />
+                                </span>
+                                <label
+                                  for="checkbox-3.9"
+                                >
+                                  3.9
                                 </label>
                               </div>
                             </fieldset>
                             <fieldset
-                              class="MuiFormControl-root mt-6"
+                              class="mt-6 flex flex-col"
                             >
                               <legend
-                                class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
-                                data-testid="title"
+                                class="font-semibold text-black text-sm mb-2"
+                                data-testid="filterCheckboxTitle"
                               >
                                 Operating system
                               </legend>
                               <div
-                                class="MuiFormGroup-root"
+                                class="flex items-start"
+                                data-testid="filterCheckbox"
                               >
-                                <label
-                                  class="MuiFormControlLabel-root items-start m-0"
-                                  data-testid="input"
+                                <span
+                                  aria-disabled="false"
+                                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current -mt-1 -ml-2"
                                 >
                                   <span
-                                    aria-disabled="false"
-                                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
+                                    class="MuiIconButton-label"
                                   >
-                                    <span
-                                      class="MuiIconButton-label"
+                                    <input
+                                      class="PrivateSwitchBase-input-4"
+                                      data-indeterminate="false"
+                                      id="checkbox-Linux"
+                                      type="checkbox"
+                                      value="false"
+                                    />
+                                    <svg
+                                      class="w-4 h-4"
+                                      fill="none"
+                                      height="14"
+                                      viewBox="0 0 14 14"
+                                      width="14"
+                                      xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <input
-                                        class="PrivateSwitchBase-input-4"
-                                        data-indeterminate="false"
-                                        type="checkbox"
-                                        value="false"
+                                      <title>
+                                        unchecked checkbox
+                                      </title>
+                                      <rect
+                                        height="13"
+                                        stroke="black"
+                                        width="13"
+                                        x="0.5"
+                                        y="0.5"
                                       />
-                                      <svg
-                                        class="w-4 h-4"
-                                        fill="none"
-                                        height="14"
-                                        viewBox="0 0 14 14"
-                                        width="14"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <title>
-                                          unchecked checkbox
-                                        </title>
-                                        <rect
-                                          height="13"
-                                          stroke="black"
-                                          width="13"
-                                          x="0.5"
-                                          y="0.5"
-                                        />
-                                      </svg>
-                                    </span>
+                                    </svg>
                                   </span>
                                   <span
-                                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                                  >
-                                    Linux
-                                  </span>
+                                    class="MuiTouchRipple-root"
+                                  />
+                                </span>
+                                <label
+                                  for="checkbox-Linux"
+                                >
+                                  Linux
                                 </label>
-                                <label
-                                  class="MuiFormControlLabel-root items-start m-0"
-                                  data-testid="input"
+                              </div>
+                              <div
+                                class="flex items-start"
+                                data-testid="filterCheckbox"
+                              >
+                                <span
+                                  aria-disabled="false"
+                                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current -mt-1 -ml-2"
                                 >
                                   <span
-                                    aria-disabled="false"
-                                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
+                                    class="MuiIconButton-label"
                                   >
-                                    <span
-                                      class="MuiIconButton-label"
+                                    <input
+                                      class="PrivateSwitchBase-input-4"
+                                      data-indeterminate="false"
+                                      id="checkbox-macOS"
+                                      type="checkbox"
+                                      value="false"
+                                    />
+                                    <svg
+                                      class="w-4 h-4"
+                                      fill="none"
+                                      height="14"
+                                      viewBox="0 0 14 14"
+                                      width="14"
+                                      xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <input
-                                        class="PrivateSwitchBase-input-4"
-                                        data-indeterminate="false"
-                                        type="checkbox"
-                                        value="false"
+                                      <title>
+                                        unchecked checkbox
+                                      </title>
+                                      <rect
+                                        height="13"
+                                        stroke="black"
+                                        width="13"
+                                        x="0.5"
+                                        y="0.5"
                                       />
-                                      <svg
-                                        class="w-4 h-4"
-                                        fill="none"
-                                        height="14"
-                                        viewBox="0 0 14 14"
-                                        width="14"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <title>
-                                          unchecked checkbox
-                                        </title>
-                                        <rect
-                                          height="13"
-                                          stroke="black"
-                                          width="13"
-                                          x="0.5"
-                                          y="0.5"
-                                        />
-                                      </svg>
-                                    </span>
+                                    </svg>
                                   </span>
                                   <span
-                                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                                  >
-                                    macOS
-                                  </span>
+                                    class="MuiTouchRipple-root"
+                                  />
+                                </span>
+                                <label
+                                  for="checkbox-macOS"
+                                >
+                                  macOS
                                 </label>
-                                <label
-                                  class="MuiFormControlLabel-root items-start m-0"
-                                  data-testid="input"
+                              </div>
+                              <div
+                                class="flex items-start"
+                                data-testid="filterCheckbox"
+                              >
+                                <span
+                                  aria-disabled="false"
+                                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current -mt-1 -ml-2"
                                 >
                                   <span
-                                    aria-disabled="false"
-                                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
+                                    class="MuiIconButton-label"
                                   >
-                                    <span
-                                      class="MuiIconButton-label"
+                                    <input
+                                      class="PrivateSwitchBase-input-4"
+                                      data-indeterminate="false"
+                                      id="checkbox-Windows"
+                                      type="checkbox"
+                                      value="false"
+                                    />
+                                    <svg
+                                      class="w-4 h-4"
+                                      fill="none"
+                                      height="14"
+                                      viewBox="0 0 14 14"
+                                      width="14"
+                                      xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <input
-                                        class="PrivateSwitchBase-input-4"
-                                        data-indeterminate="false"
-                                        type="checkbox"
-                                        value="false"
+                                      <title>
+                                        unchecked checkbox
+                                      </title>
+                                      <rect
+                                        height="13"
+                                        stroke="black"
+                                        width="13"
+                                        x="0.5"
+                                        y="0.5"
                                       />
-                                      <svg
-                                        class="w-4 h-4"
-                                        fill="none"
-                                        height="14"
-                                        viewBox="0 0 14 14"
-                                        width="14"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <title>
-                                          unchecked checkbox
-                                        </title>
-                                        <rect
-                                          height="13"
-                                          stroke="black"
-                                          width="13"
-                                          x="0.5"
-                                          y="0.5"
-                                        />
-                                      </svg>
-                                    </span>
+                                    </svg>
                                   </span>
                                   <span
-                                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                                  >
-                                    Windows
-                                  </span>
+                                    class="MuiTouchRipple-root"
+                                  />
+                                </span>
+                                <label
+                                  for="checkbox-Windows"
+                                >
+                                  Windows
                                 </label>
                               </div>
                             </fieldset>
                             <fieldset
-                              class="MuiFormControl-root mt-6"
+                              class="mt-6 flex flex-col"
                             >
                               <legend
-                                class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
-                                data-testid="title"
+                                class="font-semibold text-black text-sm mb-2"
+                                data-testid="filterCheckboxTitle"
                               >
                                 License
                               </legend>
                               <div
-                                class="MuiFormGroup-root"
+                                class="flex items-start"
+                                data-testid="filterCheckbox"
                               >
-                                <label
-                                  class="MuiFormControlLabel-root items-start m-0"
-                                  data-testid="input"
+                                <span
+                                  aria-disabled="false"
+                                  class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current -mt-1 -ml-2"
                                 >
                                   <span
-                                    aria-disabled="false"
-                                    class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
+                                    class="MuiIconButton-label"
                                   >
-                                    <span
-                                      class="MuiIconButton-label"
+                                    <input
+                                      class="PrivateSwitchBase-input-4"
+                                      data-indeterminate="false"
+                                      id="checkbox-Only show plugins with open source licenses"
+                                      type="checkbox"
+                                      value="false"
+                                    />
+                                    <svg
+                                      class="w-4 h-4"
+                                      fill="none"
+                                      height="14"
+                                      viewBox="0 0 14 14"
+                                      width="14"
+                                      xmlns="http://www.w3.org/2000/svg"
                                     >
-                                      <input
-                                        class="PrivateSwitchBase-input-4"
-                                        data-indeterminate="false"
-                                        type="checkbox"
-                                        value="false"
+                                      <title>
+                                        unchecked checkbox
+                                      </title>
+                                      <rect
+                                        height="13"
+                                        stroke="black"
+                                        width="13"
+                                        x="0.5"
+                                        y="0.5"
                                       />
-                                      <svg
-                                        class="w-4 h-4"
-                                        fill="none"
-                                        height="14"
-                                        viewBox="0 0 14 14"
-                                        width="14"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <title>
-                                          unchecked checkbox
-                                        </title>
-                                        <rect
-                                          height="13"
-                                          stroke="black"
-                                          width="13"
-                                          x="0.5"
-                                          y="0.5"
-                                        />
-                                      </svg>
-                                    </span>
+                                    </svg>
                                   </span>
                                   <span
-                                    class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                                  >
-                                    Only show plugins with open source licenses
-                                  </span>
+                                    class="MuiTouchRipple-root"
+                                  />
+                                </span>
+                                <label
+                                  for="checkbox-Only show plugins with open source licenses"
+                                >
+                                  Only show plugins with open source licenses
                                 </label>
                               </div>
                             </fieldset>
@@ -1220,352 +1236,368 @@ exports[`<PluginSearch /> should match snapshot 1`] = `
                   </legend>
                 </div>
                 <fieldset
-                  class="MuiFormControl-root mt-6"
+                  class="mt-6 flex flex-col"
                 >
                   <legend
-                    class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
-                    data-testid="title"
+                    class="font-semibold text-black text-sm mb-2"
+                    data-testid="filterCheckboxTitle"
                   >
                     Python versions
                   </legend>
                   <div
-                    class="MuiFormGroup-root"
+                    class="flex items-start"
+                    data-testid="filterCheckbox"
                   >
-                    <label
-                      class="MuiFormControlLabel-root items-start m-0"
-                      data-testid="input"
+                    <span
+                      aria-disabled="false"
+                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current -mt-1 -ml-2"
                     >
                       <span
-                        aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
+                        class="MuiIconButton-label"
                       >
-                        <span
-                          class="MuiIconButton-label"
+                        <input
+                          class="PrivateSwitchBase-input-4"
+                          data-indeterminate="false"
+                          id="checkbox-3.7"
+                          type="checkbox"
+                          value="false"
+                        />
+                        <svg
+                          class="w-4 h-4"
+                          fill="none"
+                          height="14"
+                          viewBox="0 0 14 14"
+                          width="14"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <input
-                            class="PrivateSwitchBase-input-4"
-                            data-indeterminate="false"
-                            type="checkbox"
-                            value="false"
+                          <title>
+                            unchecked checkbox
+                          </title>
+                          <rect
+                            height="13"
+                            stroke="black"
+                            width="13"
+                            x="0.5"
+                            y="0.5"
                           />
-                          <svg
-                            class="w-4 h-4"
-                            fill="none"
-                            height="14"
-                            viewBox="0 0 14 14"
-                            width="14"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title>
-                              unchecked checkbox
-                            </title>
-                            <rect
-                              height="13"
-                              stroke="black"
-                              width="13"
-                              x="0.5"
-                              y="0.5"
-                            />
-                          </svg>
-                        </span>
+                        </svg>
                       </span>
                       <span
-                        class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                      >
-                        3.7
-                      </span>
+                        class="MuiTouchRipple-root"
+                      />
+                    </span>
+                    <label
+                      for="checkbox-3.7"
+                    >
+                      3.7
                     </label>
-                    <label
-                      class="MuiFormControlLabel-root items-start m-0"
-                      data-testid="input"
+                  </div>
+                  <div
+                    class="flex items-start"
+                    data-testid="filterCheckbox"
+                  >
+                    <span
+                      aria-disabled="false"
+                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current -mt-1 -ml-2"
                     >
                       <span
-                        aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
+                        class="MuiIconButton-label"
                       >
-                        <span
-                          class="MuiIconButton-label"
+                        <input
+                          class="PrivateSwitchBase-input-4"
+                          data-indeterminate="false"
+                          id="checkbox-3.8"
+                          type="checkbox"
+                          value="false"
+                        />
+                        <svg
+                          class="w-4 h-4"
+                          fill="none"
+                          height="14"
+                          viewBox="0 0 14 14"
+                          width="14"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <input
-                            class="PrivateSwitchBase-input-4"
-                            data-indeterminate="false"
-                            type="checkbox"
-                            value="false"
+                          <title>
+                            unchecked checkbox
+                          </title>
+                          <rect
+                            height="13"
+                            stroke="black"
+                            width="13"
+                            x="0.5"
+                            y="0.5"
                           />
-                          <svg
-                            class="w-4 h-4"
-                            fill="none"
-                            height="14"
-                            viewBox="0 0 14 14"
-                            width="14"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title>
-                              unchecked checkbox
-                            </title>
-                            <rect
-                              height="13"
-                              stroke="black"
-                              width="13"
-                              x="0.5"
-                              y="0.5"
-                            />
-                          </svg>
-                        </span>
+                        </svg>
                       </span>
                       <span
-                        class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                      >
-                        3.8
-                      </span>
+                        class="MuiTouchRipple-root"
+                      />
+                    </span>
+                    <label
+                      for="checkbox-3.8"
+                    >
+                      3.8
                     </label>
-                    <label
-                      class="MuiFormControlLabel-root items-start m-0"
-                      data-testid="input"
+                  </div>
+                  <div
+                    class="flex items-start"
+                    data-testid="filterCheckbox"
+                  >
+                    <span
+                      aria-disabled="false"
+                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current -mt-1 -ml-2"
                     >
                       <span
-                        aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
+                        class="MuiIconButton-label"
                       >
-                        <span
-                          class="MuiIconButton-label"
+                        <input
+                          class="PrivateSwitchBase-input-4"
+                          data-indeterminate="false"
+                          id="checkbox-3.9"
+                          type="checkbox"
+                          value="false"
+                        />
+                        <svg
+                          class="w-4 h-4"
+                          fill="none"
+                          height="14"
+                          viewBox="0 0 14 14"
+                          width="14"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <input
-                            class="PrivateSwitchBase-input-4"
-                            data-indeterminate="false"
-                            type="checkbox"
-                            value="false"
+                          <title>
+                            unchecked checkbox
+                          </title>
+                          <rect
+                            height="13"
+                            stroke="black"
+                            width="13"
+                            x="0.5"
+                            y="0.5"
                           />
-                          <svg
-                            class="w-4 h-4"
-                            fill="none"
-                            height="14"
-                            viewBox="0 0 14 14"
-                            width="14"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title>
-                              unchecked checkbox
-                            </title>
-                            <rect
-                              height="13"
-                              stroke="black"
-                              width="13"
-                              x="0.5"
-                              y="0.5"
-                            />
-                          </svg>
-                        </span>
+                        </svg>
                       </span>
                       <span
-                        class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                      >
-                        3.9
-                      </span>
+                        class="MuiTouchRipple-root"
+                      />
+                    </span>
+                    <label
+                      for="checkbox-3.9"
+                    >
+                      3.9
                     </label>
                   </div>
                 </fieldset>
                 <fieldset
-                  class="MuiFormControl-root mt-6"
+                  class="mt-6 flex flex-col"
                 >
                   <legend
-                    class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
-                    data-testid="title"
+                    class="font-semibold text-black text-sm mb-2"
+                    data-testid="filterCheckboxTitle"
                   >
                     Operating system
                   </legend>
                   <div
-                    class="MuiFormGroup-root"
+                    class="flex items-start"
+                    data-testid="filterCheckbox"
                   >
-                    <label
-                      class="MuiFormControlLabel-root items-start m-0"
-                      data-testid="input"
+                    <span
+                      aria-disabled="false"
+                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current -mt-1 -ml-2"
                     >
                       <span
-                        aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
+                        class="MuiIconButton-label"
                       >
-                        <span
-                          class="MuiIconButton-label"
+                        <input
+                          class="PrivateSwitchBase-input-4"
+                          data-indeterminate="false"
+                          id="checkbox-Linux"
+                          type="checkbox"
+                          value="false"
+                        />
+                        <svg
+                          class="w-4 h-4"
+                          fill="none"
+                          height="14"
+                          viewBox="0 0 14 14"
+                          width="14"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <input
-                            class="PrivateSwitchBase-input-4"
-                            data-indeterminate="false"
-                            type="checkbox"
-                            value="false"
+                          <title>
+                            unchecked checkbox
+                          </title>
+                          <rect
+                            height="13"
+                            stroke="black"
+                            width="13"
+                            x="0.5"
+                            y="0.5"
                           />
-                          <svg
-                            class="w-4 h-4"
-                            fill="none"
-                            height="14"
-                            viewBox="0 0 14 14"
-                            width="14"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title>
-                              unchecked checkbox
-                            </title>
-                            <rect
-                              height="13"
-                              stroke="black"
-                              width="13"
-                              x="0.5"
-                              y="0.5"
-                            />
-                          </svg>
-                        </span>
+                        </svg>
                       </span>
                       <span
-                        class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                      >
-                        Linux
-                      </span>
+                        class="MuiTouchRipple-root"
+                      />
+                    </span>
+                    <label
+                      for="checkbox-Linux"
+                    >
+                      Linux
                     </label>
-                    <label
-                      class="MuiFormControlLabel-root items-start m-0"
-                      data-testid="input"
+                  </div>
+                  <div
+                    class="flex items-start"
+                    data-testid="filterCheckbox"
+                  >
+                    <span
+                      aria-disabled="false"
+                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current -mt-1 -ml-2"
                     >
                       <span
-                        aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
+                        class="MuiIconButton-label"
                       >
-                        <span
-                          class="MuiIconButton-label"
+                        <input
+                          class="PrivateSwitchBase-input-4"
+                          data-indeterminate="false"
+                          id="checkbox-macOS"
+                          type="checkbox"
+                          value="false"
+                        />
+                        <svg
+                          class="w-4 h-4"
+                          fill="none"
+                          height="14"
+                          viewBox="0 0 14 14"
+                          width="14"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <input
-                            class="PrivateSwitchBase-input-4"
-                            data-indeterminate="false"
-                            type="checkbox"
-                            value="false"
+                          <title>
+                            unchecked checkbox
+                          </title>
+                          <rect
+                            height="13"
+                            stroke="black"
+                            width="13"
+                            x="0.5"
+                            y="0.5"
                           />
-                          <svg
-                            class="w-4 h-4"
-                            fill="none"
-                            height="14"
-                            viewBox="0 0 14 14"
-                            width="14"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title>
-                              unchecked checkbox
-                            </title>
-                            <rect
-                              height="13"
-                              stroke="black"
-                              width="13"
-                              x="0.5"
-                              y="0.5"
-                            />
-                          </svg>
-                        </span>
+                        </svg>
                       </span>
                       <span
-                        class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                      >
-                        macOS
-                      </span>
+                        class="MuiTouchRipple-root"
+                      />
+                    </span>
+                    <label
+                      for="checkbox-macOS"
+                    >
+                      macOS
                     </label>
-                    <label
-                      class="MuiFormControlLabel-root items-start m-0"
-                      data-testid="input"
+                  </div>
+                  <div
+                    class="flex items-start"
+                    data-testid="filterCheckbox"
+                  >
+                    <span
+                      aria-disabled="false"
+                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current -mt-1 -ml-2"
                     >
                       <span
-                        aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
+                        class="MuiIconButton-label"
                       >
-                        <span
-                          class="MuiIconButton-label"
+                        <input
+                          class="PrivateSwitchBase-input-4"
+                          data-indeterminate="false"
+                          id="checkbox-Windows"
+                          type="checkbox"
+                          value="false"
+                        />
+                        <svg
+                          class="w-4 h-4"
+                          fill="none"
+                          height="14"
+                          viewBox="0 0 14 14"
+                          width="14"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <input
-                            class="PrivateSwitchBase-input-4"
-                            data-indeterminate="false"
-                            type="checkbox"
-                            value="false"
+                          <title>
+                            unchecked checkbox
+                          </title>
+                          <rect
+                            height="13"
+                            stroke="black"
+                            width="13"
+                            x="0.5"
+                            y="0.5"
                           />
-                          <svg
-                            class="w-4 h-4"
-                            fill="none"
-                            height="14"
-                            viewBox="0 0 14 14"
-                            width="14"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title>
-                              unchecked checkbox
-                            </title>
-                            <rect
-                              height="13"
-                              stroke="black"
-                              width="13"
-                              x="0.5"
-                              y="0.5"
-                            />
-                          </svg>
-                        </span>
+                        </svg>
                       </span>
                       <span
-                        class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                      >
-                        Windows
-                      </span>
+                        class="MuiTouchRipple-root"
+                      />
+                    </span>
+                    <label
+                      for="checkbox-Windows"
+                    >
+                      Windows
                     </label>
                   </div>
                 </fieldset>
                 <fieldset
-                  class="MuiFormControl-root mt-6"
+                  class="mt-6 flex flex-col"
                 >
                   <legend
-                    class="MuiFormLabel-root font-semibold text-black text-sm mb-2"
-                    data-testid="title"
+                    class="font-semibold text-black text-sm mb-2"
+                    data-testid="filterCheckboxTitle"
                   >
                     License
                   </legend>
                   <div
-                    class="MuiFormGroup-root"
+                    class="flex items-start"
+                    data-testid="filterCheckbox"
                   >
-                    <label
-                      class="MuiFormControlLabel-root items-start m-0"
-                      data-testid="input"
+                    <span
+                      aria-disabled="false"
+                      class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current -mt-1 -ml-2"
                     >
                       <span
-                        aria-disabled="false"
-                        class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-1 MuiCheckbox-root text-black fill-current py-1 pr-2 pl-0 mb-2 last:mb-0"
+                        class="MuiIconButton-label"
                       >
-                        <span
-                          class="MuiIconButton-label"
+                        <input
+                          class="PrivateSwitchBase-input-4"
+                          data-indeterminate="false"
+                          id="checkbox-Only show plugins with open source licenses"
+                          type="checkbox"
+                          value="false"
+                        />
+                        <svg
+                          class="w-4 h-4"
+                          fill="none"
+                          height="14"
+                          viewBox="0 0 14 14"
+                          width="14"
+                          xmlns="http://www.w3.org/2000/svg"
                         >
-                          <input
-                            class="PrivateSwitchBase-input-4"
-                            data-indeterminate="false"
-                            type="checkbox"
-                            value="false"
+                          <title>
+                            unchecked checkbox
+                          </title>
+                          <rect
+                            height="13"
+                            stroke="black"
+                            width="13"
+                            x="0.5"
+                            y="0.5"
                           />
-                          <svg
-                            class="w-4 h-4"
-                            fill="none"
-                            height="14"
-                            viewBox="0 0 14 14"
-                            width="14"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title>
-                              unchecked checkbox
-                            </title>
-                            <rect
-                              height="13"
-                              stroke="black"
-                              width="13"
-                              x="0.5"
-                              y="0.5"
-                            />
-                          </svg>
-                        </span>
+                        </svg>
                       </span>
                       <span
-                        class="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                      >
-                        Only show plugins with open source licenses
-                      </span>
+                        class="MuiTouchRipple-root"
+                      />
+                    </span>
+                    <label
+                      for="checkbox-Only show plugins with open source licenses"
+                    >
+                      Only show plugins with open source licenses
                     </label>
                   </div>
                 </fieldset>


### PR DESCRIPTION
## Description

This PR improves keyboard accessibility for the hub.

### Changes

- Fixes keyboard focus for filter checkboxes.
- Change tabbing order for plugin details so that the table of contents is focused before the main content.
  - A good example of this can be found in the W3 docs: https://www.w3.org/TR/WCAG20-TECHS/H4.html.
  - When tabbing through the above link, the browser will focus on the table of contents before the body
- Refactor MenuDrawer to use Material UI's [SwipeableDrawer](https://material-ui.com/api/swipeable-drawer/).
  - This improves accessibility because it restricts focus to the drawer elements.

## Demos

https://kb-a11y-frontend.dev.imaging.cziscience.com

### Filter checkbox focus

#### Before

A couple of bugs here:

- There's no focus styling when the checkbox is focused
- The Material UI ripple effect makes labels disappear for some reason

https://user-images.githubusercontent.com/2176050/128260650-563314b8-5f26-4d9f-a780-10805dc3ba1e.mp4

#### After

https://user-images.githubusercontent.com/2176050/128260663-4580c714-5192-4727-9afe-204a853e6226.mp4

### Plugin details tabbing order

#### Before

The tab order focuses on the main content first. If the content is long, then it can take a while to navigate to the table of contents and first installation button.

https://user-images.githubusercontent.com/2176050/128260758-36f81da0-4399-48c8-85c9-211b68706d3b.mp4

#### After

https://user-images.githubusercontent.com/2176050/128260762-ec92738f-b11d-4567-aaa5-dc87e5c9cea0.mp4

### Menu drawer

#### Before

The issue here is that keyboard navigation remains focused on the background elements when it should be limited to the menu drawer.

https://user-images.githubusercontent.com/2176050/128260901-f2b38942-fe35-4a3c-9600-5e203df81098.mp4

#### After

https://user-images.githubusercontent.com/2176050/128260912-fef8f4f5-9012-479d-8256-64dc208d088e.mp4

