### PR TITLE
Return plugin specific data for /plugins/:name for mock server

### DIFF
--- a/frontend/mock-server.js
+++ b/frontend/mock-server.js
@@ -4,6 +4,7 @@ if (process.env.MOCK_SERVER === 'false') {
 }
 
 const express = require('express');
+const { set } = require('lodash');
 
 const napariPlugin = require('./src/fixtures/napari.json');
 const pluginIndex = require('./src/fixtures/index.json');
@@ -11,15 +12,29 @@ const pluginIndex = require('./src/fixtures/index.json');
 const app = express();
 
 app.get('/plugins', async (_, res) => {
-  res.json({ 'napari-compressed-labels-io': '0.0.0' });
+  const versions = pluginIndex.reduce(
+    (result, { name }) => set(result, name, '0.0.0'),
+    {},
+  );
+
+  res.json(versions);
 });
 
 app.get('/plugins/index', async (_, res) => {
   res.json(pluginIndex);
 });
 
-app.get('/plugins/:name', async (_, res) => {
-  res.json(napariPlugin);
+app.get('/plugins/:name', async (req, res) => {
+  const plugin = pluginIndex.find(({ name }) => name === req.params.name);
+
+  if (plugin) {
+    res.json({
+      ...napariPlugin,
+      ...plugin,
+    });
+  } else {
+    res.status(404).send('not found');
+  }
 });
 
 app.listen(8081, () => console.log('Started mock API server'));

--- a/frontend/mock-server.js
+++ b/frontend/mock-server.js
@@ -13,7 +13,7 @@ const app = express();
 
 app.get('/plugins', async (_, res) => {
   const versions = pluginIndex.reduce(
-    (result, { name }) => set(result, name, '0.0.0'),
+    (result, { name, version }) => set(result, name, version),
     {},
   );
 


### PR DESCRIPTION
## Description

Updates the mock server to return plugin specific data instead of returning `napari-compressed-labels-io` all the time.