### PR TITLE
Adjust vertical spacing between plugin summary and install button

### DIFF
--- a/frontend/src/components/PluginDetails/PluginDetails.tsx
+++ b/frontend/src/components/PluginDetails/PluginDetails.tsx
@@ -50,7 +50,7 @@ function PluginCenterColumn() {
           'lg:flex-row lg:items-center',
 
           // Margins
-          'my-6 screen-495:mt-12 screen-600:mb-12',
+          'my-6 screen-495:mt-30 screen-600:mb-12',
         )}
         lessThan="3xl"
       >

--- a/frontend/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
+++ b/frontend/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
@@ -369,7 +369,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       Plugin exploring different options for reading and writing compressed and portable labels layers in napari.
     </h2>
     <div
-      class="fresnel-container fresnel-lessThan-3xl flex flex-col lg:flex-row lg:items-center my-6 screen-495:mt-12 screen-600:mb-12"
+      class="fresnel-container fresnel-lessThan-3xl flex flex-col lg:flex-row lg:items-center my-6 screen-495:mt-30 screen-600:mb-12"
     >
       <button
         class="fresnel-lessThan-2xl bg-napari-primary h-12 w-full screen-600:max-w-napari-col"


### PR DESCRIPTION
## Description
The vertical space between the plugin summary section and the install button was previously too far apart. This PR realigns the vertical spacing per Figma design.

## Screenshot
<img width="1792" alt="Screen Shot 2021-08-12 at 5 24 30 PM" src="https://user-images.githubusercontent.com/70177777/129286252-0982d417-898e-4ccd-a0ff-824b71df4f77.png">
<img width="1792" alt="Screen Shot 2021-08-13 at 11 16 16 AM" src="https://user-images.githubusercontent.com/70177777/129402102-c86e8a2e-e84b-4407-9ddc-2025655a571f.png">
<img width="1792" alt="Screen Shot 2021-08-13 at 11 13 38 AM" src="https://user-images.githubusercontent.com/70177777/129401849-91c9423e-8e51-4907-9e16-6c4e742e4341.png">

## Figma
https://www.figma.com/file/pDKU0CdSzpSWGaoXXQVJLz/v0-hub-final-designs?node-id=17%3A602