### PR TITLE
Fix TOC highlighting

### DIFF
--- a/frontend/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
+++ b/frontend/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
@@ -257,12 +257,12 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
         class="mt-9 flex flex-col border-l border-black"
       >
         <li
-          class="flex pl-6 border-l-4 min-h-6 h-auto my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
-          data-active="false"
+          class="flex pl-6 border-l-4 min-h-6 h-auto my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-black"
+          data-active="true"
           data-testid="tocItem"
         >
           <a
-            class=""
+            class="font-bold"
             href="#description"
           >
             Description
@@ -341,12 +341,12 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
           </a>
         </li>
         <li
-          class="flex pl-6 border-l-4 min-h-6 h-auto my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-black"
-          data-active="true"
+          class="flex pl-6 border-l-4 min-h-6 h-auto my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
+          data-active="false"
           data-testid="tocItem"
         >
           <a
-            class="font-bold"
+            class=""
             href="#issues"
           >
             Issues

--- a/frontend/src/components/common/TableOfContents/TableOfContents.hooks.ts
+++ b/frontend/src/components/common/TableOfContents/TableOfContents.hooks.ts
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import { throttle } from 'lodash';
+import { useCallback, useEffect, useState } from 'react';
 
 import { TOCHeader } from './TableOfContents.types';
 
@@ -7,7 +8,54 @@ import { TOCHeader } from './TableOfContents.types';
  * viewport when scrolling to a heading, so the next heading should be
  * highlighted when hitting that offset.
  */
-const TOP_OFFSET = 35;
+const TOP_OFFSET_PX = 35;
+
+/**
+ * Duration of throttling for  `findActiveHeader()` function. This is so that
+ * the `findActiveHeader()` function is called no more than 100ms so that we can
+ * reduce expensive calls to `getBoundingClientRect()`.
+ */
+const FIND_ACTIVE_HEADER_THROTTLE_MS = 100;
+
+/**
+ * Duration to wait for before setting the active header on initial load.
+ */
+const SET_INITIAL_HEADER_TIMEOUT_MS = 200;
+
+/**
+ * Utility function for finding the first header in the viewport by looking for
+ * the first positive `top` value.
+ *
+ * TODO Look into using IntersectionObserver API: https://mzl.la/3lYJvpt
+ *
+ * @param headers The markdown headers.
+ * @returns Data for the first header in the viewport.
+ */
+function firstHeaderInViewport(headers: TOCHeader[]) {
+  // Find first header that is in viewport.
+  let firstHeaderTop = 0;
+  let firstHeaderIndex = -1;
+
+  for (let i = 0; i < headers.length; i += 1) {
+    const { id } = headers[i];
+    const node = document.getElementById(id);
+    const top = node?.getBoundingClientRect()?.top ?? 0;
+
+    if (top >= 0) {
+      firstHeaderTop = top;
+      firstHeaderIndex = i;
+      break;
+    }
+  }
+
+  const firstHeader = headers[firstHeaderIndex] as TOCHeader | undefined;
+
+  return {
+    firstHeader,
+    firstHeaderTop,
+    firstHeaderIndex,
+  };
+}
 
 /**
  * Hook for getting the selected heading anchor from an array of markdown
@@ -20,57 +68,91 @@ const TOP_OFFSET = 35;
  * @param headers Markdown headers from `getHeadersFromMarkdown()`
  * @returns Active header ID
  */
-export function useActiveHeader(headers: TOCHeader[]): string {
-  const [active, setActive] = useState(headers[0]?.id ?? '');
+export function useActiveHeader(headers: TOCHeader[]) {
+  const [activeHeader, setActiveHeader] = useState(headers[0]?.id ?? '');
 
-  useEffect(() => {
-    function findActiveHeader() {
-      // Get headers as DOM nodes.
-      const headerTags = headers.map((header) =>
-        document.getElementById(header.id),
-      );
+  // Function that finds the active header based on the current viewport `scrollY`.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const findActiveHeader = useCallback(
+    throttle(() => {
+      const {
+        firstHeader,
+        firstHeaderIndex,
+        firstHeaderTop,
+      } = firstHeaderInViewport(headers);
 
-      // Find first header that is in viewport.
-      const firstHeaderIndex = headerTags.findIndex((header) => {
-        const top = header?.getBoundingClientRect()?.top ?? 0;
-        return top >= 0;
-      });
-      const firstHeader = headerTags[firstHeaderIndex];
-
-      if (firstHeader) {
-        const { top } = firstHeader.getBoundingClientRect();
-
-        // If user reaches the bottom, set the last header as selected.
-        if (
-          window.innerHeight + window.pageYOffset >=
-          document.body.scrollHeight
-        ) {
-          setActive(headers[headers.length - 1].id);
-        } else if (Math.floor(top) <= TOP_OFFSET) {
-          setActive(firstHeader.id);
-        } else {
-          /*
-            If the first header in viewport is greater than the offset, then
-            the user is still in the previous section.
-          */
-          const previousHeader = headers[firstHeaderIndex - 1] ?? firstHeader;
-          setActive(previousHeader.id);
-        }
+      if (!firstHeader) {
+        return;
       }
-    }
 
+      // If user reaches the bottom, set the last header as selected.
+      if (window.innerHeight + window.scrollY >= document.body.scrollHeight) {
+        setActiveHeader(headers[headers.length - 1].id);
+      } else if (Math.floor(firstHeaderTop) <= TOP_OFFSET_PX) {
+        setActiveHeader(firstHeader.id);
+      } else {
+        // If the first header in the viewport is greater than the offset, then the
+        // user is still in the previous section.
+        const previousHeader = headers[firstHeaderIndex - 1] ?? firstHeader;
+        setActiveHeader(previousHeader.id);
+      }
+    }, FIND_ACTIVE_HEADER_THROTTLE_MS),
+    [headers],
+  );
+
+  const enableEventHandlers = useCallback(() => {
     document.addEventListener('scroll', findActiveHeader);
     document.addEventListener('resize', findActiveHeader);
+  }, [findActiveHeader]);
 
-    // Find active header on initial render
-    findActiveHeader();
+  const disableEventHandlers = useCallback(() => {
+    document.removeEventListener('scroll', findActiveHeader);
+    document.removeEventListener('resize', findActiveHeader);
+  }, [findActiveHeader]);
 
-    // Remove event listeners on cleanup.
-    return () => {
-      document.removeEventListener('scroll', findActiveHeader);
-      document.removeEventListener('resize', findActiveHeader);
-    };
-  }, [headers]);
+  // Effect for determining the active header on initial load. For some reason,
+  // this effect doesn't work on Safari because of some weird hash link issue.
+  // When opening a URL like https://napari-hub.org/plugins/example#license,
+  // Safari will sometimes open the page several pixels above the `License`
+  // header.
+  //
+  // The same issue can be seen on GitHub when opening a hash link in Safari:
+  // https://docs.github.com/en/actions/creating-actions/about-actions#creating-a-readme-file-for-your-action
+  // TODO Look into fix for Safari.
+  useEffect(() => {
+    const initialHeader = window.location.hash.replace(/^#/, '');
 
-  return active;
+    // If the user is opening a link with a header specified in the hash, then
+    // we need to figure out the correct active header to render.
+    if (headers.find((header) => header.id === initialHeader)) {
+      // Wrap in timeout so that the DOM has time to settle after initial load.
+      setTimeout(() => {
+        // If the header is at the bottom of the page, then set the active
+        // header to whatever was specified in the URL hash.
+        if (window.innerHeight + window.scrollY >= document.body.scrollHeight) {
+          setActiveHeader(initialHeader);
+        } else {
+          // If the page is loaded anywhere else, then just find the next active
+          // header in the viewport.
+          findActiveHeader();
+        }
+
+        enableEventHandlers();
+      }, SET_INITIAL_HEADER_TIMEOUT_MS);
+    } else {
+      // If there is no header specified in the hash, then just find the next
+      // active header in the viewport.
+      findActiveHeader();
+      enableEventHandlers();
+    }
+
+    return disableEventHandlers;
+  }, [disableEventHandlers, enableEventHandlers, findActiveHeader, headers]);
+
+  return {
+    activeHeader,
+    setActiveHeader,
+    enableEventHandlers,
+    disableEventHandlers,
+  };
 }

--- a/frontend/src/components/common/TableOfContents/TableOfContents.hooks.ts
+++ b/frontend/src/components/common/TableOfContents/TableOfContents.hooks.ts
@@ -85,10 +85,7 @@ export function useActiveHeader(headers: TOCHeader[]) {
         return;
       }
 
-      // If user reaches the bottom, set the last header as selected.
-      if (window.innerHeight + window.scrollY >= document.body.scrollHeight) {
-        setActiveHeader(headers[headers.length - 1].id);
-      } else if (Math.floor(firstHeaderTop) <= TOP_OFFSET_PX) {
+      if (Math.floor(firstHeaderTop) <= TOP_OFFSET_PX) {
         setActiveHeader(firstHeader.id);
       } else {
         // If the first header in the viewport is greater than the offset, then the

--- a/frontend/src/components/common/TableOfContents/TableOfContents.tsx
+++ b/frontend/src/components/common/TableOfContents/TableOfContents.tsx
@@ -26,11 +26,21 @@ interface Props {
 }
 
 /**
+ * Duration to wait for before re-enabling the TOC event handlers.
+ */
+const ENABLE_EVENT_HANDLERS_TIMEOUT_MS = 100;
+
+/**
  * Component for rendering TOC from the given headers. Highlighting will
  * only work if the headers match those present on the page.
  */
 export function TableOfContents({ className, onClick, headers, free }: Props) {
-  const activeHeader = useActiveHeader(headers);
+  const {
+    activeHeader,
+    setActiveHeader,
+    enableEventHandlers,
+    disableEventHandlers,
+  } = useActiveHeader(headers);
 
   return (
     <ul
@@ -79,7 +89,29 @@ export function TableOfContents({ className, onClick, headers, free }: Props) {
             <a
               className={clsx(isActive && 'font-bold')}
               href={`#${header.id}`}
-              onClick={() => onClick?.(header.text)}
+              onClick={(event) => {
+                event.preventDefault();
+
+                // The event handlers are disabled here because we want to set
+                // the active header AND scroll to the header. If the handlers
+                // aren't disabled, then the handlers and the below
+                // `setActiveHeader()` will have a race condition.
+                disableEventHandlers();
+
+                // Set the hash to the header ID so that the page scrolls to it.
+                window.location.hash = header.id;
+                setActiveHeader(header.id);
+                onClick?.(header.text);
+
+                // Wrap in timeout so that the browser has time to scroll the
+                // header. If we don't wrap it in a timeout, then setting the
+                // hash will fire a scroll event and overwrite the active
+                // header.
+                setTimeout(
+                  () => enableEventHandlers(),
+                  ENABLE_EVENT_HANDLERS_TIMEOUT_MS,
+                );
+              }}
             >
               {header.text}
             </a>

--- a/frontend/src/components/common/TableOfContents/__snapshots__/TableOfContents.test.tsx.snap
+++ b/frontend/src/components/common/TableOfContents/__snapshots__/TableOfContents.test.tsx.snap
@@ -6,24 +6,24 @@ exports[`Table of Contents should match snapshot 1`] = `
     class="flex flex-col border-l border-black sticky top-12"
   >
     <li
-      class="flex pl-6 border-l-4 min-h-6 h-auto my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
-      data-active="false"
-      data-testid="tocItem"
-    >
-      <a
-        class=""
-        href="#one"
-      >
-        One
-      </a>
-    </li>
-    <li
       class="flex pl-6 border-l-4 min-h-6 h-auto my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-black"
       data-active="true"
       data-testid="tocItem"
     >
       <a
         class="font-bold"
+        href="#one"
+      >
+        One
+      </a>
+    </li>
+    <li
+      class="flex pl-6 border-l-4 min-h-6 h-auto my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
+      data-active="false"
+      data-testid="tocItem"
+    >
+      <a
+        class=""
         href="#two"
       >
         Two

--- a/frontend/src/components/common/TableOfContents/__snapshots__/TableOfContents.test.tsx.snap
+++ b/frontend/src/components/common/TableOfContents/__snapshots__/TableOfContents.test.tsx.snap
@@ -6,24 +6,24 @@ exports[`Table of Contents should match snapshot 1`] = `
     class="flex flex-col border-l border-black sticky top-12"
   >
     <li
-      class="flex pl-6 border-l-4 min-h-6 h-auto my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-black"
-      data-active="true"
-      data-testid="tocItem"
-    >
-      <a
-        class="font-bold"
-        href="#one"
-      >
-        One
-      </a>
-    </li>
-    <li
       class="flex pl-6 border-l-4 min-h-6 h-auto my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-transparent"
       data-active="false"
       data-testid="tocItem"
     >
       <a
         class=""
+        href="#one"
+      >
+        One
+      </a>
+    </li>
+    <li
+      class="flex pl-6 border-l-4 min-h-6 h-auto my-2 first:mt-0 last:mb-0 transition-colors hover:border-napari-primary border-black"
+      data-active="true"
+      data-testid="tocItem"
+    >
+      <a
+        class="font-bold"
         href="#two"
       >
         Two


### PR DESCRIPTION
## Description

Closes #157 

This PR fixes the active header highlighting for the `TableOfContents` component. This updates the logic so that it implements the [following missing behavior](https://github.com/chanzuckerberg/napari-hub/issues/157#issuecomment-897084157):

> when I click the second-to-last item in the nav:❗️it does not apply selected style to the clicked-nav item (instead keeps same style on last section's nav item). The treatment should change to show second-to-last section's nav item in selected treatment. (Also the page doens't scroll, but that's to be expected because the second-to-last section is also too short to touch the top... but if it's not too short then it should).

## Demos

https://fix-toc-frontend.dev.imaging.cziscience.com/plugins/napari-bioformats

### Highlight Selected

Clicking on a TOC will highlight the selected item, even if there's not enough space for it to be active on scroll, and it'll stay highlighted until the user scrolls again.

https://user-images.githubusercontent.com/2176050/129811889-09417b53-6935-408f-ab5d-4bd24abfde1e.mp4

### Highlight on Initial Load

When sharing a link to a heading directly, the page will:

1. Scroll to the heading
1. Highlight the corresponding TOC item

https://user-images.githubusercontent.com/2176050/129414445-370a01a1-80e4-484f-9241-0948e933c499.mp4

### Highlight on Reload

#### Chrome / Edge / Safari

The above browsers will maintain the previous scroll position on reload and highlight the next header in the viewport.

https://user-images.githubusercontent.com/2176050/129414436-c9c442d3-6dcc-40b1-8c5a-5be833ac3ce2.mp4

#### Firefox

Firefox is the only browser that scrolls back to the heading on reload (instead of maintaining the previous scroll position).

https://user-images.githubusercontent.com/2176050/129414418-9604bf6b-d3d9-47f7-ab23-dae3ff1172ab.mp4
