### PR TITLE
Update shield API to return a valid badge for plugins not listed

### DIFF
--- a/backend/_tests/test_lambda.py
+++ b/backend/_tests/test_lambda.py
@@ -157,7 +157,10 @@ def test_get_shield(mock_plugins):
     assert 'color' in result
 
     result = get_shield('not-a-package')
-    assert result == {}
+    assert result['message'] == 'not a plugin'
+    assert 'label' in result
+    assert 'schemaVersion' in result
+    assert 'color' in result
 
 
 def test_github_get_url():

--- a/backend/_tests/test_lambda.py
+++ b/backend/_tests/test_lambda.py
@@ -157,7 +157,7 @@ def test_get_shield(mock_plugins):
     assert 'color' in result
 
     result = get_shield('not-a-package')
-    assert result['message'] == 'not a plugin'
+    assert result['message'] == 'plugin not found'
     assert 'label' in result
     assert 'schemaVersion' in result
     assert 'color' in result

--- a/backend/napari.py
+++ b/backend/napari.py
@@ -384,12 +384,12 @@ def get_plugin(plugin: str, version: str = None) -> dict:
 @app.route('/shields/<plugin>')
 def get_shield(plugin: str):
     plugins = get_plugins()
+    plugin_shield_schema = copy.deepcopy(shield_schema)
     if plugin not in plugins:
-        return {}
+        plugin_shield_schema['message'] = 'plugin not found'
     else:
-        plugin_shield_schema = copy.deepcopy(shield_schema)
         plugin_shield_schema['message'] = plugin
-        return plugin_shield_schema
+    return plugin_shield_schema
 
 
 def cache_available(key: str, ttl: [timedelta, None]) -> bool:


### PR DESCRIPTION
Rather than returning blank JSON response when a plugin is not found, we now return a valid JSON schema for a `plugin not found` badge.

Also updated tests to reflect this change.