### PR TITLE
Add instructions for using napari hub shield to FAQ

### DIFF
--- a/frontend/src/pages/faq.mdx
+++ b/frontend/src/pages/faq.mdx
@@ -148,6 +148,22 @@ to see what metadata we will present and where we source it from.
 </Accordion>
 
 <Accordion
+  title="How do I add a shield/badge for the hub to my repository?"
+  variant="faq"
+>
+
+The napari hub supports Shields.io shields for your repository linking to your plugin’s 
+listing page. If you want to add a shield to your README or other markdown files, 
+you can copy paste this snippet:
+
+`[![napari hub](https://img.shields.io/endpoint?url=https://api.napari-hub.org/shields/<your-plugin-name-here>)](https://napari-hub.org/<your-plugin-name-here>)`
+
+If you just want access to the badge SVG, you can access that at 
+`https://img.shields.io/endpoint?url=https://api.napari-hub.org/shields/<your-plugin-name-here>)`.
+
+</Accordion>
+
+<Accordion
   title="Can I preview my listing before I upload my plugin?"
   variant="faq"
 >

--- a/frontend/src/pages/faq.mdx
+++ b/frontend/src/pages/faq.mdx
@@ -158,7 +158,7 @@ you can copy paste this snippet:
 
 `[![napari hub](https://img.shields.io/endpoint?url=https://api.napari-hub.org/shields/<your-plugin-name-here>)](https://napari-hub.org/<your-plugin-name-here>)`
 
-If you just want access to the badge SVG, you can access that at 
+If you just want the badge SVG, you can access that at 
 `https://img.shields.io/endpoint?url=https://api.napari-hub.org/shields/<your-plugin-name-here>)`.
 
 </Accordion>

--- a/frontend/src/pages/faq.mdx
+++ b/frontend/src/pages/faq.mdx
@@ -156,10 +156,15 @@ The napari hub supports [Shields.io](https://shields.io/) shields for your repos
 listing page. If you want to add a shield to your README or other markdown files,
 you can copy & paste the snippet:
 
-`[![napari hub](https://img.shields.io/endpoint?url=https://api.napari-hub.org/shields/<your-plugin-name-here>)](https://napari-hub.org/plugins/<your-plugin-name-here>)`
+```
+[![napari hub](https://img.shields.io/endpoint?url=https://api.napari-hub.org/shields/<your-plugin-name-here>)](https://napari-hub.org/plugins/<your-plugin-name-here>)
+```
 
-If you just want the badge SVG, you can access that at
-`https://img.shields.io/endpoint?url=https://api.napari-hub.org/shields/<your-plugin-name-here>`.
+If you just want the badge SVG, you can access that at the URL below.
+
+```
+https://img.shields.io/endpoint?url=https://api.napari-hub.org/shields/<your-plugin-name-here>
+```
 
 </Accordion>
 

--- a/frontend/src/pages/faq.mdx
+++ b/frontend/src/pages/faq.mdx
@@ -152,13 +152,13 @@ to see what metadata we will present and where we source it from.
   variant="faq"
 >
 
-The napari hub supports [Shields.io](https://shields.io/) shields for your repository linking to your plugin’s 
-listing page. If you want to add a shield to your README or other markdown files, 
-you can copy paste this snippet:
+The napari hub supports [Shields.io](https://shields.io/) shields for your repository linking to your plugin’s
+listing page. If you want to add a shield to your README or other markdown files,
+you can copy & paste the snippet:
 
 `[![napari hub](https://img.shields.io/endpoint?url=https://api.napari-hub.org/shields/<your-plugin-name-here>)](https://napari-hub.org/plugins/<your-plugin-name-here>)`
 
-If you just want the badge SVG, you can access that at 
+If you just want the badge SVG, you can access that at
 `https://img.shields.io/endpoint?url=https://api.napari-hub.org/shields/<your-plugin-name-here>`.
 
 </Accordion>

--- a/frontend/src/pages/faq.mdx
+++ b/frontend/src/pages/faq.mdx
@@ -152,7 +152,7 @@ to see what metadata we will present and where we source it from.
   variant="faq"
 >
 
-The napari hub supports Shields.io shields for your repository linking to your plugin’s 
+The napari hub supports [Shields.io](https://shields.io/) shields for your repository linking to your plugin’s 
 listing page. If you want to add a shield to your README or other markdown files, 
 you can copy paste this snippet:
 

--- a/frontend/src/pages/faq.mdx
+++ b/frontend/src/pages/faq.mdx
@@ -156,10 +156,10 @@ The napari hub supports [Shields.io](https://shields.io/) shields for your repos
 listing page. If you want to add a shield to your README or other markdown files, 
 you can copy paste this snippet:
 
-`[![napari hub](https://img.shields.io/endpoint?url=https://api.napari-hub.org/shields/<your-plugin-name-here>)](https://napari-hub.org/<your-plugin-name-here>)`
+`[![napari hub](https://img.shields.io/endpoint?url=https://api.napari-hub.org/shields/<your-plugin-name-here>)](https://napari-hub.org/plugins/<your-plugin-name-here>)`
 
 If you just want the badge SVG, you can access that at 
-`https://img.shields.io/endpoint?url=https://api.napari-hub.org/shields/<your-plugin-name-here>)`.
+`https://img.shields.io/endpoint?url=https://api.napari-hub.org/shields/<your-plugin-name-here>`.
 
 </Accordion>
 

--- a/frontend/src/pages/faq.mdx
+++ b/frontend/src/pages/faq.mdx
@@ -148,7 +148,7 @@ to see what metadata we will present and where we source it from.
 </Accordion>
 
 <Accordion
-  title="How do I add a shield/badge for the hub to my repository?"
+  title="How do I add a shield/badge for the napari hub to my repository?"
   variant="faq"
 >
 


### PR DESCRIPTION
Add instructions for embedding shield into markdown (linking back to the hub) or just accessing the SVG.

Not sure if this is the best place to put this, but it made sense to me to put it under "Customizing your plugin's listing" - @neuromusic thoughts and/or concerns?

I'll also open a PR on the cookiecutter reop to add it to our README there, and once we release next week, advertise in the community meeting and on Zulip.