### PR TITLE
Fix code highlighting for single backticks in MDX files

### DIFF
--- a/frontend/jest/test.config.js
+++ b/frontend/jest/test.config.js
@@ -4,14 +4,13 @@ module.exports = {
   testMatch: ['<rootDir>/src/**/*.test.ts?(x)'],
 
   moduleNameMapper: {
-    '^@/(.*)$': '<rootDir>/src/$1',
-
     /*
       `identity-obj-proxy` returns a string for whatever key you use, so we use
       it for SCSS modules since components use the exports to assign class
       names.
     */
     '^.+\\.module\\.scss$': 'identity-obj-proxy',
+    '^@/(.*)$': '<rootDir>/src/$1',
   },
 
   transform: {

--- a/frontend/src/components/LayoutMDX/LayoutMDX.tsx
+++ b/frontend/src/components/LayoutMDX/LayoutMDX.tsx
@@ -5,9 +5,8 @@ import { ReactNode } from 'react';
 import { ColumnLayout, TableOfContents, TOCHeader } from '@/components/common';
 import { Media } from '@/components/common/media';
 
-import { useHeaders } from './LayoutMDX.hooks';
-
 import styles from '../common/Markdown/Markdown.module.scss';
+import { useHeaders } from './LayoutMDX.hooks';
 
 interface Props {
   toc?: boolean;

--- a/frontend/src/components/LayoutMDX/LayoutMDX.tsx
+++ b/frontend/src/components/LayoutMDX/LayoutMDX.tsx
@@ -3,9 +3,9 @@ import Head from 'next/head';
 import { ReactNode } from 'react';
 
 import { ColumnLayout, TableOfContents, TOCHeader } from '@/components/common';
+import styles from '@/components/common/Markdown/Markdown.module.scss';
 import { Media } from '@/components/common/media';
 
-import styles from '../common/Markdown/Markdown.module.scss';
 import { useHeaders } from './LayoutMDX.hooks';
 
 interface Props {

--- a/frontend/src/components/LayoutMDX/LayoutMDX.tsx
+++ b/frontend/src/components/LayoutMDX/LayoutMDX.tsx
@@ -27,13 +27,7 @@ export function LayoutMDX({ toc, title, children }: Props) {
         <article
           className={clsx(
             styles.markdown,
-            /*
-          Use Tailwind prose for reasonable defaults on markdown styling. In
-          the future, we can fine tune the CSS by hand for each markdown
-          element.
-        */
             'prose',
-            // Disable max-width set by prose
             'max-w-none',
             'col-span-2',
             'screen-875:col-span-3',

--- a/frontend/src/components/LayoutMDX/LayoutMDX.tsx
+++ b/frontend/src/components/LayoutMDX/LayoutMDX.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import Head from 'next/head';
 import { ReactNode } from 'react';
 
@@ -5,6 +6,8 @@ import { ColumnLayout, TableOfContents, TOCHeader } from '@/components/common';
 import { Media } from '@/components/common/media';
 
 import { useHeaders } from './LayoutMDX.hooks';
+
+import styles from '../common/Markdown/Markdown.module.scss';
 
 interface Props {
   toc?: boolean;
@@ -22,7 +25,22 @@ export function LayoutMDX({ toc, title, children }: Props) {
       </Head>
 
       <ColumnLayout className="p-6 md:p-12 screen-1150:px-0">
-        <article className="markdown prose max-w-none col-span-2 screen-875:col-span-3 screen-1425:col-start-2">
+        <article
+          className={clsx(
+            styles.markdown,
+            /*
+          Use Tailwind prose for reasonable defaults on markdown styling. In
+          the future, we can fine tune the CSS by hand for each markdown
+          element.
+        */
+            'prose',
+            // Disable max-width set by prose
+            'max-w-none',
+            'col-span-2',
+            'screen-875:col-span-3',
+            'screen-1425:col-start-2',
+          )}
+        >
           {children}
         </article>
         {toc && (

--- a/frontend/src/components/LayoutMDX/LayoutMDX.tsx
+++ b/frontend/src/components/LayoutMDX/LayoutMDX.tsx
@@ -1,9 +1,9 @@
 import clsx from 'clsx';
 import Head from 'next/head';
 import { ReactNode } from 'react';
-import styles from 'src/components/common/Markdown/Markdown.module.scss';
 
 import { ColumnLayout, TableOfContents, TOCHeader } from '@/components/common';
+import styles from '@/components/common/Markdown/Markdown.module.scss';
 import { Media } from '@/components/common/media';
 
 import { useHeaders } from './LayoutMDX.hooks';

--- a/frontend/src/components/LayoutMDX/LayoutMDX.tsx
+++ b/frontend/src/components/LayoutMDX/LayoutMDX.tsx
@@ -1,9 +1,9 @@
 import clsx from 'clsx';
 import Head from 'next/head';
 import { ReactNode } from 'react';
+import styles from 'src/components/common/Markdown/Markdown.module.scss';
 
 import { ColumnLayout, TableOfContents, TOCHeader } from '@/components/common';
-import styles from '@/components/common/Markdown/Markdown.module.scss';
 import { Media } from '@/components/common/media';
 
 import { useHeaders } from './LayoutMDX.hooks';


### PR DESCRIPTION
This PR fixes code highlighting for single backticks in MDX files e.g. the FAQ page - the `Article` element just needed the appropriate styles. @codemonkey800 please make sure I haven't done anything weird, it's my first foray into the frontend for the hub.

Before this PR:
![image](https://user-images.githubusercontent.com/17995243/133864696-fe81ec23-0237-4011-9099-a88c6f340b79.png)

After this PR:
![image](https://user-images.githubusercontent.com/17995243/133864721-ed24a6fe-51cd-4254-a113-24bf517f0e13.png)