### PR TITLE
Fix pagination issues

### DIFF
--- a/frontend/src/components/PluginSearch/PluginSearch.tsx
+++ b/frontend/src/components/PluginSearch/PluginSearch.tsx
@@ -8,6 +8,7 @@ import { ColumnLayout, Pagination } from '@/components/common';
 import { loadingStore } from '@/store/loading';
 import { searchFormStore } from '@/store/search/form.store';
 import { searchResultsStore } from '@/store/search/results.store';
+import { scrollToSearchBar } from '@/utils';
 
 import { PluginSearchBar } from './PluginSearchBar';
 import { PluginSearchControls } from './PluginSearchControls';
@@ -29,8 +30,9 @@ function updatePage(value: number) {
   // Update page value.
   searchFormStore.page += value;
 
-  // Schedule scroll for later execution. Wrap in `raf()` to remove scroll flicker.
-  requestAnimationFrame(() => window.scroll(0, document.body.scrollHeight));
+  // Scroll to top of results so that the user will see the most relevant for
+  // the current page.
+  scrollToSearchBar();
 }
 
 /**

--- a/frontend/src/components/common/Pagination/Pagination.tsx
+++ b/frontend/src/components/common/Pagination/Pagination.tsx
@@ -45,7 +45,7 @@ export function Pagination({
           styles.pageButton,
           'focus-visible:bg-napari-hover-gray hover:bg-napari-hover-gray',
 
-          isDisabled && 'opacity-0 hover:cursor-default',
+          isDisabled && 'opacity-0 cursor-default',
           type === 'left' ? 'mr-2' : 'ml-2',
         )}
         data-testid={`pagination${upperFirst(type)}`}

--- a/frontend/src/components/common/Pagination/Pagination.tsx
+++ b/frontend/src/components/common/Pagination/Pagination.tsx
@@ -59,7 +59,16 @@ export function Pagination({
   }
 
   return (
-    <nav className={clsx(className, 'flex items-center justify-center')}>
+    <nav
+      className={clsx(
+        className,
+        'flex items-center justify-center',
+
+        // Disable user selection so that the cursor doesn't flicker between the
+        // default and select pointers.
+        'select-none',
+      )}
+    >
       {renderPageButton('left')}
 
       <span className={styles.value} data-testid="paginationValue">

--- a/frontend/src/components/common/Pagination/Pagination.tsx
+++ b/frontend/src/components/common/Pagination/Pagination.tsx
@@ -45,7 +45,7 @@ export function Pagination({
           styles.pageButton,
           'focus-visible:bg-napari-hover-gray hover:bg-napari-hover-gray',
 
-          isDisabled && 'opacity-0',
+          isDisabled && 'opacity-0 hover:cursor-default',
           type === 'left' ? 'mr-2' : 'ml-2',
         )}
         data-testid={`pagination${upperFirst(type)}`}

--- a/frontend/src/components/common/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/frontend/src/components/common/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`<Pagination /> should match snapshot 1`] = `
 <DocumentFragment>
   <nav
-    class="flex items-center justify-center"
+    class="flex items-center justify-center select-none"
   >
     <button
-      class="pageButton focus-visible:bg-napari-hover-gray hover:bg-napari-hover-gray opacity-0 mr-2"
+      class="pageButton focus-visible:bg-napari-hover-gray hover:bg-napari-hover-gray opacity-0 hover:cursor-default mr-2"
       data-testid="paginationLeft"
       disabled=""
       type="button"

--- a/frontend/src/components/common/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/frontend/src/components/common/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<Pagination /> should match snapshot 1`] = `
     class="flex items-center justify-center select-none"
   >
     <button
-      class="pageButton focus-visible:bg-napari-hover-gray hover:bg-napari-hover-gray opacity-0 hover:cursor-default mr-2"
+      class="pageButton focus-visible:bg-napari-hover-gray hover:bg-napari-hover-gray opacity-0 cursor-default mr-2"
       data-testid="paginationLeft"
       disabled=""
       type="button"

--- a/frontend/src/store/search/queryParameters.ts
+++ b/frontend/src/store/search/queryParameters.ts
@@ -1,4 +1,4 @@
-import { inRange, set } from 'lodash';
+import { set } from 'lodash';
 import { subscribe } from 'valtio';
 
 import { BEGINNING_PAGE, RESULTS_PER_PAGE } from '@/constants/search';
@@ -84,10 +84,15 @@ function initStateFromQueryParameters() {
       searchFormStore.search.index.length / RESULTS_PER_PAGE,
     );
 
-    searchFormStore.page =
-      Number.isNaN(page) || !inRange(page, BEGINNING_PAGE, totalPages + 1)
-        ? BEGINNING_PAGE
-        : page;
+    // If the page number is not a number or not in range, then set it to the
+    // beginning or ending page depending on which is closer.
+    if (Number.isNaN(page) || page < BEGINNING_PAGE) {
+      searchFormStore.page = BEGINNING_PAGE;
+    } else if (page > totalPages) {
+      searchFormStore.page = totalPages;
+    } else {
+      searchFormStore.page = page;
+    }
   }
 }
 


### PR DESCRIPTION
## Description

Fixes issues found during QA:

> 1. when user clicks the next/back page... page remains at the bottom when it should go up every time user navigates the pagination
> 1. when page 1 or last page if displayed, if user positions the mouse next to the pagination, there is a hover state that should not be showing up
> 1. if there is only 5 pages, and in the search bar user enters page 7 for example, first page is displayed, instead of last page, in this case. page 5

## Demos

https://pagination-frontend.dev.imaging.cziscience.com/

### Pagination scrolls to top when changing pages

Before the page would stay at the bottom when navigating.

https://user-images.githubusercontent.com/2176050/136067488-ea55a891-7be5-4ea3-ab15-4ca11de32487.mp4

### Remove hover state from disabled buttons

#### Before

![highlight-state-before](https://user-images.githubusercontent.com/2176050/136088709-3b6976e5-420e-4b64-8644-ac2410df29ef.gif)

#### After

![highlight-state-after](https://user-images.githubusercontent.com/2176050/136088623-16bc9cb7-40b5-4904-b400-607d60b2e730.gif)

### Open closest extreme for out-of-range pages

Before, the page would always start at page 1 if the page was out of range. Now, the page will be set to the closest extreme:

1. If the page is < 1 or not a number, then the page is automatically set to first page.
2. If the page is > `totalPages`, the page is set to the last page.

![page-invalid-values](https://user-images.githubusercontent.com/2176050/136067773-dc75b217-eb7c-4fe6-ac2a-220571ffe432.gif)


