### PR TITLE
Fix page metadata not working

### DIFF
--- a/frontend/src/components/PluginDetails/PluginDetails.tsx
+++ b/frontend/src/components/PluginDetails/PluginDetails.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import { throttle } from 'lodash';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 
 import {
@@ -169,6 +170,7 @@ const scrollHandler = throttle(() => {
 export function PluginDetails() {
   const loading = useLoadingState();
   const { plugin } = usePluginState();
+  const router = useRouter();
 
   useEffect(() => {
     if (loading) {
@@ -198,7 +200,11 @@ export function PluginDetails() {
     <>
       <Head>
         <title>{title}</title>
-        <PageMetadata keywords={keywords} description={plugin?.summary} />
+        <PageMetadata
+          keywords={keywords}
+          description={plugin?.summary}
+          pathname={router.pathname}
+        />
       </Head>
 
       <ColumnLayout

--- a/frontend/src/components/common/PageMetadata/PageMetadata.tsx
+++ b/frontend/src/components/common/PageMetadata/PageMetadata.tsx
@@ -1,10 +1,14 @@
-import { useRouter } from 'next/router';
-
 import { getPageMetadata } from './PageMetadata.utils';
 
 interface Props {
   keywords?: string[];
   description?: string;
+
+  /**
+   * Pathname has to be passed directly because `useRouter()` cannot be used
+   * within `<Head />` components.
+   */
+  pathname: string;
 }
 
 /**
@@ -12,9 +16,8 @@ interface Props {
  * appended to the keyword list used for the page. If a description is provided,
  * it's used instead of the configured value.
  */
-export function PageMetadata({ keywords, description }: Props) {
-  const router = useRouter();
-  const metadata = getPageMetadata(router?.pathname ?? '');
+export function PageMetadata({ keywords, description, pathname }: Props) {
+  const metadata = getPageMetadata(pathname);
 
   return (
     <>

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -83,7 +83,9 @@ export default function App({ Component, pageProps }: AppProps) {
           // The plugin page has plugin specific content that needs to be added
           // to the Page Metadata, so skip adding it here in `_app.tsx` so that
           // the data can be fetched by the plugin page.
-          !router.pathname.includes('/plugins/') && <PageMetadata />
+          !router.pathname.includes('/plugins/') && (
+            <PageMetadata pathname={router.pathname} />
+          )
         }
 
         {/*


### PR DESCRIPTION
Closes #285

For some reason, the `useRouter()` hook returns `null` when used within the `<Head>` component. Because the `<PageMetadata>` component is always used within a `<Head>` component, we'll need to pass the pathname directly.