### PR TITLE
Remove dates from preview page

### DIFF
--- a/frontend/src/components/AppBar/metadataPreview.hooks.ts
+++ b/frontend/src/components/AppBar/metadataPreview.hooks.ts
@@ -91,14 +91,6 @@ export function useMetadataSections(): MetadataSection[] {
           hasValue: !!plugin.version,
         },
         {
-          name: 'Release date',
-          hasValue: !!plugin.release_date,
-        },
-        {
-          name: 'First released',
-          hasValue: !!plugin.first_released,
-        },
-        {
           name: 'Development Status',
           hasValue: !!plugin.development_status,
         },


### PR DESCRIPTION
## Description

Removes `First released` and `Release date` from the preview page since this is metadata that can't be controlled by the user.

## Demos

- Missing data: https://napari-hub-preview-missing-data.vercel.app/preview.html
- All complete data: https://napari-hub-preview-all-complete.vercel.app/preview.html