### PR TITLE
Preview page refactors

### DIFF
--- a/frontend/src/components/AppBar/metadataPreview.hooks.ts
+++ b/frontend/src/components/AppBar/metadataPreview.hooks.ts
@@ -15,6 +15,7 @@ export interface MetadataSection {
 
 export function useMetadataSections(): MetadataSection[] {
   const { plugin } = usePluginState();
+
   return [
     {
       title: 'Name + descriptions',
@@ -23,15 +24,15 @@ export function useMetadataSections(): MetadataSection[] {
       fields: [
         {
           name: 'Plugin name',
-          hasValue: !!plugin.name,
+          hasValue: !!plugin?.name,
         },
         {
           name: 'Brief description',
-          hasValue: !!plugin.summary,
+          hasValue: !!plugin?.summary,
         },
         {
           name: 'Plugin description using hub-specific template',
-          hasValue: !!plugin.description,
+          hasValue: !!plugin?.description,
         },
         // TODO Future categories, disable this for now until the data is ready.
         // {
@@ -51,7 +52,7 @@ export function useMetadataSections(): MetadataSection[] {
       fields: [
         {
           name: 'Authors',
-          hasValue: !isEmpty(plugin.authors),
+          hasValue: !isEmpty(plugin?.authors),
         },
         // TODO Add when design for optional metadata is ready
         // {
@@ -60,7 +61,7 @@ export function useMetadataSections(): MetadataSection[] {
         // },
         {
           name: 'Report issues site',
-          hasValue: !!plugin.report_issues,
+          hasValue: !!plugin?.report_issues,
         },
         // TODO Add when design for optional metadata is ready
         // {
@@ -69,15 +70,15 @@ export function useMetadataSections(): MetadataSection[] {
         // },
         {
           name: 'Source code',
-          hasValue: !!plugin.code_repository,
+          hasValue: !!plugin?.code_repository,
         },
         {
           name: 'Documentation site',
-          hasValue: !!plugin.documentation,
+          hasValue: !!plugin?.documentation,
         },
         {
           name: 'Support site',
-          hasValue: !!plugin.support,
+          hasValue: !!plugin?.support,
         },
       ],
     },
@@ -88,15 +89,15 @@ export function useMetadataSections(): MetadataSection[] {
       fields: [
         {
           name: 'Version',
-          hasValue: !!plugin.version,
+          hasValue: !!plugin?.version,
         },
         {
           name: 'Development Status',
-          hasValue: !!plugin.development_status,
+          hasValue: !!plugin?.development_status,
         },
         {
           name: 'License',
-          hasValue: !!plugin.license,
+          hasValue: !!plugin?.license,
         },
       ],
     },
@@ -107,15 +108,15 @@ export function useMetadataSections(): MetadataSection[] {
       fields: [
         {
           name: 'Python versions supported',
-          hasValue: !isEmpty(plugin.python_version),
+          hasValue: !isEmpty(plugin?.python_version),
         },
         {
           name: 'Operating system',
-          hasValue: !isEmpty(plugin.operating_system),
+          hasValue: !isEmpty(plugin?.operating_system),
         },
         {
           name: 'Requirements',
-          hasValue: !!plugin.requirements,
+          hasValue: !!plugin?.requirements,
         },
       ],
     },

--- a/frontend/src/components/AppBar/metadataPreview.hooks.ts
+++ b/frontend/src/components/AppBar/metadataPreview.hooks.ts
@@ -1,6 +1,6 @@
 import { isEmpty } from 'lodash';
 
-import { usePluginState } from '@/context/plugin';
+import { MetadataKeys, usePluginMetadata } from '@/context/plugin';
 
 export interface MetadataSectionField {
   name: string;
@@ -13,112 +13,66 @@ export interface MetadataSection {
   fields: MetadataSectionField[];
 }
 
+function hasPreviewName<T extends { previewName: string }>(
+  value: unknown,
+): value is T {
+  return !!(value as T).previewName;
+}
+
 export function useMetadataSections(): MetadataSection[] {
-  const { plugin } = usePluginState();
+  const metadata = usePluginMetadata();
+
+  function getFields(...keys: MetadataKeys[]) {
+    return keys
+      .map((key) => metadata[key])
+      .map((data) => ({
+        name: hasPreviewName(data) ? data.previewName : data.name,
+        hasValue: !isEmpty(data.value),
+      }));
+  }
 
   return [
     {
       title: 'Name + descriptions',
       description:
         '[Explain what these metadata help the end user understand / why useful to populate them.]',
-      fields: [
-        {
-          name: 'Plugin name',
-          hasValue: !!plugin?.name,
-        },
-        {
-          name: 'Brief description',
-          hasValue: !!plugin?.summary,
-        },
-        {
-          name: 'Plugin description using hub-specific template',
-          hasValue: !!plugin?.description,
-        },
+      fields: getFields(
+        'name',
+        'summary',
+        'description',
+
         // TODO Future categories, disable this for now until the data is ready.
-        // {
-        //   name: 'Supported data',
-        //   hasValue: true,
-        // },
-        // {
-        //   name: 'Plugin type',
-        //   hasValue: true,
-        // },
-      ],
+        // 'supportedData',
+        // 'pluginType',
+      ),
     },
     {
       title: 'Support + contact',
       description:
         '[Explain what these metadata help the end user understand / why useful to populate them.]',
-      fields: [
-        {
-          name: 'Authors',
-          hasValue: !isEmpty(plugin?.authors),
-        },
+      fields: getFields(
+        'authors',
         // TODO Add when design for optional metadata is ready
-        // {
-        //   name: 'Project site',
-        //   hasValue: !!plugin.project_site,
-        // },
-        {
-          name: 'Report issues site',
-          hasValue: !!plugin?.report_issues,
-        },
+        // 'projectSite',
+        'reportIssues',
         // TODO Add when design for optional metadata is ready
-        // {
-        //   name: 'Twitter handle',
-        //   hasValue: !!plugin.twitter,
-        // },
-        {
-          name: 'Source code',
-          hasValue: !!plugin?.code_repository,
-        },
-        {
-          name: 'Documentation site',
-          hasValue: !!plugin?.documentation,
-        },
-        {
-          name: 'Support site',
-          hasValue: !!plugin?.support,
-        },
-      ],
+        // 'twitter',
+        'sourceCode',
+        'documentationSite',
+        'supportSite',
+      ),
     },
     {
       title: 'Development information',
       description:
         '[Explain what these metadata help the end user understand / why useful to populate them.]',
-      fields: [
-        {
-          name: 'Version',
-          hasValue: !!plugin?.version,
-        },
-        {
-          name: 'Development Status',
-          hasValue: !!plugin?.development_status,
-        },
-        {
-          name: 'License',
-          hasValue: !!plugin?.license,
-        },
-      ],
+      fields: getFields('version', 'developmentStatus', 'license'),
     },
     {
       title: 'Implementation requirements',
       description:
         '[Explain what these metadata help the end user understand / why useful to populate them.]',
-      fields: [
-        {
-          name: 'Python versions supported',
-          hasValue: !isEmpty(plugin?.python_version),
-        },
-        {
-          name: 'Operating system',
-          hasValue: !isEmpty(plugin?.operating_system),
-        },
-        {
-          name: 'Requirements',
-          hasValue: !!plugin?.requirements,
-        },
-      ],
+      fields: getFields('pythonVersion', 'operatingSystems', 'requirements'),
     },
   ];
 }

--- a/frontend/src/components/MetadataList/EmptyListItem.tsx
+++ b/frontend/src/components/MetadataList/EmptyListItem.tsx
@@ -1,0 +1,33 @@
+import { Tooltip } from '@material-ui/core';
+import clsx from 'clsx';
+
+import { MetadataStatus } from '@/components/MetadataStatus';
+
+import { useMetadataContext } from './metadata.context';
+
+/**
+ * Renders a special list item indicating to inform the user that the metadata
+ * has no supplied value.
+ */
+export function EmptyListItem() {
+  const { inline } = useMetadataContext();
+
+  return (
+    <li
+      className={clsx(
+        'flex justify-between items-center',
+        inline ? 'inline' : 'block',
+      )}
+    >
+      <span className="text-napari-gray font-normal">
+        information not submitted
+      </span>
+
+      <Tooltip placement="right" title="MetadataStatus Text Placeholder">
+        <div>
+          <MetadataStatus hasValue={false} />
+        </div>
+      </Tooltip>
+    </li>
+  );
+}

--- a/frontend/src/components/MetadataList/EmptyListItem.tsx
+++ b/frontend/src/components/MetadataList/EmptyListItem.tsx
@@ -6,8 +6,8 @@ import { MetadataStatus } from '@/components/MetadataStatus';
 import { useMetadataContext } from './metadata.context';
 
 /**
- * Renders a special list item indicating to inform the user that the metadata
- * has no supplied value.
+ * Renders a special list item informing the user that the metadata has no
+ * supplied value.
  */
 export function EmptyListItem() {
   const { inline } = useMetadataContext();

--- a/frontend/src/components/MetadataList/MetadataList.module.scss
+++ b/frontend/src/components/MetadataList/MetadataList.module.scss
@@ -1,8 +1,10 @@
+// Styles to apply to inline lists and their list items.
 .inlineList {
   .textItem,
   .linkItem {
     @apply inline;
 
+    // Add commas for every item except the last.
     &:not(:last-child)::after {
       @apply mr-1;
       content: ', ';
@@ -14,8 +16,8 @@
     }
   }
 
-  // If there are multiple items in the list, use inline flex so that
-  // links and icons can:
+  // If there are multiple link items in the list, use inline flex so that links
+  // and icons do not break on separate lines:
   // https://stackoverflow.com/a/18738114
   .linkItem + .linkItem {
     @apply inline-flex items-end;

--- a/frontend/src/components/MetadataList/MetadataList.module.scss
+++ b/frontend/src/components/MetadataList/MetadataList.module.scss
@@ -1,0 +1,23 @@
+.inlineList {
+  .textItem,
+  .linkItem {
+    @apply inline;
+
+    &:not(:last-child)::after {
+      @apply mr-1;
+      content: ', ';
+    }
+
+    // Make icons inline.
+    svg {
+      @apply inline;
+    }
+  }
+
+  // If there are multiple items in the list, use inline flex so that
+  // links and icons can:
+  // https://stackoverflow.com/a/18738114
+  .linkItem + .linkItem {
+    @apply inline-flex items-end;
+  }
+}

--- a/frontend/src/components/MetadataList/MetadataList.module.scss.d.ts
+++ b/frontend/src/components/MetadataList/MetadataList.module.scss.d.ts
@@ -1,5 +1,7 @@
 export type Styles = {
-  commaList: string;
+  inlineList: string;
+  linkItem: string;
+  textItem: string;
 };
 
 export type ClassNames = keyof Styles;

--- a/frontend/src/components/MetadataList/MetadataList.tsx
+++ b/frontend/src/components/MetadataList/MetadataList.tsx
@@ -17,7 +17,7 @@ interface Props {
 }
 
 /**
- * Component for rendering a plugin metadata values as a titled list.
+ * Component for rendering plugin metadata values as a titled list.
  */
 export function MetadataList({
   children,

--- a/frontend/src/components/MetadataList/MetadataList.tsx
+++ b/frontend/src/components/MetadataList/MetadataList.tsx
@@ -1,0 +1,84 @@
+import clsx from 'clsx';
+import { ReactNode } from 'react';
+
+import { useIsPreview } from '@/hooks';
+
+import { EmptyListItem } from './EmptyListItem';
+import { MetadataContextProvider } from './metadata.context';
+import styles from './MetadataList.module.scss';
+
+interface Props {
+  children: ReactNode;
+  className?: string;
+  title: string;
+  inline?: boolean;
+  compact?: boolean;
+  empty?: boolean;
+}
+
+/**
+ * Component for rendering a plugin metadata values as a titled list.
+ */
+export function MetadataList({
+  children,
+  className,
+  compact,
+  empty,
+  title,
+  inline,
+}: Props) {
+  const isPreview = useIsPreview();
+
+  return (
+    // Pass list props in context so that list items can render differently
+    // depending on the list props.
+    <MetadataContextProvider empty={!!empty} inline={!!inline}>
+      {/*
+        Use list wrapper so that the preview highlight overlay only renders as
+        tall as the content.
+       */}
+      <div className={clsx('text-sm', className)}>
+        {/* List container */}
+        <div
+          className={clsx(
+            // Render overlay if the list is empty.
+            isPreview && empty && 'bg-napari-preview-orange-overlay',
+
+            // Item spacing for inline lists.
+            inline && 'space-x-2',
+
+            // Vertical spacing.
+            'space-y-2',
+          )}
+        >
+          {/* List title */}
+          <h4
+            className={clsx(
+              // Font
+              'font-bold whitespace-nowrap',
+
+              // Render title inline with values.
+              inline && 'inline',
+            )}
+          >
+            {title}:
+          </h4>
+
+          {/* List values */}
+          <ul
+            className={clsx(
+              'list-none text-sm leading-normal',
+
+              // Vertical and horizontal spacing.
+              inline
+                ? ['inline space-y-2', styles.inlineList]
+                : [compact ? 'space-y-2' : 'space-y-5'],
+            )}
+          >
+            {empty ? <EmptyListItem /> : children}
+          </ul>
+        </div>
+      </div>
+    </MetadataContextProvider>
+  );
+}

--- a/frontend/src/components/MetadataList/MetadataListLinkItem.tsx
+++ b/frontend/src/components/MetadataList/MetadataListLinkItem.tsx
@@ -1,0 +1,80 @@
+import clsx from 'clsx';
+import { ReactNode } from 'react-markdown';
+
+import { Link } from '@/components/common/Link/Link';
+import { MetadataStatus } from '@/components/MetadataStatus';
+import { usePluginState } from '@/context/plugin';
+import { usePlausible } from '@/hooks';
+
+import { useMetadataContext } from './metadata.context';
+import styles from './MetadataList.module.scss';
+
+interface Props {
+  children: string;
+  href: string;
+  icon?: ReactNode;
+  missingIcon?: ReactNode;
+}
+
+export function MetadataListLinkItem({
+  children,
+  href,
+  icon,
+  missingIcon,
+}: Props) {
+  const plausible = usePlausible();
+  const { plugin } = usePluginState();
+  const { inline } = useMetadataContext();
+  const isPreview = !!process.env.PREVIEW;
+  const itemClassName = 'ml-2 -mt-1 flex-grow';
+  const internalLink = !isExternalUrl(value.href);
+
+  return (
+    <li
+      className={clsx(
+        'flex',
+        styles.linkItem,
+        isPreview && !href && 'bg-napari-preview-orange-overlay',
+      )}
+    >
+      <span className="min-w-4">{href ? icon : missingIcon || icon}</span>
+
+      {href ? (
+        <Link
+          className={clsx(itemClassName, 'underline')}
+          href={href}
+          newTab={!internalLink}
+          onClick={
+            internalLink
+              ? undefined
+              : () => {
+                  const url = new URL(href);
+
+                  if (plugin?.name) {
+                    plausible('Links', {
+                      host: url.host,
+                      link: children,
+                      plugin: plugin.name,
+                      url: href,
+                    });
+                  }
+                }
+          }
+        >
+          {children}
+        </Link>
+      ) : (
+        <span className={clsx(itemClassName, 'text-napari-gray')}>
+          {children}
+        </span>
+      )}
+
+      {isPreview && !href && (
+        <MetadataStatus
+          hasValue={false}
+          variant={inline ? 'inline' : 'regular'}
+        />
+      )}
+    </li>
+  );
+}

--- a/frontend/src/components/MetadataList/MetadataListLinkItem.tsx
+++ b/frontend/src/components/MetadataList/MetadataListLinkItem.tsx
@@ -17,6 +17,10 @@ interface Props {
   missingIcon?: ReactNode;
 }
 
+/**
+ * Component for rendering link items in metadata lists. A link item can also
+ * include an icon, or a missing icon if the URL is empty.
+ */
 export function MetadataListLinkItem({
   children,
   href,

--- a/frontend/src/components/MetadataList/MetadataListLinkItem.tsx
+++ b/frontend/src/components/MetadataList/MetadataListLinkItem.tsx
@@ -5,6 +5,7 @@ import { Link } from '@/components/common/Link/Link';
 import { MetadataStatus } from '@/components/MetadataStatus';
 import { usePluginState } from '@/context/plugin';
 import { usePlausible } from '@/hooks';
+import { isExternalUrl } from '@/utils';
 
 import { useMetadataContext } from './metadata.context';
 import styles from './MetadataList.module.scss';
@@ -27,7 +28,7 @@ export function MetadataListLinkItem({
   const { inline } = useMetadataContext();
   const isPreview = !!process.env.PREVIEW;
   const itemClassName = 'ml-2 -mt-1 flex-grow';
-  const internalLink = !isExternalUrl(value.href);
+  const internalLink = !isExternalUrl(href);
 
   return (
     <li

--- a/frontend/src/components/MetadataList/MetadataListTextItem.tsx
+++ b/frontend/src/components/MetadataList/MetadataListTextItem.tsx
@@ -1,0 +1,13 @@
+import clsx from 'clsx';
+import { ReactNode } from 'react';
+
+import styles from './MetadataList.module.scss';
+
+interface Props {
+  children: ReactNode;
+  className?: string;
+}
+
+export function MetadataListTextItem({ children, className }: Props) {
+  return <li className={clsx(styles.textItem, className)}>{children}</li>;
+}

--- a/frontend/src/components/MetadataList/MetadataListTextItem.tsx
+++ b/frontend/src/components/MetadataList/MetadataListTextItem.tsx
@@ -8,6 +8,9 @@ interface Props {
   className?: string;
 }
 
+/**
+ * Component for rendering text items in metadata lists.
+ */
 export function MetadataListTextItem({ children, className }: Props) {
   return <li className={clsx(styles.textItem, className)}>{children}</li>;
 }

--- a/frontend/src/components/MetadataList/index.ts
+++ b/frontend/src/components/MetadataList/index.ts
@@ -1,0 +1,3 @@
+export * from './MetadataList';
+export * from './MetadataListLinkItem';
+export * from './MetadataListTextItem';

--- a/frontend/src/components/MetadataList/metadata.context.tsx
+++ b/frontend/src/components/MetadataList/metadata.context.tsx
@@ -1,3 +1,8 @@
+/**
+ * This module provides global access to metadata list data so that internal
+ * list components can access it.
+ */
+
 import { createContext, ReactNode, useContext } from 'react';
 
 interface MetadataContextValue {

--- a/frontend/src/components/MetadataList/metadata.context.tsx
+++ b/frontend/src/components/MetadataList/metadata.context.tsx
@@ -1,0 +1,27 @@
+import { createContext, ReactNode, useContext } from 'react';
+
+interface MetadataContextValue {
+  empty: boolean;
+  inline: boolean;
+}
+
+const MetadataContext = createContext<MetadataContextValue>({
+  empty: false,
+  inline: false,
+});
+
+interface Props extends MetadataContextValue {
+  children: ReactNode;
+}
+
+export function MetadataContextProvider({ children, ...props }: Props) {
+  return (
+    <MetadataContext.Provider value={props}>
+      {children}
+    </MetadataContext.Provider>
+  );
+}
+
+export function useMetadataContext(): MetadataContextValue {
+  return useContext(MetadataContext);
+}

--- a/frontend/src/components/MetadataStatus.tsx
+++ b/frontend/src/components/MetadataStatus.tsx
@@ -3,11 +3,13 @@ import clsx from 'clsx';
 import { Check, PriorityHigh } from '@/components/common/icons';
 
 interface MetadataStatusProps {
+  className?: string;
   hasValue: boolean;
-  variant?: 'regular' | 'small';
+  variant?: 'regular' | 'small' | 'inline';
 }
 
 export function MetadataStatus({
+  className,
   hasValue,
   variant = 'regular',
 }: MetadataStatusProps) {
@@ -15,8 +17,10 @@ export function MetadataStatus({
     <div
       className={clsx(
         'flex items-center justify-center',
+        className,
         hasValue ? 'bg-napari-primary' : 'bg-napari-preview-orange',
         variant === 'small' ? 'w-2 h-2' : 'w-[0.9375rem] h-[0.9375rem]',
+        variant === 'inline' && 'inline-flex',
       )}
     >
       {hasValue ? <Check /> : <PriorityHigh color="#fff" />}

--- a/frontend/src/components/PluginDetails/CallToActionButton.tsx
+++ b/frontend/src/components/PluginDetails/CallToActionButton.tsx
@@ -41,9 +41,12 @@ export function CallToActionButton({ className }: Props) {
             )}
             onClick={() => {
               setVisible(true);
-              plausible('Install', {
-                plugin: plugin.name,
-              });
+
+              if (plugin?.name) {
+                plausible('Install', {
+                  plugin: plugin.name,
+                });
+              }
             }}
             type="button"
           >

--- a/frontend/src/components/PluginDetails/CitationInfo.tsx
+++ b/frontend/src/components/PluginDetails/CitationInfo.tsx
@@ -42,7 +42,7 @@ export function CitationInfo({ className }: Props) {
     COPY_FEEDBACK_DEBOUNCE_DURATION_MS,
   );
 
-  const citation = plugin.citations ? plugin.citations[tab] : '';
+  const citation = plugin?.citations ? plugin.citations[tab] : '';
 
   const handleChange = (_: unknown, changedTab: CitationKeys) => {
     setTab(changedTab);
@@ -87,7 +87,7 @@ export function CitationInfo({ className }: Props) {
                 className="py-4 px-6 mt-6 bg-napari-hover-gray"
               >
                 <div className="whitespace-pre-wrap overflow-y-auto max-h-32">
-                  {plugin.citations?.[item]}
+                  {plugin?.citations?.[item]}
                 </div>
               </TabPanel>
             );
@@ -99,7 +99,9 @@ export function CitationInfo({ className }: Props) {
             className={BUTTON_STYLES}
             variant="outlined"
             onClick={async () => {
-              await navigator.clipboard?.writeText?.(citation);
+              if (citation) {
+                await navigator.clipboard?.writeText?.(citation);
+              }
 
               // Set `copied` to true immediately when the user clicks
               if (!copied) {

--- a/frontend/src/components/PluginDetails/CitationInfo.tsx
+++ b/frontend/src/components/PluginDetails/CitationInfo.tsx
@@ -115,16 +115,19 @@ export function CitationInfo({ className }: Props) {
           >
             {copied ? <>Copied!</> : <>Copy</>}
           </Button>
-          <Button
-            className={clsx(BUTTON_STYLES)}
-            variant="outlined"
-            download={`${plugin.name}.${CITATION_EXTS[tab]}`}
-            href={`data:text/plain;charset=utf-8,${encodeURIComponent(
-              citation,
-            )}`}
-          >
-            Download
-          </Button>
+
+          {plugin?.name && citation && (
+            <Button
+              className={clsx(BUTTON_STYLES)}
+              variant="outlined"
+              download={`${plugin.name}.${CITATION_EXTS[tab]}`}
+              href={`data:text/plain;charset=utf-8,${encodeURIComponent(
+                citation,
+              )}`}
+            >
+              Download
+            </Button>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/components/PluginDetails/InstallModal.tsx
+++ b/frontend/src/components/PluginDetails/InstallModal.tsx
@@ -50,8 +50,6 @@ function CopyPluginNameButton() {
         'transition-colors',
       )}
       onClick={async () => {
-        await navigator.clipboard?.writeText?.(plugin.name);
-
         // Set `clicked` to true immediately when the user clicks
         if (!clicked) {
           setClicked(true);
@@ -61,12 +59,16 @@ function CopyPluginNameButton() {
         // so if the user clicks on the button again, it'll reset the timeout.
         setClickDebounced(false);
 
-        plausible('Copy Package', {
-          plugin: plugin.name,
-        });
+        if (plugin?.name) {
+          await navigator.clipboard?.writeText?.(plugin.name);
+
+          plausible('Copy Package', {
+            plugin: plugin.name,
+          });
+        }
       }}
     >
-      {plugin.name}{' '}
+      {plugin?.name}{' '}
       <span className="ml-2 inline-flex">
         {clicked ? (
           <CheckCircle className="w-4" />

--- a/frontend/src/components/PluginDetails/MetadataList.module.scss
+++ b/frontend/src/components/PluginDetails/MetadataList.module.scss
@@ -1,9 +1,0 @@
-/**
- * Class that adds a comma after every child except the last.  Useful for
- * making long lists inline.
- */
-.commaList {
-  &:not(:last-child)::after {
-    content: ', ';
-  }
-}

--- a/frontend/src/components/PluginDetails/MetadataList.tsx
+++ b/frontend/src/components/PluginDetails/MetadataList.tsx
@@ -109,12 +109,15 @@ function MetadataListItem({ inline, title, values }: MetadataListItemProps) {
                         ? undefined
                         : () => {
                             const url = new URL(value.href);
-                            plausible('Links', {
-                              host: url.host,
-                              link: value.text,
-                              plugin: plugin.name,
-                              url: value.href,
-                            });
+
+                            if (plugin?.name) {
+                              plausible('Links', {
+                                host: url.host,
+                                link: value.text,
+                                plugin: plugin.name,
+                                url: value.href,
+                              });
+                            }
                           }
                     }
                   >

--- a/frontend/src/components/PluginDetails/PluginDetails.tsx
+++ b/frontend/src/components/PluginDetails/PluginDetails.tsx
@@ -34,8 +34,16 @@ function PluginLeftColumn() {
   );
 }
 
+const EMPTY_DESCRIPTION_PLACEHOLDER =
+  'The developer has not yet provided a napari-hub specific description.';
+
 function PluginCenterColumn() {
   const { plugin } = usePluginState();
+
+  // Check if body is an empty string or if it's set to the cookiecutter text.
+  const isEmptyDescription =
+    !plugin?.description ||
+    plugin.description.includes(EMPTY_DESCRIPTION_PLACEHOLDER);
 
   return (
     <article
@@ -49,7 +57,12 @@ function PluginCenterColumn() {
       <SkeletonLoader
         className="h-12"
         render={() => (
-          <h1 className="font-bold text-4xl">
+          <h1
+            className={clsx(
+              'font-bold text-4xl',
+              !plugin?.name && 'text-napari-dark-gray',
+            )}
+          >
             {plugin?.name ?? 'Plugin name'}
           </h1>
         )}
@@ -58,7 +71,12 @@ function PluginCenterColumn() {
       <SkeletonLoader
         className="h-6 my-6"
         render={() => (
-          <h2 className="font-semibold my-6 text-lg">
+          <h2
+            className={clsx(
+              'font-semibold my-6 text-lg',
+              !plugin?.summary && '!text-napari-dark-gray',
+            )}
+          >
             {plugin?.summary ?? 'Brief description'}
           </h2>
         )}
@@ -118,8 +136,12 @@ function PluginCenterColumn() {
       <SkeletonLoader
         className="h-[600px] mb-10"
         render={() => (
-          <Markdown className={clsx('mb-10')} disableHeader>
-            {plugin?.description ?? ''}
+          <Markdown
+            className={clsx('mb-10')}
+            disableHeader
+            placeholder={isEmptyDescription}
+          >
+            {plugin?.description ?? EMPTY_DESCRIPTION_PLACEHOLDER}
           </Markdown>
         )}
       />

--- a/frontend/src/components/PluginDetails/PluginDetails.tsx
+++ b/frontend/src/components/PluginDetails/PluginDetails.tsx
@@ -39,6 +39,7 @@ const EMPTY_DESCRIPTION_PLACEHOLDER =
 
 function PluginCenterColumn() {
   const { plugin } = usePluginState();
+  const isPreview = useIsPreview();
 
   // Check if body is an empty string or if it's set to the cookiecutter text.
   const isEmptyDescription =
@@ -60,7 +61,10 @@ function PluginCenterColumn() {
           <h1
             className={clsx(
               'font-bold text-4xl',
-              !plugin?.name && 'text-napari-dark-gray',
+              !plugin?.name && [
+                'text-napari-dark-gray',
+                isPreview && 'bg-napari-preview-orange-overlay',
+              ],
             )}
           >
             {plugin?.name ?? 'Plugin name'}
@@ -74,7 +78,10 @@ function PluginCenterColumn() {
           <h2
             className={clsx(
               'font-semibold my-6 text-lg',
-              !plugin?.summary && '!text-napari-dark-gray',
+              !plugin?.summary && [
+                '!text-napari-dark-gray',
+                isPreview && 'bg-napari-preview-orange-overlay',
+              ],
             )}
           >
             {plugin?.summary ?? 'Brief description'}
@@ -137,7 +144,12 @@ function PluginCenterColumn() {
         className="h-[600px] mb-10"
         render={() => (
           <Markdown
-            className={clsx('mb-10')}
+            className={clsx(
+              'mb-10',
+              isPreview &&
+                isEmptyDescription &&
+                'bg-napari-preview-orange-overlay',
+            )}
             disableHeader
             placeholder={isEmptyDescription}
           >

--- a/frontend/src/components/PluginDetails/PluginDetails.tsx
+++ b/frontend/src/components/PluginDetails/PluginDetails.tsx
@@ -48,13 +48,19 @@ function PluginCenterColumn() {
     >
       <SkeletonLoader
         className="h-12"
-        render={() => <h1 className="font-bold text-4xl">{plugin.name}</h1>}
+        render={() => (
+          <h1 className="font-bold text-4xl">
+            {plugin?.name ?? 'Plugin name'}
+          </h1>
+        )}
       />
 
       <SkeletonLoader
         className="h-6 my-6"
         render={() => (
-          <h2 className="font-semibold my-6 text-lg">{plugin.summary}</h2>
+          <h2 className="font-semibold my-6 text-lg">
+            {plugin?.summary ?? 'Brief description'}
+          </h2>
         )}
       />
 
@@ -112,8 +118,8 @@ function PluginCenterColumn() {
       <SkeletonLoader
         className="h-[600px] mb-10"
         render={() => (
-          <Markdown className="mb-10" disableHeader>
-            {plugin.description}
+          <Markdown className={clsx('mb-10')} disableHeader>
+            {plugin?.description ?? ''}
           </Markdown>
         )}
       />
@@ -148,12 +154,14 @@ function PluginRightColumn() {
           render={() => (
             <Markdown.TOC
               className="mt-9"
-              markdown={plugin.description}
+              markdown={plugin?.description ?? ''}
               onClick={(section) => {
-                plausible('Description Nav', {
-                  section,
-                  plugin: plugin.name,
-                });
+                if (plugin?.name) {
+                  plausible('Description Nav', {
+                    section,
+                    plugin: plugin.name,
+                  });
+                }
               }}
               free
               extraHeaders={plugin.citations ? [CITATION_HEADER] : undefined}
@@ -203,7 +211,11 @@ export function PluginDetails() {
       title = `${title} by ${authors}`;
     }
 
-    keywords.push(plugin.name, ...plugin.authors.map(({ name }) => name));
+    for (const { name } of plugin.authors ?? []) {
+      if (name) {
+        keywords.push(plugin.name, name);
+      }
+    }
   }
 
   return (

--- a/frontend/src/components/PluginDetails/PluginDetails.tsx
+++ b/frontend/src/components/PluginDetails/PluginDetails.tsx
@@ -11,6 +11,7 @@ import { Media, MediaFragment } from '@/components/common/media';
 import { PageMetadata } from '@/components/common/PageMetadata';
 import { SkeletonLoader } from '@/components/common/SkeletonLoader';
 import { TOCHeader } from '@/components/common/TableOfContents';
+import { MetadataStatus } from '@/components/MetadataStatus';
 import { useLoadingState } from '@/context/loading';
 import { usePluginState } from '@/context/plugin';
 import { useIsPreview, usePlausible } from '@/hooks';
@@ -58,34 +59,52 @@ function PluginCenterColumn() {
       <SkeletonLoader
         className="h-12"
         render={() => (
-          <h1
+          <div
             className={clsx(
-              'font-bold text-4xl',
-              !plugin?.name && [
-                'text-napari-dark-gray',
-                isPreview && 'bg-napari-preview-orange-overlay',
-              ],
+              'flex justify-between',
+              !plugin?.name && isPreview && 'bg-napari-preview-orange-overlay',
             )}
           >
-            {plugin?.name ?? 'Plugin name'}
-          </h1>
+            <h1
+              className={clsx(
+                'font-bold text-4xl',
+                !plugin?.name && 'text-napari-dark-gray',
+              )}
+            >
+              {plugin?.name ?? 'Plugin name'}
+            </h1>
+
+            {isPreview && !plugin?.name && (
+              <MetadataStatus className="self-end" hasValue={false} />
+            )}
+          </div>
         )}
       />
 
       <SkeletonLoader
         className="h-6 my-6"
         render={() => (
-          <h2
+          <div
             className={clsx(
-              'font-semibold my-6 text-lg',
-              !plugin?.summary && [
-                '!text-napari-dark-gray',
-                isPreview && 'bg-napari-preview-orange-overlay',
-              ],
+              'flex justify-between items-center mt-6',
+              !plugin?.summary &&
+                isPreview &&
+                'bg-napari-preview-orange-overlay',
             )}
           >
-            {plugin?.summary ?? 'Brief description'}
-          </h2>
+            <h2
+              className={clsx(
+                'font-semibold text-lg',
+                !plugin?.summary && 'text-napari-dark-gray',
+              )}
+            >
+              {plugin?.summary ?? 'Brief description'}
+            </h2>
+
+            {isPreview && !plugin?.summary && (
+              <MetadataStatus hasValue={false} />
+            )}
+          </div>
         )}
       />
 
@@ -143,24 +162,28 @@ function PluginCenterColumn() {
       <SkeletonLoader
         className="h-[600px] mb-10"
         render={() => (
-          <Markdown
+          <div
             className={clsx(
-              'mb-10',
+              'flex items-center justify-between mb-10',
               isPreview &&
                 isEmptyDescription &&
                 'bg-napari-preview-orange-overlay',
             )}
-            disableHeader
-            placeholder={isEmptyDescription}
           >
-            {plugin?.description ?? EMPTY_DESCRIPTION_PLACEHOLDER}
-          </Markdown>
+            <Markdown disableHeader placeholder={isEmptyDescription}>
+              {plugin?.description ?? EMPTY_DESCRIPTION_PLACEHOLDER}
+            </Markdown>
+
+            {isPreview && isEmptyDescription && (
+              <MetadataStatus hasValue={false} />
+            )}
+          </div>
         )}
       />
 
       <div className="mb-6 screen-495:mb-12 screen-1150:mb-20">
         <CallToActionButton />
-        {plugin.citations && <CitationInfo className="mt-10" />}
+        {plugin?.citations && <CitationInfo className="mt-10" />}
       </div>
 
       <MediaFragment lessThan="3xl">
@@ -198,7 +221,7 @@ function PluginRightColumn() {
                 }
               }}
               free
-              extraHeaders={plugin.citations ? [CITATION_HEADER] : undefined}
+              extraHeaders={plugin?.citations ? [CITATION_HEADER] : undefined}
             />
           )}
         />

--- a/frontend/src/components/PluginDetails/PluginMetadata.tsx
+++ b/frontend/src/components/PluginDetails/PluginMetadata.tsx
@@ -110,25 +110,33 @@ function PluginMetadataBase({
           items={[
             {
               title: 'Version',
-              value: plugin.version,
+              value: plugin?.version ?? '',
             },
             {
               title: 'Release date',
-              value: formatDate(plugin.release_date),
+              value: plugin?.release_date
+                ? formatDate(plugin.release_date)
+                : '',
             },
             {
               title: 'First released',
-              value: formatDate(plugin.first_released),
+              value: plugin?.first_released
+                ? formatDate(plugin.first_released)
+                : '',
             },
             {
               title: 'Development status',
-              value: plugin.development_status.map((status) =>
-                status.replace('Development Status :: ', ''),
-              ),
+              value:
+                plugin?.development_status
+                  ?.map(
+                    (status) =>
+                      status?.replace('Development Status :: ', '') ?? '',
+                  )
+                  .filter((value): value is string => !!value) ?? [],
             },
             {
               title: 'License',
-              value: plugin.license,
+              value: plugin?.license ?? '',
             },
           ]}
         />
@@ -145,21 +153,26 @@ function PluginMetadataBase({
           items={[
             {
               title: 'Python versions supported',
-              value: plugin.python_version,
+              value: plugin?.python_version ?? '',
             },
             {
               title: 'Operating system',
-              value: plugin.operating_system.map((operatingSystem) =>
-                operatingSystem.replace('Operating System :: ', ''),
-              ),
+              value: plugin?.operating_system
+                ? plugin.operating_system
+                    .map((operatingSystem) =>
+                      operatingSystem?.replace('Operating System :: ', ''),
+                    )
+                    .filter((value): value is string => !!value)
+                : '',
             },
             {
               title: 'Requirements',
-              value: isArray(plugin.requirements)
-                ? plugin.requirements.filter(
-                    (req) => !req.includes('; extra == '),
-                  )
-                : '',
+              value:
+                plugin?.requirements && isArray(plugin.requirements)
+                  ? plugin.requirements.filter(
+                      (req): req is string => !req?.includes('; extra == '),
+                    )
+                  : '',
             },
           ]}
         />

--- a/frontend/src/components/PluginDetails/PluginMetadata.tsx
+++ b/frontend/src/components/PluginDetails/PluginMetadata.tsx
@@ -1,14 +1,17 @@
 import clsx from 'clsx';
-import { isArray } from 'lodash';
+import { isEmpty } from 'lodash';
 import { ReactNode } from 'react';
 
 import { Divider } from '@/components/common/Divider';
-import { MediaFragment } from '@/components/common/media';
+import { Media } from '@/components/common/media';
 import { SkeletonLoader } from '@/components/common/SkeletonLoader';
-import { usePluginState } from '@/context/plugin';
-import { formatDate } from '@/utils';
-
-import { MetadataList } from './MetadataList';
+import { MetadataList, MetadataListTextItem } from '@/components/MetadataList';
+import {
+  Metadata,
+  MetadataKeys,
+  usePluginMetadata,
+  usePluginState,
+} from '@/context/plugin';
 
 interface GithubMetadataItem {
   title: string;
@@ -41,31 +44,23 @@ function PluginGithubData() {
     `We're having trouble loading the GitHub stats: ${repoFetchError.status}`;
 
   return (
-    <div
-      className={clsx(
-        // Layout
-        'flex flex-col',
-
-        // Centering only for xl layout
-        'items-start xl:items-center 2xl:items-start',
-
-        // Font
-        'text-sm',
-      )}
+    <MetadataList
+      className="screen-875:justify-self-center screen-1150:justify-self-start"
+      title="GitHub activity"
+      compact
     >
-      <h4 className="font-bold">Github Activity</h4>
       {error ? (
-        <p className="text-napari-error mt-2">{error}</p>
+        <li>
+          <p className="text-napari-error mt-2">{error}</p>
+        </li>
       ) : (
-        <ul className="list-none">
-          {items.map((item) => (
-            <li className="my-2" key={item.title}>
-              {item.title}: <span className="font-bold">{item.count}</span>
-            </li>
-          ))}
-        </ul>
+        items.map((item) => (
+          <MetadataListTextItem key={item.title}>
+            {item.title}: <span className="font-bold">{item.count}</span>
+          </MetadataListTextItem>
+        ))
       )}
-    </div>
+    </MetadataList>
   );
 }
 
@@ -77,69 +72,66 @@ interface CommonProps {
 }
 
 interface PluginMetadataBaseProps extends CommonProps {
-  /**
-   * Divider to render between metadata lists.
-   */
-  divider?: ReactNode;
-
-  /**
-   * Render metadata lists inline.
-   */
+  divider: ReactNode;
   inline?: boolean;
 }
 
 /**
- * Component for rendering plugin metadata sidebar in the plugin details page.
- *
- * TODO Replace with actual plugin data.
+ * Utility type for picking keys that have a value that is a specific type. For
+ * example, `PickMetadataKeys<string>` will return `'name' | 'summary' | ...`
+ * because those metadata keys have strings as their value, while
+ * `PickMetadataKeys<string[]>` will return `'operatingSystems' | 'requirements' | ...`,
+ * because those metadata keys have string arrays as their values.
  */
+type PickMetadataKeys<T> = {
+  [Key in MetadataKeys]: Metadata[Key]['value'] extends T ? Key : never;
+}[MetadataKeys];
 
+/**
+ * Component for rendering plugin metadata responsively.  This handles
+ * rendering the divider for vertical layouts and rendering headers / values
+ * inline for smaller screens.
+ */
 function PluginMetadataBase({
   className,
   divider,
   inline,
 }: PluginMetadataBaseProps) {
-  const { plugin } = usePluginState();
+  const metadata = usePluginMetadata();
+
+  function renderSingleItemList(key: PickMetadataKeys<string>) {
+    const { name, value } = metadata[key];
+
+    return (
+      <MetadataList inline={inline} title={name} empty={!value}>
+        <MetadataListTextItem>{value}</MetadataListTextItem>
+      </MetadataList>
+    );
+  }
+
+  function renderItemList(key: PickMetadataKeys<string[]>) {
+    const { name, value: values } = metadata[key];
+
+    return (
+      <MetadataList inline={inline} title={name} empty={isEmpty(values)}>
+        {values.map((value) => (
+          <MetadataListTextItem key={value}>{value}</MetadataListTextItem>
+        ))}
+      </MetadataList>
+    );
+  }
 
   const projectMetadata = (
     <SkeletonLoader
       className="h-56"
       render={() => (
-        <MetadataList
-          inline={inline}
-          items={[
-            {
-              title: 'Version',
-              value: plugin?.version ?? '',
-            },
-            {
-              title: 'Release date',
-              value: plugin?.release_date
-                ? formatDate(plugin.release_date)
-                : '',
-            },
-            {
-              title: 'First released',
-              value: plugin?.first_released
-                ? formatDate(plugin.first_released)
-                : '',
-            },
-            {
-              title: 'Development status',
-              value:
-                plugin?.development_status
-                  ?.map(
-                    (status) =>
-                      status?.replace('Development Status :: ', '') ?? '',
-                  )
-                  .filter((value): value is string => !!value) ?? [],
-            },
-            {
-              title: 'License',
-              value: plugin?.license ?? '',
-            },
-          ]}
-        />
+        <>
+          {renderSingleItemList('version')}
+          {renderSingleItemList('releaseDate')}
+          {renderSingleItemList('firstReleased')}
+          {renderItemList('developmentStatus')}
+          {renderSingleItemList('license')}
+        </>
       )}
     />
   );
@@ -148,34 +140,11 @@ function PluginMetadataBase({
     <SkeletonLoader
       className="h-56"
       render={() => (
-        <MetadataList
-          inline={inline}
-          items={[
-            {
-              title: 'Python versions supported',
-              value: plugin?.python_version ?? '',
-            },
-            {
-              title: 'Operating system',
-              value: plugin?.operating_system
-                ? plugin.operating_system
-                    .map((operatingSystem) =>
-                      operatingSystem?.replace('Operating System :: ', ''),
-                    )
-                    .filter((value): value is string => !!value)
-                : '',
-            },
-            {
-              title: 'Requirements',
-              value:
-                plugin?.requirements && isArray(plugin.requirements)
-                  ? plugin.requirements.filter(
-                      (req): req is string => !req?.includes('; extra == '),
-                    )
-                  : '',
-            },
-          ]}
-        />
+        <>
+          {renderSingleItemList('pythonVersion')}
+          {renderItemList('operatingSystems')}
+          {renderItemList('requirements')}
+        </>
       )}
     />
   );
@@ -188,17 +157,19 @@ function PluginMetadataBase({
         className,
 
         // Vertical 1-column grid layout for < xl
-        'grid',
+        'grid space-y-6',
 
         // Horizontal layout with 3-column grid for xl+
-        'xl:grid-cols-3',
+        'screen-875:grid-cols-3 screen-875:space-y-0',
 
         // Back to 1-column vertical layout for 3xl+
-        '3xl:grid-cols-1',
+        'screen-1425:grid-cols-1 screen-1425:space-y-6',
       )}
     >
-      {projectMetadata}
+      <div className="space-y-6">{projectMetadata}</div>
+
       {divider}
+
       <SkeletonLoader
         className={clsx(
           'h-40',
@@ -207,8 +178,10 @@ function PluginMetadataBase({
         )}
         render={() => <PluginGithubData />}
       />
+
       {divider}
-      {requirementMetadata}
+
+      <div className="space-y-6">{requirementMetadata}</div>
     </div>
   );
 }
@@ -222,20 +195,20 @@ export function PluginMetadata(props: CommonProps) {
   let divider = <Divider className="my-6" />;
   divider = (
     <>
-      <MediaFragment greaterThanOrEqual="3xl">{divider}</MediaFragment>
-      <MediaFragment lessThan="xl">{divider}</MediaFragment>
+      <Media greaterThanOrEqual="screen-1425">{divider}</Media>
+      <Media lessThan="screen-875">{divider}</Media>
     </>
   );
 
   return (
     <>
-      <MediaFragment lessThan="3xl">
+      <Media lessThan="screen-1425">
         <PluginMetadataBase {...props} divider={divider} inline />
-      </MediaFragment>
+      </Media>
 
-      <MediaFragment greaterThanOrEqual="3xl">
+      <Media greaterThanOrEqual="screen-1425">
         <PluginMetadataBase {...props} divider={divider} />
-      </MediaFragment>
+      </Media>
     </>
   );
 }

--- a/frontend/src/components/PluginDetails/SupportInfo.module.scss
+++ b/frontend/src/components/PluginDetails/SupportInfo.module.scss
@@ -14,6 +14,12 @@
   }
 }
 
+.missingGithub {
+  path {
+    @apply stroke-current text-napari-gray;
+  }
+}
+
 .missingDocumentation {
   path {
     @apply stroke-current text-napari-gray;

--- a/frontend/src/components/PluginDetails/SupportInfo.module.scss.d.ts
+++ b/frontend/src/components/PluginDetails/SupportInfo.module.scss.d.ts
@@ -1,5 +1,6 @@
 export type Styles = {
   missingDocumentation: string;
+  missingGithub: string;
   missingProjectIssues: string;
   missingProjectSupport: string;
 };

--- a/frontend/src/components/PluginDetails/SupportInfo.tsx
+++ b/frontend/src/components/PluginDetails/SupportInfo.tsx
@@ -125,7 +125,12 @@ export function SupportInfoBase({ className, inline }: SupportInfoBaseProps) {
     <div
       className={clsx(
         className,
-        'text-black bg-gray-100 p-5 overflow-x-auto',
+        'text-black bg-gray-100 p-5',
+
+        // Overflow on x-axis in case of really long twitter names.
+        'overflow-x-auto',
+
+        // Grid layout.
         'grid',
         inline ? 'grid-cols-1 gap-4' : 'grid-cols-3',
       )}

--- a/frontend/src/components/PluginDetails/SupportInfo.tsx
+++ b/frontend/src/components/PluginDetails/SupportInfo.tsx
@@ -84,13 +84,6 @@ export function SupportInfoBase({ className, inline }: SupportInfoBaseProps) {
   }
 
   learnMoreItems.push(
-    // plugin.citations
-    //   ? {
-    //       href: `${plugin.name}#${ANCHOR}`,
-    //       icon: <Quotes />,
-    //       text: 'Citation information',
-    //     }
-    //   : [],
     {
       ...getLink('documentationSite'),
       icon: <ProjectDocumentation />,

--- a/frontend/src/components/PluginDetails/SupportInfo.tsx
+++ b/frontend/src/components/PluginDetails/SupportInfo.tsx
@@ -66,13 +66,16 @@ export function SupportInfoBase({
   const items: MetadataItem[] = [
     {
       title: 'Authors',
-      value: plugin.authors.map((author) => author.name),
+      value:
+        plugin?.authors
+          ?.map((author) => author.name)
+          .filter((name): name is string => !!name) ?? [],
     },
 
     {
       title: 'Learn more',
       value: ([] as MetadataItemLink[]).concat(
-        plugin.project_site
+        plugin?.project_site
           ? {
               href: plugin.project_site,
               icon: <ProjectSite />,
@@ -81,7 +84,7 @@ export function SupportInfoBase({
           : [],
 
         {
-          href: plugin.documentation,
+          href: plugin?.documentation ?? '',
           icon: <ProjectDocumentation />,
           missingIcon: (
             <ProjectDocumentation className={styles.missingDocumentation} />
@@ -89,7 +92,7 @@ export function SupportInfoBase({
           text: 'Documentation',
         },
         {
-          href: plugin.support,
+          href: plugin?.support ?? '',
           icon: <ProjectSupport />,
           missingIcon: (
             <ProjectSupport className={styles.missingProjectSupport} />
@@ -97,7 +100,7 @@ export function SupportInfoBase({
           text: 'Support',
         },
         {
-          href: plugin.report_issues,
+          href: plugin?.report_issues ?? '',
           icon: <ProjectIssues />,
           missingIcon: (
             <ProjectIssues className={styles.missingProjectIssues} />
@@ -105,7 +108,7 @@ export function SupportInfoBase({
           text: 'Report issues',
         },
 
-        plugin.twitter
+        plugin?.twitter
           ? {
               href: plugin.twitter,
               icon: <Twitter />,
@@ -125,11 +128,14 @@ export function SupportInfoBase({
 
     {
       title: 'Source code',
-      value: plugin.code_repository && {
-        href: plugin.code_repository,
-        icon: <GitHub />,
-        text: plugin.name,
-      },
+      value:
+        plugin?.code_repository && plugin.name
+          ? {
+              href: plugin.code_repository,
+              icon: <GitHub />,
+              text: plugin.name,
+            }
+          : '',
     },
   ];
 

--- a/frontend/src/components/PluginDetails/SupportInfo.tsx
+++ b/frontend/src/components/PluginDetails/SupportInfo.tsx
@@ -1,4 +1,6 @@
 import clsx from 'clsx';
+import { isEmpty } from 'lodash';
+import { ReactNode } from 'react';
 
 import {
   GitHub,
@@ -10,11 +12,14 @@ import {
   Twitter,
 } from '@/components/common/icons';
 import { Media } from '@/components/common/media';
-import { usePluginState } from '@/context/plugin';
+import {
+  MetadataList,
+  MetadataListLinkItem,
+  MetadataListTextItem,
+} from '@/components/MetadataList';
+import { MetadataKeys, usePluginMetadata } from '@/context/plugin';
 
 import { ANCHOR } from './CitationInfo.constants';
-import { MetadataList } from './MetadataList';
-import { MetadataItem, MetadataItemLink } from './PluginDetails.types';
 import styles from './SupportInfo.module.scss';
 
 /**
@@ -44,108 +49,128 @@ interface CommonProps {
   className?: string;
 }
 
-interface SupportInfoBaseProps extends CommonProps {
-  /**
-   * Render the support info metadata list horizontally.
-   */
-  horizontal?: boolean;
+interface MetadataLinkItem {
+  text: string;
+  href: string;
+  icon?: ReactNode;
+  missingIcon?: ReactNode;
+}
 
+interface SupportInfoBaseProps extends CommonProps {
   /**
    * Render the support info metadata list items inline.
    */
   inline?: boolean;
 }
 
-export function SupportInfoBase({
-  className,
-  horizontal,
-  inline,
-}: SupportInfoBaseProps) {
-  const { plugin } = usePluginState();
+export function SupportInfoBase({ className, inline }: SupportInfoBaseProps) {
+  const metadata = usePluginMetadata();
+  const learnMoreItems: MetadataLinkItem[] = [];
 
-  const items: MetadataItem[] = [
+  function getLink(key: MetadataKeys) {
+    const data = metadata[key];
+
+    return {
+      text: data.name,
+      href: data.value as string,
+    };
+  }
+
+  if (metadata.projectSite.value) {
+    learnMoreItems.push({
+      ...getLink('projectSite'),
+      icon: <ProjectSite />,
+    });
+  }
+
+  learnMoreItems.push(
+    // plugin.citations
+    //   ? {
+    //       href: `${plugin.name}#${ANCHOR}`,
+    //       icon: <Quotes />,
+    //       text: 'Citation information',
+    //     }
+    //   : [],
     {
-      title: 'Authors',
-      value:
-        plugin?.authors
-          ?.map((author) => author.name)
-          .filter((name): name is string => !!name) ?? [],
-    },
-
-    {
-      title: 'Learn more',
-      value: ([] as MetadataItemLink[]).concat(
-        plugin?.project_site
-          ? {
-              href: plugin.project_site,
-              icon: <ProjectSite />,
-              text: 'Project site',
-            }
-          : [],
-
-        {
-          href: plugin?.documentation ?? '',
-          icon: <ProjectDocumentation />,
-          missingIcon: (
-            <ProjectDocumentation className={styles.missingDocumentation} />
-          ),
-          text: 'Documentation',
-        },
-        {
-          href: plugin?.support ?? '',
-          icon: <ProjectSupport />,
-          missingIcon: (
-            <ProjectSupport className={styles.missingProjectSupport} />
-          ),
-          text: 'Support',
-        },
-        {
-          href: plugin?.report_issues ?? '',
-          icon: <ProjectIssues />,
-          missingIcon: (
-            <ProjectIssues className={styles.missingProjectIssues} />
-          ),
-          text: 'Report issues',
-        },
-
-        plugin?.twitter
-          ? {
-              href: plugin.twitter,
-              icon: <Twitter />,
-              text: formatTwitter(plugin.twitter),
-            }
-          : [],
-
-        plugin.citations
-          ? {
-              href: `${plugin.name}#${ANCHOR}`,
-              icon: <Quotes />,
-              text: 'Citation information',
-            }
-          : [],
+      ...getLink('documentationSite'),
+      icon: <ProjectDocumentation />,
+      missingIcon: (
+        <ProjectDocumentation className={styles.missingDocumentation} />
       ),
     },
-
     {
-      title: 'Source code',
-      value:
-        plugin?.code_repository && plugin.name
-          ? {
-              href: plugin.code_repository,
-              icon: <GitHub />,
-              text: plugin.name,
-            }
-          : '',
+      ...getLink('supportSite'),
+      icon: <ProjectSupport />,
+      missingIcon: <ProjectSupport className={styles.missingProjectSupport} />,
     },
-  ];
+    {
+      ...getLink('reportIssues'),
+      icon: <ProjectIssues />,
+      missingIcon: <ProjectIssues className={styles.missingProjectIssues} />,
+    },
+  );
+
+  if (metadata.twitter.value) {
+    const { href } = getLink('twitter');
+
+    learnMoreItems.push({
+      href,
+      text: formatTwitter(href),
+      icon: <Twitter />,
+    });
+  }
+
+  if (metadata.citations.value) {
+    learnMoreItems.push({
+      href: `${metadata.name.value}#${ANCHOR}`,
+      text: metadata.citations.name,
+      icon: <Quotes />,
+    });
+  }
 
   return (
-    <MetadataList
-      className={clsx('text-black bg-napari-hover-gray p-5', className)}
-      horizontal={horizontal}
-      inline={inline}
-      items={items}
-    />
+    <div
+      className={clsx(
+        className,
+        'text-black bg-gray-100 p-5 overflow-x-auto',
+        'grid',
+        inline ? 'grid-cols-1 gap-4' : 'grid-cols-3',
+      )}
+    >
+      <MetadataList
+        title={metadata.authors.name}
+        empty={isEmpty(metadata.authors.value)}
+        inline={inline}
+      >
+        {metadata.authors.value.map((author) => (
+          <MetadataListTextItem key={author}>{author}</MetadataListTextItem>
+        ))}
+      </MetadataList>
+
+      <MetadataList title="Learn more" inline={inline}>
+        {learnMoreItems.map(({ text, ...linkProps }) => (
+          <MetadataListLinkItem key={linkProps.href} {...linkProps}>
+            {text}
+          </MetadataListLinkItem>
+        ))}
+      </MetadataList>
+
+      <MetadataList
+        title={metadata.sourceCode.name}
+        empty={!metadata.sourceCode.value}
+        inline={inline}
+      >
+        {metadata.sourceCode.value && (
+          <MetadataListLinkItem
+            href={metadata.sourceCode.value}
+            icon={<GitHub />}
+            missingIcon={<GitHub className={styles.missingGithub} />}
+          >
+            {metadata.name.value}
+          </MetadataListLinkItem>
+        )}
+      </MetadataList>
+    </div>
   );
 }
 
@@ -158,7 +183,7 @@ export function SupportInfo(props: CommonProps) {
   return (
     <>
       <Media greaterThanOrEqual="xl">
-        <SupportInfoBase {...props} horizontal />
+        <SupportInfoBase {...props} />
       </Media>
 
       <Media lessThan="xl">

--- a/frontend/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
+++ b/frontend/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
@@ -9,236 +9,294 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
     class="fresnel-container fresnel-greaterThanOrEqual-3xl "
   >
     <div
-      class="fresnel-greaterThanOrEqual-3xl grid xl:grid-cols-3 3xl:grid-cols-1"
-      id="pluginMetadata"
+      class="fresnel-container fresnel-lessThan-screen-1425 "
+    />
+    <div
+      class="fresnel-container fresnel-greaterThanOrEqual-screen-1425 "
     >
-      <ul
-        class="list-none"
-      >
-        <li
-          class="mb-4 text-sm"
-        >
-          <h4
-            class="block mb-2 font-bold whitespace-nowrap"
-          >
-            Version
-            :
-          </h4>
-          <ul
-            class="list-none space-y-5 block"
-          >
-            <li
-              class="leading-normal"
-            >
-              0.0.2
-            </li>
-          </ul>
-        </li>
-        <li
-          class="mb-4 text-sm"
-        >
-          <h4
-            class="block mb-2 font-bold whitespace-nowrap"
-          >
-            Release date
-            :
-          </h4>
-          <ul
-            class="list-none space-y-5 block"
-          >
-            <li
-              class="leading-normal"
-            >
-              03 March 2021
-            </li>
-          </ul>
-        </li>
-        <li
-          class="mb-4 text-sm"
-        >
-          <h4
-            class="block mb-2 font-bold whitespace-nowrap"
-          >
-            First released
-            :
-          </h4>
-          <ul
-            class="list-none space-y-5 block"
-          >
-            <li
-              class="leading-normal"
-            >
-              22 February 2021
-            </li>
-          </ul>
-        </li>
-        <li
-          class="mb-4 text-sm"
-        >
-          <h4
-            class="block mb-2 font-bold whitespace-nowrap"
-          >
-            Development status
-            :
-          </h4>
-          <ul
-            class="list-none space-y-5 block"
-          >
-            <li
-              class="leading-normal"
-            >
-              4 - Beta
-            </li>
-          </ul>
-        </li>
-        <li
-          class="mb-4 text-sm"
-        >
-          <h4
-            class="block mb-2 font-bold whitespace-nowrap"
-          >
-            License
-            :
-          </h4>
-          <ul
-            class="list-none space-y-5 block"
-          >
-            <li
-              class="leading-normal"
-            >
-              MIT
-            </li>
-          </ul>
-        </li>
-      </ul>
       <div
-        class="fresnel-greaterThanOrEqual-3xl my-6 h-px bg-black border-none"
-      />
-      <div
-        class="flex flex-col items-start xl:items-center 2xl:items-start text-sm"
+        class="grid space-y-6 screen-875:grid-cols-3 screen-875:space-y-0 screen-1425:grid-cols-1 screen-1425:space-y-6"
+        id="pluginMetadata"
       >
-        <h4
-          class="font-bold"
+        <div
+          class="space-y-6"
         >
-          Github Activity
-        </h4>
-        <ul
-          class="list-none"
+          <div
+            class="text-sm"
+          >
+            <div
+              class="space-y-2"
+            >
+              <h4
+                class="font-bold whitespace-nowrap"
+              >
+                Version
+                :
+              </h4>
+              <ul
+                class="list-none text-sm leading-normal space-y-5"
+              >
+                <li
+                  class="textItem"
+                >
+                  0.0.2
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div
+            class="text-sm"
+          >
+            <div
+              class="space-y-2"
+            >
+              <h4
+                class="font-bold whitespace-nowrap"
+              >
+                Release date
+                :
+              </h4>
+              <ul
+                class="list-none text-sm leading-normal space-y-5"
+              >
+                <li
+                  class="textItem"
+                >
+                  03 March 2021
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div
+            class="text-sm"
+          >
+            <div
+              class="space-y-2"
+            >
+              <h4
+                class="font-bold whitespace-nowrap"
+              >
+                First released
+                :
+              </h4>
+              <ul
+                class="list-none text-sm leading-normal space-y-5"
+              >
+                <li
+                  class="textItem"
+                >
+                  22 February 2021
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div
+            class="text-sm"
+          >
+            <div
+              class="space-y-2"
+            >
+              <h4
+                class="font-bold whitespace-nowrap"
+              >
+                Development status
+                :
+              </h4>
+              <ul
+                class="list-none text-sm leading-normal space-y-5"
+              >
+                <li
+                  class="textItem"
+                >
+                  4 - Beta
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div
+            class="text-sm"
+          >
+            <div
+              class="space-y-2"
+            >
+              <h4
+                class="font-bold whitespace-nowrap"
+              >
+                License
+                :
+              </h4>
+              <ul
+                class="list-none text-sm leading-normal space-y-5"
+              >
+                <li
+                  class="textItem"
+                >
+                  MIT
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+        <div
+          class="fresnel-container fresnel-greaterThanOrEqual-screen-1425 "
         >
-          <li
-            class="my-2"
+          <div
+            class="my-6 h-px bg-black border-none"
+          />
+        </div>
+        <div
+          class="fresnel-container fresnel-lessThan-screen-875 "
+        />
+        <div
+          class="text-sm screen-875:justify-self-center screen-1150:justify-self-start"
+        >
+          <div
+            class="space-y-2"
           >
-            Stars
-            : 
-            <span
-              class="font-bold"
+            <h4
+              class="font-bold whitespace-nowrap"
             >
-              0
-            </span>
-          </li>
-          <li
-            class="my-2"
+              GitHub activity
+              :
+            </h4>
+            <ul
+              class="list-none text-sm leading-normal space-y-2"
+            >
+              <li
+                class="textItem"
+              >
+                Stars
+                : 
+                <span
+                  class="font-bold"
+                >
+                  0
+                </span>
+              </li>
+              <li
+                class="textItem"
+              >
+                Forks
+                : 
+                <span
+                  class="font-bold"
+                >
+                  0
+                </span>
+              </li>
+              <li
+                class="textItem"
+              >
+                Issues + PRs
+                : 
+                <span
+                  class="font-bold"
+                >
+                  0
+                </span>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div
+          class="fresnel-container fresnel-greaterThanOrEqual-screen-1425 "
+        >
+          <div
+            class="my-6 h-px bg-black border-none"
+          />
+        </div>
+        <div
+          class="fresnel-container fresnel-lessThan-screen-875 "
+        />
+        <div
+          class="space-y-6"
+        >
+          <div
+            class="text-sm"
           >
-            Forks
-            : 
-            <span
-              class="font-bold"
+            <div
+              class="space-y-2"
             >
-              0
-            </span>
-          </li>
-          <li
-            class="my-2"
+              <h4
+                class="font-bold whitespace-nowrap"
+              >
+                Python versions supported
+                :
+              </h4>
+              <ul
+                class="list-none text-sm leading-normal space-y-5"
+              >
+                <li
+                  class="textItem"
+                >
+                  &gt;=3.6
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div
+            class="text-sm"
           >
-            Issues + PRs
-            : 
-            <span
-              class="font-bold"
+            <div
+              class="space-y-2"
             >
-              0
-            </span>
-          </li>
-        </ul>
+              <h4
+                class="font-bold whitespace-nowrap"
+              >
+                Operating system
+                :
+              </h4>
+              <ul
+                class="list-none text-sm leading-normal space-y-5"
+              >
+                <li
+                  class="textItem"
+                >
+                  OS Independent
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div
+            class="text-sm"
+          >
+            <div
+              class="space-y-2"
+            >
+              <h4
+                class="font-bold whitespace-nowrap"
+              >
+                Requirements
+                :
+              </h4>
+              <ul
+                class="list-none text-sm leading-normal space-y-5"
+              >
+                <li
+                  class="textItem"
+                >
+                  napari-plugin-engine (&gt;=0.1.4)
+                </li>
+                <li
+                  class="textItem"
+                >
+                  numpy
+                </li>
+                <li
+                  class="textItem"
+                >
+                  zarr
+                </li>
+                <li
+                  class="textItem"
+                >
+                  dask[complete]
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
       </div>
-      <div
-        class="fresnel-greaterThanOrEqual-3xl my-6 h-px bg-black border-none"
-      />
-      <ul
-        class="list-none"
-      >
-        <li
-          class="mb-4 text-sm"
-        >
-          <h4
-            class="block mb-2 font-bold whitespace-nowrap"
-          >
-            Python versions supported
-            :
-          </h4>
-          <ul
-            class="list-none space-y-5 block"
-          >
-            <li
-              class="leading-normal"
-            >
-              &gt;=3.6
-            </li>
-          </ul>
-        </li>
-        <li
-          class="mb-4 text-sm"
-        >
-          <h4
-            class="block mb-2 font-bold whitespace-nowrap"
-          >
-            Operating system
-            :
-          </h4>
-          <ul
-            class="list-none space-y-5 block"
-          >
-            <li
-              class="leading-normal"
-            >
-              OS Independent
-            </li>
-          </ul>
-        </li>
-        <li
-          class="mb-4 text-sm"
-        >
-          <h4
-            class="block mb-2 font-bold whitespace-nowrap"
-          >
-            Requirements
-            :
-          </h4>
-          <ul
-            class="list-none space-y-5 block"
-          >
-            <li
-              class="leading-normal"
-            >
-              napari-plugin-engine (&gt;=0.1.4)
-            </li>
-            <li
-              class="leading-normal"
-            >
-              numpy
-            </li>
-            <li
-              class="leading-normal"
-            >
-              zarr
-            </li>
-            <li
-              class="leading-normal"
-            >
-              dask[complete]
-            </li>
-          </ul>
-        </li>
-      </ul>
     </div>
   </div>
   <div
@@ -358,16 +416,24 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
   <article
     class="w-full col-span-2 row-start-1 screen-875:col-span-3 screen-1150:col-start-1 screen-1425:col-start-2"
   >
-    <h1
-      class="font-bold text-4xl"
+    <div
+      class="flex justify-between"
     >
-      napari-compressed-labels-io
-    </h1>
-    <h2
-      class="font-semibold my-6 text-lg"
+      <h1
+        class="font-bold text-4xl"
+      >
+        napari-compressed-labels-io
+      </h1>
+    </div>
+    <div
+      class="flex justify-between items-center mt-6"
     >
-      Plugin exploring different options for reading and writing compressed and portable labels layers in napari.
-    </h2>
+      <h2
+        class="font-semibold text-lg"
+      >
+        Plugin exploring different options for reading and writing compressed and portable labels layers in napari.
+      </h2>
+    </div>
     <div
       class="fresnel-container fresnel-lessThan-3xl flex flex-col lg:flex-row lg:items-center my-6 screen-495:mt-30 screen-600:mb-12"
     >
@@ -387,45 +453,49 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
     <div
       class="fresnel-container fresnel-greaterThanOrEqual-xl "
     >
-      <ul
-        class="text-black bg-napari-hover-gray p-5 mb-6 screen-495:mb-12 list-none grid grid-cols-3"
+      <div
+        class="mb-6 screen-495:mb-12 text-black bg-gray-100 p-5 overflow-x-auto grid grid-cols-3"
       >
-        <li
-          class="mb-4 text-sm"
+        <div
+          class="text-sm"
         >
-          <h4
-            class="block mb-2 font-bold whitespace-nowrap"
+          <div
+            class="space-y-2"
           >
-            Authors
-            :
-          </h4>
-          <ul
-            class="list-none space-y-5 block"
-          >
-            <li
-              class="leading-normal"
+            <h4
+              class="font-bold whitespace-nowrap"
             >
-              Draga Doncila
-            </li>
-          </ul>
-        </li>
-        <li
-          class="mb-4 text-sm"
+              Authors
+              :
+            </h4>
+            <ul
+              class="list-none text-sm leading-normal space-y-5"
+            >
+              <li
+                class="textItem"
+              >
+                Draga Doncila
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div
+          class="text-sm"
         >
-          <h4
-            class="block mb-2 font-bold whitespace-nowrap"
+          <div
+            class="space-y-2"
           >
-            Learn more
-            :
-          </h4>
-          <ul
-            class="list-none space-y-5 block"
-          >
-            <li
-              class="leading-normal"
+            <h4
+              class="font-bold whitespace-nowrap"
             >
-              <span
-                class="flex"
+              Learn more
+              :
+            </h4>
+            <ul
+              class="list-none text-sm leading-normal space-y-5"
+            >
+              <li
+                class="flex linkItem"
               >
                 <span
                   class="min-w-4"
@@ -457,20 +527,16 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
                   </svg>
                 </span>
                 <a
-                  class="ml-2 underline inline -mt-1"
+                  class="ml-2 -mt-1 flex-grow underline"
                   href="https://pypi.org/project/napari-compressed-labels-io"
                   rel="noreferrer"
                   target="_blank"
                 >
                   Project site
                 </a>
-              </span>
-            </li>
-            <li
-              class="leading-normal"
-            >
-              <span
-                class="flex"
+              </li>
+              <li
+                class="flex linkItem"
               >
                 <span
                   class="min-w-4"
@@ -498,20 +564,16 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
                   </svg>
                 </span>
                 <a
-                  class="ml-2 underline inline -mt-1"
+                  class="ml-2 -mt-1 flex-grow underline"
                   href="https://github.com/DragaDoncila/napari-compressed-labels-io"
                   rel="noreferrer"
                   target="_blank"
                 >
                   Documentation
                 </a>
-              </span>
-            </li>
-            <li
-              class="leading-normal"
-            >
-              <span
-                class="flex"
+              </li>
+              <li
+                class="flex linkItem"
               >
                 <span
                   class="min-w-4"
@@ -559,20 +621,16 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
                   </svg>
                 </span>
                 <a
-                  class="ml-2 underline inline -mt-1"
+                  class="ml-2 -mt-1 flex-grow underline"
                   href="https://github.com/DragaDoncila/napari-compressed-labels-io/issues"
                   rel="noreferrer"
                   target="_blank"
                 >
-                  Support
+                  Support site
                 </a>
-              </span>
-            </li>
-            <li
-              class="leading-normal"
-            >
-              <span
-                class="flex"
+              </li>
+              <li
+                class="flex linkItem"
               >
                 <span
                   class="min-w-4"
@@ -605,20 +663,16 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
                   </svg>
                 </span>
                 <a
-                  class="ml-2 underline inline -mt-1"
+                  class="ml-2 -mt-1 flex-grow underline"
                   href="https://github.com/DragaDoncila/napari-compressed-labels-io/issues"
                   rel="noreferrer"
                   target="_blank"
                 >
                   Report issues
                 </a>
-              </span>
-            </li>
-            <li
-              class="leading-normal"
-            >
-              <span
-                class="flex"
+              </li>
+              <li
+                class="flex linkItem"
               >
                 <span
                   class="min-w-4"
@@ -637,34 +691,34 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
                   </svg>
                 </span>
                 <a
-                  class="ml-2 underline inline -mt-1"
+                  class="ml-2 -mt-1 flex-grow underline"
                   href="https://twitter.com/DragaDoncila"
                   rel="noreferrer"
                   target="_blank"
                 >
                   @DragaDoncila
                 </a>
-              </span>
-            </li>
-          </ul>
-        </li>
-        <li
-          class="mb-4 text-sm"
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div
+          class="text-sm"
         >
-          <h4
-            class="block mb-2 font-bold whitespace-nowrap"
+          <div
+            class="space-y-2"
           >
-            Source code
-            :
-          </h4>
-          <ul
-            class="list-none space-y-5 block"
-          >
-            <li
-              class="leading-normal"
+            <h4
+              class="font-bold whitespace-nowrap"
             >
-              <span
-                class="flex"
+              Source code
+              :
+            </h4>
+            <ul
+              class="list-none text-sm leading-normal space-y-5"
+            >
+              <li
+                class="flex linkItem"
               >
                 <span
                   class="min-w-4"
@@ -683,61 +737,65 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
                   </svg>
                 </span>
                 <a
-                  class="ml-2 underline inline -mt-1"
+                  class="ml-2 -mt-1 flex-grow underline"
                   href="https://github.com/DragaDoncila/napari-compressed-labels-io"
                   rel="noreferrer"
                   target="_blank"
                 >
                   napari-compressed-labels-io
                 </a>
-              </span>
-            </li>
-          </ul>
-        </li>
-      </ul>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
     </div>
     <div
       class="fresnel-container fresnel-lessThan-xl "
     >
-      <ul
-        class="text-black bg-napari-hover-gray p-5 mb-6 screen-495:mb-12 list-none"
+      <div
+        class="mb-6 screen-495:mb-12 text-black bg-gray-100 p-5 overflow-x-auto grid grid-cols-1 gap-4"
       >
-        <li
-          class="mb-4 text-sm"
+        <div
+          class="text-sm"
         >
-          <h4
-            class="inline mr-2 font-bold whitespace-nowrap"
+          <div
+            class="space-x-2 space-y-2"
           >
-            Authors
-            :
-          </h4>
-          <ul
-            class="list-none space-y-5 inline"
-          >
-            <li
-              class="leading-normal inline commaList"
+            <h4
+              class="font-bold whitespace-nowrap inline"
             >
-              Draga Doncila
-            </li>
-          </ul>
-        </li>
-        <li
-          class="mb-4 text-sm"
+              Authors
+              :
+            </h4>
+            <ul
+              class="list-none text-sm leading-normal inline space-y-2 inlineList"
+            >
+              <li
+                class="textItem"
+              >
+                Draga Doncila
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div
+          class="text-sm"
         >
-          <h4
-            class="inline mr-2 font-bold whitespace-nowrap"
+          <div
+            class="space-x-2 space-y-2"
           >
-            Learn more
-            :
-          </h4>
-          <ul
-            class="list-none space-y-5 inline"
-          >
-            <li
-              class="leading-normal inline commaList"
+            <h4
+              class="font-bold whitespace-nowrap inline"
             >
-              <span
-                class="inline-flex"
+              Learn more
+              :
+            </h4>
+            <ul
+              class="list-none text-sm leading-normal inline space-y-2 inlineList"
+            >
+              <li
+                class="flex linkItem"
               >
                 <span
                   class="min-w-4"
@@ -769,20 +827,16 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
                   </svg>
                 </span>
                 <a
-                  class="ml-2 underline inline -mt-1"
+                  class="ml-2 -mt-1 flex-grow underline"
                   href="https://pypi.org/project/napari-compressed-labels-io"
                   rel="noreferrer"
                   target="_blank"
                 >
                   Project site
                 </a>
-              </span>
-            </li>
-            <li
-              class="leading-normal inline commaList"
-            >
-              <span
-                class="inline-flex"
+              </li>
+              <li
+                class="flex linkItem"
               >
                 <span
                   class="min-w-4"
@@ -810,20 +864,16 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
                   </svg>
                 </span>
                 <a
-                  class="ml-2 underline inline -mt-1"
+                  class="ml-2 -mt-1 flex-grow underline"
                   href="https://github.com/DragaDoncila/napari-compressed-labels-io"
                   rel="noreferrer"
                   target="_blank"
                 >
                   Documentation
                 </a>
-              </span>
-            </li>
-            <li
-              class="leading-normal inline commaList"
-            >
-              <span
-                class="inline-flex"
+              </li>
+              <li
+                class="flex linkItem"
               >
                 <span
                   class="min-w-4"
@@ -871,20 +921,16 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
                   </svg>
                 </span>
                 <a
-                  class="ml-2 underline inline -mt-1"
+                  class="ml-2 -mt-1 flex-grow underline"
                   href="https://github.com/DragaDoncila/napari-compressed-labels-io/issues"
                   rel="noreferrer"
                   target="_blank"
                 >
-                  Support
+                  Support site
                 </a>
-              </span>
-            </li>
-            <li
-              class="leading-normal inline commaList"
-            >
-              <span
-                class="inline-flex"
+              </li>
+              <li
+                class="flex linkItem"
               >
                 <span
                   class="min-w-4"
@@ -917,20 +963,16 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
                   </svg>
                 </span>
                 <a
-                  class="ml-2 underline inline -mt-1"
+                  class="ml-2 -mt-1 flex-grow underline"
                   href="https://github.com/DragaDoncila/napari-compressed-labels-io/issues"
                   rel="noreferrer"
                   target="_blank"
                 >
                   Report issues
                 </a>
-              </span>
-            </li>
-            <li
-              class="leading-normal inline commaList"
-            >
-              <span
-                class="inline-flex"
+              </li>
+              <li
+                class="flex linkItem"
               >
                 <span
                   class="min-w-4"
@@ -949,34 +991,34 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
                   </svg>
                 </span>
                 <a
-                  class="ml-2 underline inline -mt-1"
+                  class="ml-2 -mt-1 flex-grow underline"
                   href="https://twitter.com/DragaDoncila"
                   rel="noreferrer"
                   target="_blank"
                 >
                   @DragaDoncila
                 </a>
-              </span>
-            </li>
-          </ul>
-        </li>
-        <li
-          class="mb-4 text-sm"
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div
+          class="text-sm"
         >
-          <h4
-            class="inline mr-2 font-bold whitespace-nowrap"
+          <div
+            class="space-x-2 space-y-2"
           >
-            Source code
-            :
-          </h4>
-          <ul
-            class="list-none space-y-5 inline"
-          >
-            <li
-              class="leading-normal inline commaList"
+            <h4
+              class="font-bold whitespace-nowrap inline"
             >
-              <span
-                class="inline-flex"
+              Source code
+              :
+            </h4>
+            <ul
+              class="list-none text-sm leading-normal inline space-y-2 inlineList"
+            >
+              <li
+                class="flex linkItem"
               >
                 <span
                   class="min-w-4"
@@ -995,256 +1037,259 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
                   </svg>
                 </span>
                 <a
-                  class="ml-2 underline inline -mt-1"
+                  class="ml-2 -mt-1 flex-grow underline"
                   href="https://github.com/DragaDoncila/napari-compressed-labels-io"
                   rel="noreferrer"
                   target="_blank"
                 >
                   napari-compressed-labels-io
                 </a>
-              </span>
-            </li>
-          </ul>
-        </li>
-      </ul>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
     </div>
     <div
-      class="mb-10 markdown"
+      class="flex items-center justify-between mb-10"
     >
-      
-
-      <p>
-        <a
-          href="https://github.com/DragaDoncila/napari-compressed-labels-io/raw/master/LICENSE"
-          rel="noreferrer"
-          target="_blank"
-        >
-          <img
-            alt="License"
-            src="https://img.shields.io/pypi/l/napari-compressed-labels-io.svg?color=green"
-          />
-        </a>
+      <div
+        class="markdown"
+      >
         
 
-        <a
-          href="https://pypi.org/project/napari-compressed-labels-io"
-          rel="noreferrer"
-          target="_blank"
-        >
-          <img
-            alt="PyPI"
-            src="https://img.shields.io/pypi/v/napari-compressed-labels-io.svg?color=green"
-          />
-        </a>
+        <p>
+          <a
+            href="https://github.com/DragaDoncila/napari-compressed-labels-io/raw/master/LICENSE"
+            rel="noreferrer"
+            target="_blank"
+          >
+            <img
+              alt="License"
+              src="https://img.shields.io/pypi/l/napari-compressed-labels-io.svg?color=green"
+            />
+          </a>
+          
+
+          <a
+            href="https://pypi.org/project/napari-compressed-labels-io"
+            rel="noreferrer"
+            target="_blank"
+          >
+            <img
+              alt="PyPI"
+              src="https://img.shields.io/pypi/v/napari-compressed-labels-io.svg?color=green"
+            />
+          </a>
+          
+
+          <a
+            href="https://python.org"
+            rel="noreferrer"
+            target="_blank"
+          >
+            <img
+              alt="Python Version"
+              src="https://img.shields.io/pypi/pyversions/napari-compressed-labels-io.svg?color=green"
+            />
+          </a>
+          
+
+          <a
+            href="https://github.com/DragaDoncila/napari-compressed-labels-io/actions"
+            rel="noreferrer"
+            target="_blank"
+          >
+            <img
+              alt="tests"
+              src="https://github.com/DragaDoncila/napari-compressed-labels-io/workflows/tests/badge.svg"
+            />
+          </a>
+          
+
+          <a
+            href="https://codecov.io/gh/DragaDoncila/napari-compressed-labels-io"
+            rel="noreferrer"
+            target="_blank"
+          >
+            <img
+              alt="codecov"
+              src="https://codecov.io/gh/DragaDoncila/napari-compressed-labels-io/branch/master/graph/badge.svg"
+            />
+          </a>
+        </p>
         
 
-        <a
-          href="https://python.org"
-          rel="noreferrer"
-          target="_blank"
+        <h2
+          id="description"
         >
-          <img
-            alt="Python Version"
-            src="https://img.shields.io/pypi/pyversions/napari-compressed-labels-io.svg?color=green"
-          />
-        </a>
+          Description
+        </h2>
         
 
-        <a
-          href="https://github.com/DragaDoncila/napari-compressed-labels-io/actions"
-          rel="noreferrer"
-          target="_blank"
-        >
-          <img
-            alt="tests"
-            src="https://github.com/DragaDoncila/napari-compressed-labels-io/workflows/tests/badge.svg"
-          />
-        </a>
+        <p>
+          This napari plugin provides readers and writers for labels and their corresponding image layers into zarr format for compression and portability. Each reader/writer pair supports a round trip of saving and loading image and labels layers.
+        </p>
         
 
-        <a
-          href="https://codecov.io/gh/DragaDoncila/napari-compressed-labels-io"
-          rel="noreferrer"
-          target="_blank"
+        <h2
+          id="writers"
         >
-          <img
-            alt="codecov"
-            src="https://codecov.io/gh/DragaDoncila/napari-compressed-labels-io/branch/master/graph/badge.svg"
-          />
-        </a>
-      </p>
-      
+          Writers
+        </h2>
+        
 
-      <h2
-        id="description"
-      >
-        Description
-      </h2>
-      
+        <p>
+          Two writers are provided by this plugin, each with its own reader.
+        </p>
+        
 
-      <p>
-        This napari plugin provides readers and writers for labels and their corresponding image layers into zarr format for compression and portability. Each reader/writer pair supports a round trip of saving and loading image and labels layers.
-      </p>
-      
-
-      <h2
-        id="writers"
-      >
-        Writers
-      </h2>
-      
-
-      <p>
-        Two writers are provided by this plugin, each with its own reader.
-      </p>
-      
-
-      <h3
-        id="labels_to_zarr"
-      >
-        <code
-          node="[object Object]"
+        <h3
+          id="labels_to_zarr"
         >
-          labels_to_zarr
-        </code>
-      </h3>
-      
+          <code
+            node="[object Object]"
+          >
+            labels_to_zarr
+          </code>
+        </h3>
+        
 
-      <p>
-        This writer is an alternative to napari's default label writer and will write an entire labels layer, regardless of its dimensions, into a single zarr file. This writer provides the best compression option and its associated reader 
-        <code
-          node="[object Object]"
+        <p>
+          This writer is an alternative to napari's default label writer and will write an entire labels layer, regardless of its dimensions, into a single zarr file. This writer provides the best compression option and its associated reader 
+          <code
+            node="[object Object]"
+          >
+            get_zarr_labels
+          </code>
+           will read the layer back into napari.
+        </p>
+        
+
+        <p>
+          This writer will be called when the user tries to save a selected labels layer into a path ending with .zarr
+        </p>
+        
+
+        <h3
+          id="label_image_pairs_to_zarr"
         >
-          get_zarr_labels
-        </code>
-         will read the layer back into napari.
-      </p>
-      
+          <code
+            node="[object Object]"
+          >
+            label_image_pairs_to_zarr
+          </code>
+        </h3>
+        
 
-      <p>
-        This writer will be called when the user tries to save a selected labels layer into a path ending with .zarr
-      </p>
-      
+        <p>
+          This writer will save 3-dimensional labels and image layers from the viewer into individual zarrs for portability and convenience. For example, given one labels and one image layer of the shape (10, 200, 200) saved to my_stacks.zarr, 10 subdirectories will be created, each with two zarrs inside of shape (200, 200) corresponding to the labels and image layer.
+        </p>
+        
 
-      <h3
-        id="label_image_pairs_to_zarr"
-      >
-        <code
-          node="[object Object]"
+        <p>
+          This writer allows users to load stacks of associated images, label them, and then quickly save these stacks out into individual slices for easy loading, viewing and interaction. Its associated reader supports the loading into napari of the whole stack, all layers at one slice of the stack, and an individual layer of a given slice of the stack.
+        </p>
+        
+
+        <p>
+          The writer currently supports only 3D layers, with the exception of RGB images of the form (z, y, x, 3), which are also supported.
+        </p>
+        
+
+        <h2
+          id="readers"
         >
-          label_image_pairs_to_zarr
-        </code>
-      </h3>
-      
+          Readers
+        </h2>
+        
 
-      <p>
-        This writer will save 3-dimensional labels and image layers from the viewer into individual zarrs for portability and convenience. For example, given one labels and one image layer of the shape (10, 200, 200) saved to my_stacks.zarr, 10 subdirectories will be created, each with two zarrs inside of shape (200, 200) corresponding to the labels and image layer.
-      </p>
-      
+        <p>
+          Two readers are provided by this plugin for loading the formats saved by each writer. These are detailed below.
+        </p>
+        
 
-      <p>
-        This writer allows users to load stacks of associated images, label them, and then quickly save these stacks out into individual slices for easy loading, viewing and interaction. Its associated reader supports the loading into napari of the whole stack, all layers at one slice of the stack, and an individual layer of a given slice of the stack.
-      </p>
-      
-
-      <p>
-        The writer currently supports only 3D layers, with the exception of RGB images of the form (z, y, x, 3), which are also supported.
-      </p>
-      
-
-      <h2
-        id="readers"
-      >
-        Readers
-      </h2>
-      
-
-      <p>
-        Two readers are provided by this plugin for loading the formats saved by each writer. These are detailed below.
-      </p>
-      
-
-      <h3
-        id="get_zarr_labels"
-      >
-        <code
-          node="[object Object]"
+        <h3
+          id="get_zarr_labels"
         >
-          get_zarr_labels
-        </code>
-      </h3>
-      
+          <code
+            node="[object Object]"
+          >
+            get_zarr_labels
+          </code>
+        </h3>
+        
 
-      <p>
-        This reader will open any zarr file with a .zarray at the top level in 
-        <code
-          node="[object Object]"
-        >
-          path
-        </code>
-         as a labels layer. This is to be used in conjunction with 
-        <code
-          node="[object Object]"
-        >
-          labels_to_zarr
-        </code>
-        .
-      </p>
-      
+        <p>
+          This reader will open any zarr file with a .zarray at the top level in 
+          <code
+            node="[object Object]"
+          >
+            path
+          </code>
+           as a labels layer. This is to be used in conjunction with 
+          <code
+            node="[object Object]"
+          >
+            labels_to_zarr
+          </code>
+          .
+        </p>
+        
 
-      <h3
-        id="get_label_image_stack"
-      >
-        <code
-          node="[object Object]"
+        <h3
+          id="get_label_image_stack"
         >
-          get_label_image_stack
-        </code>
-      </h3>
-      
+          <code
+            node="[object Object]"
+          >
+            get_label_image_stack
+          </code>
+        </h3>
+        
 
-      <p>
-        This reader will open any zarr containing a 
-        <code
-          node="[object Object]"
+        <p>
+          This reader will open any zarr containing a 
+          <code
+            node="[object Object]"
+          >
+            .zmeta
+          </code>
+           file as layers into napari. Depending on what is being opened, the reader will either load a full stack of labels and images, one slice of a stack of images and labels or an individual layer within a slice. This is to be used in conjunction with 
+          <code
+            node="[object Object]"
+          >
+            label_image_pairs_to_zarr
+          </code>
+          .
+        </p>
+        
+
+        <h2
+          id="zmeta"
         >
           .zmeta
-        </code>
-         file as layers into napari. Depending on what is being opened, the reader will either load a full stack of labels and images, one slice of a stack of images and labels or an individual layer within a slice. This is to be used in conjunction with 
-        <code
-          node="[object Object]"
+        </h2>
+        
+
+        <p>
+          This metadata file contains information about the layer types in the stack and in each individual slice, as well as the number of image/label slices. This allows the reader plugin to load the correct layer types with appropriate names both at a stack level and at the individual slice level.
+        </p>
+        
+
+        <h3
+          id="an-example-zmeta-specification"
         >
-          label_image_pairs_to_zarr
-        </code>
-        .
-      </p>
-      
+          An example .zmeta specification
+        </h3>
+        
 
-      <h2
-        id="zmeta"
-      >
-        .zmeta
-      </h2>
-      
-
-      <p>
-        This metadata file contains information about the layer types in the stack and in each individual slice, as well as the number of image/label slices. This allows the reader plugin to load the correct layer types with appropriate names both at a stack level and at the individual slice level.
-      </p>
-      
-
-      <h3
-        id="an-example-zmeta-specification"
-      >
-        An example .zmeta specification
-      </h3>
-      
-
-      <pre>
-        <code
-          language="json"
-          node="[object Object]"
-        >
-          {
+        <pre>
+          <code
+            language="json"
+            node="[object Object]"
+          >
+            {
     "meta": {
         "stack": 7                               # number of slices in the entire stack (1 for an individual slice, 0 for a layer within a slice)
     },
@@ -1272,146 +1317,147 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
     }
 }
 
-        </code>
-      </pre>
-      
+          </code>
+        </pre>
+        
 
-      <hr />
-      
+        <hr />
+        
 
-      <p>
-        This 
-        <a
-          href="https://github.com/napari/napari"
-          rel="noreferrer"
-          target="_blank"
-        >
-          napari
-        </a>
-         plugin was generated with 
-        <a
-          href="https://github.com/audreyr/cookiecutter"
-          rel="noreferrer"
-          target="_blank"
-        >
-          Cookiecutter
-        </a>
-         using with 
-        <a
-          href="https://github.com/napari"
-          rel="noreferrer"
-          target="_blank"
-        >
-          @napari
-        </a>
-        's 
-        <a
-          href="https://github.com/napari/cookiecutter-napari-plugin"
-          rel="noreferrer"
-          target="_blank"
-        >
-          cookiecutter-napari-plugin
-        </a>
-         template.
-      </p>
-      
+        <p>
+          This 
+          <a
+            href="https://github.com/napari/napari"
+            rel="noreferrer"
+            target="_blank"
+          >
+            napari
+          </a>
+           plugin was generated with 
+          <a
+            href="https://github.com/audreyr/cookiecutter"
+            rel="noreferrer"
+            target="_blank"
+          >
+            Cookiecutter
+          </a>
+           using with 
+          <a
+            href="https://github.com/napari"
+            rel="noreferrer"
+            target="_blank"
+          >
+            @napari
+          </a>
+          's 
+          <a
+            href="https://github.com/napari/cookiecutter-napari-plugin"
+            rel="noreferrer"
+            target="_blank"
+          >
+            cookiecutter-napari-plugin
+          </a>
+           template.
+        </p>
+        
 
-      <h2
-        id="installation"
-      >
-        Installation
-      </h2>
-      
-
-      <p>
-        You can install 
-        <code
-          node="[object Object]"
+        <h2
+          id="installation"
         >
-          napari-compressed-labels-io
-        </code>
-         via 
-        <a
-          href="https://pypi.org/project/pip/"
-          rel="noreferrer"
-          target="_blank"
-        >
-          pip
-        </a>
-        :
-      </p>
-      
+          Installation
+        </h2>
+        
 
-      <pre>
-        <code
-          language=""
-          node="[object Object]"
-        >
-          pip install napari-compressed-labels-io
-        </code>
-      </pre>
-      
+        <p>
+          You can install 
+          <code
+            node="[object Object]"
+          >
+            napari-compressed-labels-io
+          </code>
+           via 
+          <a
+            href="https://pypi.org/project/pip/"
+            rel="noreferrer"
+            target="_blank"
+          >
+            pip
+          </a>
+          :
+        </p>
+        
 
-      <h2
-        id="contributing"
-      >
-        Contributing
-      </h2>
-      
+        <pre>
+          <code
+            language=""
+            node="[object Object]"
+          >
+            pip install napari-compressed-labels-io
+          </code>
+        </pre>
+        
 
-      <p>
-        Contributions are very welcome. Tests can be run with 
-        <a
-          href="https://tox.readthedocs.io/en/latest/"
-          rel="noreferrer"
-          target="_blank"
+        <h2
+          id="contributing"
         >
-          tox
-        </a>
-        , please ensure
+          Contributing
+        </h2>
+        
+
+        <p>
+          Contributions are very welcome. Tests can be run with 
+          <a
+            href="https://tox.readthedocs.io/en/latest/"
+            rel="noreferrer"
+            target="_blank"
+          >
+            tox
+          </a>
+          , please ensure
 the coverage at least stays the same before you submit a pull request.
-      </p>
-      
+        </p>
+        
 
-      <h2
-        id="license"
-      >
-        License
-      </h2>
-      
-
-      <p>
-        Distributed under the terms of the 
-        <a
-          href="http://opensource.org/licenses/MIT"
-          rel="noreferrer"
-          target="_blank"
+        <h2
+          id="license"
         >
-          MIT
-        </a>
-         license,
+          License
+        </h2>
+        
+
+        <p>
+          Distributed under the terms of the 
+          <a
+            href="http://opensource.org/licenses/MIT"
+            rel="noreferrer"
+            target="_blank"
+          >
+            MIT
+          </a>
+           license,
 "napari-compressed-labels-io" is free and open source software
-      </p>
-      
+        </p>
+        
 
-      <h2
-        id="issues"
-      >
-        Issues
-      </h2>
-      
-
-      <p>
-        If you encounter any problems, please 
-        <a
-          href="https://github.com/DragaDoncila/napari-compressed-labels-io/issues"
-          rel="noreferrer"
-          target="_blank"
+        <h2
+          id="issues"
         >
-          file an issue
-        </a>
-         along with a detailed description.
-      </p>
+          Issues
+        </h2>
+        
+
+        <p>
+          If you encounter any problems, please 
+          <a
+            href="https://github.com/DragaDoncila/napari-compressed-labels-io/issues"
+            rel="noreferrer"
+            target="_blank"
+          >
+            file an issue
+          </a>
+           along with a detailed description.
+        </p>
+      </div>
     </div>
     <div
       class="mb-6 screen-495:mb-12 screen-1150:mb-20"
@@ -1424,236 +1470,578 @@ the coverage at least stays the same before you submit a pull request.
       </button>
     </div>
     <div
-      class="fresnel-lessThan-3xl fresnel-lessThan-3xl grid xl:grid-cols-3 3xl:grid-cols-1"
-      id="pluginMetadata"
+      class="fresnel-container fresnel-lessThan-screen-1425 "
     >
-      <ul
-        class="list-none"
-      >
-        <li
-          class="mb-4 text-sm"
-        >
-          <h4
-            class="inline mr-2 font-bold whitespace-nowrap"
-          >
-            Version
-            :
-          </h4>
-          <ul
-            class="list-none space-y-5 inline"
-          >
-            <li
-              class="leading-normal inline commaList"
-            >
-              0.0.2
-            </li>
-          </ul>
-        </li>
-        <li
-          class="mb-4 text-sm"
-        >
-          <h4
-            class="inline mr-2 font-bold whitespace-nowrap"
-          >
-            Release date
-            :
-          </h4>
-          <ul
-            class="list-none space-y-5 inline"
-          >
-            <li
-              class="leading-normal inline commaList"
-            >
-              03 March 2021
-            </li>
-          </ul>
-        </li>
-        <li
-          class="mb-4 text-sm"
-        >
-          <h4
-            class="inline mr-2 font-bold whitespace-nowrap"
-          >
-            First released
-            :
-          </h4>
-          <ul
-            class="list-none space-y-5 inline"
-          >
-            <li
-              class="leading-normal inline commaList"
-            >
-              22 February 2021
-            </li>
-          </ul>
-        </li>
-        <li
-          class="mb-4 text-sm"
-        >
-          <h4
-            class="inline mr-2 font-bold whitespace-nowrap"
-          >
-            Development status
-            :
-          </h4>
-          <ul
-            class="list-none space-y-5 inline"
-          >
-            <li
-              class="leading-normal inline commaList"
-            >
-              4 - Beta
-            </li>
-          </ul>
-        </li>
-        <li
-          class="mb-4 text-sm"
-        >
-          <h4
-            class="inline mr-2 font-bold whitespace-nowrap"
-          >
-            License
-            :
-          </h4>
-          <ul
-            class="list-none space-y-5 inline"
-          >
-            <li
-              class="leading-normal inline commaList"
-            >
-              MIT
-            </li>
-          </ul>
-        </li>
-      </ul>
       <div
-        class="fresnel-lessThan-xl my-6 h-px bg-black border-none"
-      />
-      <div
-        class="flex flex-col items-start xl:items-center 2xl:items-start text-sm"
+        class="fresnel-lessThan-3xl grid space-y-6 screen-875:grid-cols-3 screen-875:space-y-0 screen-1425:grid-cols-1 screen-1425:space-y-6"
+        id="pluginMetadata"
       >
-        <h4
-          class="font-bold"
+        <div
+          class="space-y-6"
         >
-          Github Activity
-        </h4>
-        <ul
-          class="list-none"
+          <div
+            class="text-sm"
+          >
+            <div
+              class="space-x-2 space-y-2"
+            >
+              <h4
+                class="font-bold whitespace-nowrap inline"
+              >
+                Version
+                :
+              </h4>
+              <ul
+                class="list-none text-sm leading-normal inline space-y-2 inlineList"
+              >
+                <li
+                  class="textItem"
+                >
+                  0.0.2
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div
+            class="text-sm"
+          >
+            <div
+              class="space-x-2 space-y-2"
+            >
+              <h4
+                class="font-bold whitespace-nowrap inline"
+              >
+                Release date
+                :
+              </h4>
+              <ul
+                class="list-none text-sm leading-normal inline space-y-2 inlineList"
+              >
+                <li
+                  class="textItem"
+                >
+                  03 March 2021
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div
+            class="text-sm"
+          >
+            <div
+              class="space-x-2 space-y-2"
+            >
+              <h4
+                class="font-bold whitespace-nowrap inline"
+              >
+                First released
+                :
+              </h4>
+              <ul
+                class="list-none text-sm leading-normal inline space-y-2 inlineList"
+              >
+                <li
+                  class="textItem"
+                >
+                  22 February 2021
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div
+            class="text-sm"
+          >
+            <div
+              class="space-x-2 space-y-2"
+            >
+              <h4
+                class="font-bold whitespace-nowrap inline"
+              >
+                Development status
+                :
+              </h4>
+              <ul
+                class="list-none text-sm leading-normal inline space-y-2 inlineList"
+              >
+                <li
+                  class="textItem"
+                >
+                  4 - Beta
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div
+            class="text-sm"
+          >
+            <div
+              class="space-x-2 space-y-2"
+            >
+              <h4
+                class="font-bold whitespace-nowrap inline"
+              >
+                License
+                :
+              </h4>
+              <ul
+                class="list-none text-sm leading-normal inline space-y-2 inlineList"
+              >
+                <li
+                  class="textItem"
+                >
+                  MIT
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+        <div
+          class="fresnel-container fresnel-greaterThanOrEqual-screen-1425 "
+        />
+        <div
+          class="fresnel-container fresnel-lessThan-screen-875 "
         >
-          <li
-            class="my-2"
+          <div
+            class="my-6 h-px bg-black border-none"
+          />
+        </div>
+        <div
+          class="text-sm screen-875:justify-self-center screen-1150:justify-self-start"
+        >
+          <div
+            class="space-y-2"
           >
-            Stars
-            : 
-            <span
-              class="font-bold"
+            <h4
+              class="font-bold whitespace-nowrap"
             >
-              0
-            </span>
-          </li>
-          <li
-            class="my-2"
+              GitHub activity
+              :
+            </h4>
+            <ul
+              class="list-none text-sm leading-normal space-y-2"
+            >
+              <li
+                class="textItem"
+              >
+                Stars
+                : 
+                <span
+                  class="font-bold"
+                >
+                  0
+                </span>
+              </li>
+              <li
+                class="textItem"
+              >
+                Forks
+                : 
+                <span
+                  class="font-bold"
+                >
+                  0
+                </span>
+              </li>
+              <li
+                class="textItem"
+              >
+                Issues + PRs
+                : 
+                <span
+                  class="font-bold"
+                >
+                  0
+                </span>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div
+          class="fresnel-container fresnel-greaterThanOrEqual-screen-1425 "
+        />
+        <div
+          class="fresnel-container fresnel-lessThan-screen-875 "
+        >
+          <div
+            class="my-6 h-px bg-black border-none"
+          />
+        </div>
+        <div
+          class="space-y-6"
+        >
+          <div
+            class="text-sm"
           >
-            Forks
-            : 
-            <span
-              class="font-bold"
+            <div
+              class="space-x-2 space-y-2"
             >
-              0
-            </span>
-          </li>
-          <li
-            class="my-2"
+              <h4
+                class="font-bold whitespace-nowrap inline"
+              >
+                Python versions supported
+                :
+              </h4>
+              <ul
+                class="list-none text-sm leading-normal inline space-y-2 inlineList"
+              >
+                <li
+                  class="textItem"
+                >
+                  &gt;=3.6
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div
+            class="text-sm"
           >
-            Issues + PRs
-            : 
-            <span
-              class="font-bold"
+            <div
+              class="space-x-2 space-y-2"
             >
-              0
-            </span>
-          </li>
-        </ul>
+              <h4
+                class="font-bold whitespace-nowrap inline"
+              >
+                Operating system
+                :
+              </h4>
+              <ul
+                class="list-none text-sm leading-normal inline space-y-2 inlineList"
+              >
+                <li
+                  class="textItem"
+                >
+                  OS Independent
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div
+            class="text-sm"
+          >
+            <div
+              class="space-x-2 space-y-2"
+            >
+              <h4
+                class="font-bold whitespace-nowrap inline"
+              >
+                Requirements
+                :
+              </h4>
+              <ul
+                class="list-none text-sm leading-normal inline space-y-2 inlineList"
+              >
+                <li
+                  class="textItem"
+                >
+                  napari-plugin-engine (&gt;=0.1.4)
+                </li>
+                <li
+                  class="textItem"
+                >
+                  numpy
+                </li>
+                <li
+                  class="textItem"
+                >
+                  zarr
+                </li>
+                <li
+                  class="textItem"
+                >
+                  dask[complete]
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
       </div>
+    </div>
+    <div
+      class="fresnel-container fresnel-greaterThanOrEqual-screen-1425 "
+    >
       <div
-        class="fresnel-lessThan-xl my-6 h-px bg-black border-none"
-      />
-      <ul
-        class="list-none"
+        class="fresnel-lessThan-3xl grid space-y-6 screen-875:grid-cols-3 screen-875:space-y-0 screen-1425:grid-cols-1 screen-1425:space-y-6"
+        id="pluginMetadata"
       >
-        <li
-          class="mb-4 text-sm"
+        <div
+          class="space-y-6"
         >
-          <h4
-            class="inline mr-2 font-bold whitespace-nowrap"
+          <div
+            class="text-sm"
           >
-            Python versions supported
-            :
-          </h4>
-          <ul
-            class="list-none space-y-5 inline"
-          >
-            <li
-              class="leading-normal inline commaList"
+            <div
+              class="space-y-2"
             >
-              &gt;=3.6
-            </li>
-          </ul>
-        </li>
-        <li
-          class="mb-4 text-sm"
+              <h4
+                class="font-bold whitespace-nowrap"
+              >
+                Version
+                :
+              </h4>
+              <ul
+                class="list-none text-sm leading-normal space-y-5"
+              >
+                <li
+                  class="textItem"
+                >
+                  0.0.2
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div
+            class="text-sm"
+          >
+            <div
+              class="space-y-2"
+            >
+              <h4
+                class="font-bold whitespace-nowrap"
+              >
+                Release date
+                :
+              </h4>
+              <ul
+                class="list-none text-sm leading-normal space-y-5"
+              >
+                <li
+                  class="textItem"
+                >
+                  03 March 2021
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div
+            class="text-sm"
+          >
+            <div
+              class="space-y-2"
+            >
+              <h4
+                class="font-bold whitespace-nowrap"
+              >
+                First released
+                :
+              </h4>
+              <ul
+                class="list-none text-sm leading-normal space-y-5"
+              >
+                <li
+                  class="textItem"
+                >
+                  22 February 2021
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div
+            class="text-sm"
+          >
+            <div
+              class="space-y-2"
+            >
+              <h4
+                class="font-bold whitespace-nowrap"
+              >
+                Development status
+                :
+              </h4>
+              <ul
+                class="list-none text-sm leading-normal space-y-5"
+              >
+                <li
+                  class="textItem"
+                >
+                  4 - Beta
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div
+            class="text-sm"
+          >
+            <div
+              class="space-y-2"
+            >
+              <h4
+                class="font-bold whitespace-nowrap"
+              >
+                License
+                :
+              </h4>
+              <ul
+                class="list-none text-sm leading-normal space-y-5"
+              >
+                <li
+                  class="textItem"
+                >
+                  MIT
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+        <div
+          class="fresnel-container fresnel-greaterThanOrEqual-screen-1425 "
         >
-          <h4
-            class="inline mr-2 font-bold whitespace-nowrap"
-          >
-            Operating system
-            :
-          </h4>
-          <ul
-            class="list-none space-y-5 inline"
-          >
-            <li
-              class="leading-normal inline commaList"
-            >
-              OS Independent
-            </li>
-          </ul>
-        </li>
-        <li
-          class="mb-4 text-sm"
+          <div
+            class="my-6 h-px bg-black border-none"
+          />
+        </div>
+        <div
+          class="fresnel-container fresnel-lessThan-screen-875 "
+        />
+        <div
+          class="text-sm screen-875:justify-self-center screen-1150:justify-self-start"
         >
-          <h4
-            class="inline mr-2 font-bold whitespace-nowrap"
+          <div
+            class="space-y-2"
           >
-            Requirements
-            :
-          </h4>
-          <ul
-            class="list-none space-y-5 inline"
+            <h4
+              class="font-bold whitespace-nowrap"
+            >
+              GitHub activity
+              :
+            </h4>
+            <ul
+              class="list-none text-sm leading-normal space-y-2"
+            >
+              <li
+                class="textItem"
+              >
+                Stars
+                : 
+                <span
+                  class="font-bold"
+                >
+                  0
+                </span>
+              </li>
+              <li
+                class="textItem"
+              >
+                Forks
+                : 
+                <span
+                  class="font-bold"
+                >
+                  0
+                </span>
+              </li>
+              <li
+                class="textItem"
+              >
+                Issues + PRs
+                : 
+                <span
+                  class="font-bold"
+                >
+                  0
+                </span>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div
+          class="fresnel-container fresnel-greaterThanOrEqual-screen-1425 "
+        >
+          <div
+            class="my-6 h-px bg-black border-none"
+          />
+        </div>
+        <div
+          class="fresnel-container fresnel-lessThan-screen-875 "
+        />
+        <div
+          class="space-y-6"
+        >
+          <div
+            class="text-sm"
           >
-            <li
-              class="leading-normal inline commaList"
+            <div
+              class="space-y-2"
             >
-              napari-plugin-engine (&gt;=0.1.4)
-            </li>
-            <li
-              class="leading-normal inline commaList"
+              <h4
+                class="font-bold whitespace-nowrap"
+              >
+                Python versions supported
+                :
+              </h4>
+              <ul
+                class="list-none text-sm leading-normal space-y-5"
+              >
+                <li
+                  class="textItem"
+                >
+                  &gt;=3.6
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div
+            class="text-sm"
+          >
+            <div
+              class="space-y-2"
             >
-              numpy
-            </li>
-            <li
-              class="leading-normal inline commaList"
+              <h4
+                class="font-bold whitespace-nowrap"
+              >
+                Operating system
+                :
+              </h4>
+              <ul
+                class="list-none text-sm leading-normal space-y-5"
+              >
+                <li
+                  class="textItem"
+                >
+                  OS Independent
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div
+            class="text-sm"
+          >
+            <div
+              class="space-y-2"
             >
-              zarr
-            </li>
-            <li
-              class="leading-normal inline commaList"
-            >
-              dask[complete]
-            </li>
-          </ul>
-        </li>
-      </ul>
+              <h4
+                class="font-bold whitespace-nowrap"
+              >
+                Requirements
+                :
+              </h4>
+              <ul
+                class="list-none text-sm leading-normal space-y-5"
+              >
+                <li
+                  class="textItem"
+                >
+                  napari-plugin-engine (&gt;=0.1.4)
+                </li>
+                <li
+                  class="textItem"
+                >
+                  numpy
+                </li>
+                <li
+                  class="textItem"
+                >
+                  zarr
+                </li>
+                <li
+                  class="textItem"
+                >
+                  dask[complete]
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </article>
 </div>

--- a/frontend/src/components/PluginSearch/PluginSearchResult.tsx
+++ b/frontend/src/components/PluginSearch/PluginSearchResult.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { isEmpty } from 'lodash';
+import { isArray, isEmpty } from 'lodash';
 import { CSSProperties } from 'react';
 
 import { Link } from '@/components/common/Link';
@@ -119,7 +119,9 @@ export function PluginSearchResult({
         },
         {
           label: 'operating system',
-          value: plugin.operating_system.map(formatOperatingSystem).join(', '),
+          value: isArray(plugin.operating_system)
+            ? plugin.operating_system.map(formatOperatingSystem).join(', ')
+            : '',
         },
       ];
 
@@ -177,6 +179,7 @@ export function PluginSearchResult({
           <ul className="mt-5 text-xs">
             <SkeletonLoader
               render={() =>
+                isArray(plugin.authors) &&
                 plugin.authors.map((author) => (
                   <li
                     className="my-2 font-bold"

--- a/frontend/src/components/common/Markdown/Markdown.module.scss
+++ b/frontend/src/components/common/Markdown/Markdown.module.scss
@@ -9,6 +9,11 @@
 
   font-size: calculate-rem(17px);
 
+  // Styles for when the Markdown content is placeholder text.
+  &.placeholder {
+    @apply text-napari-dark-gray;
+  }
+
   code {
     @apply text-base font-normal p-1;
     background: #f7f7f7;

--- a/frontend/src/components/common/Markdown/Markdown.module.scss.d.ts
+++ b/frontend/src/components/common/Markdown/Markdown.module.scss.d.ts
@@ -1,5 +1,6 @@
 export type Styles = {
   markdown: string;
+  placeholder: string;
 };
 
 export type ClassNames = keyof Styles;

--- a/frontend/src/components/common/Markdown/Markdown.tsx
+++ b/frontend/src/components/common/Markdown/Markdown.tsx
@@ -22,6 +22,9 @@ interface Props {
 
   // Disable H1 headers when rendering markdown.
   disableHeader?: boolean;
+
+  // Render markdown with placeholder styles.
+  placeholder?: boolean;
 }
 
 const REMARK_PLUGINS: PluggableList = [
@@ -58,7 +61,12 @@ const REHYPE_PLUGINS: PluggableList = [
 /**
  * Component for rendering Markdown consistently in napari hub.
  */
-export function Markdown({ className, children, disableHeader }: Props) {
+export function Markdown({
+  className,
+  children,
+  disableHeader,
+  placeholder,
+}: Props) {
   const components: TransformOptions['components'] = {
     code: MarkdownCode,
     p: MarkdownParagraph,
@@ -70,7 +78,11 @@ export function Markdown({ className, children, disableHeader }: Props) {
 
   return (
     <ReactMarkdown
-      className={clsx(className, styles.markdown)}
+      className={clsx(
+        className,
+        styles.markdown,
+        placeholder && styles.placeholder,
+      )}
       components={components}
       remarkPlugins={REMARK_PLUGINS}
       rehypePlugins={REHYPE_PLUGINS}

--- a/frontend/src/context/plugin.tsx
+++ b/frontend/src/context/plugin.tsx
@@ -1,4 +1,5 @@
 import { createContext, ReactNode, useContext } from 'react';
+import { DeepPartial } from 'utility-types';
 
 import { PluginData, PluginRepoData, PluginRepoFetchError } from '@/types';
 
@@ -6,7 +7,7 @@ import { PluginData, PluginRepoData, PluginRepoFetchError } from '@/types';
  * Shared state for plugin data.
  */
 interface PluginState {
-  plugin: PluginData;
+  plugin?: DeepPartial<PluginData>;
   repo: PluginRepoData;
   repoFetchError?: PluginRepoFetchError;
 }

--- a/frontend/src/context/plugin.tsx
+++ b/frontend/src/context/plugin.tsx
@@ -169,6 +169,11 @@ export function usePluginMetadata() {
             )
           : [],
     },
+
+    citations: {
+      name: 'Citation information',
+      value: plugin?.citations,
+    },
   };
 }
 

--- a/frontend/src/context/plugin.tsx
+++ b/frontend/src/context/plugin.tsx
@@ -1,7 +1,9 @@
+import { isArray } from 'lodash';
 import { createContext, ReactNode, useContext } from 'react';
 import { DeepPartial } from 'utility-types';
 
 import { PluginData, PluginRepoData, PluginRepoFetchError } from '@/types';
+import { formatDate } from '@/utils';
 
 /**
  * Shared state for plugin data.
@@ -46,3 +48,130 @@ export function usePluginState(): PluginState {
 
   return context;
 }
+
+export function usePluginMetadata() {
+  const { plugin } = usePluginState();
+
+  return {
+    name: {
+      name: 'Plugin name',
+      value: plugin?.name ?? '',
+    },
+
+    summary: {
+      name: 'Brief description',
+      value: plugin?.name ?? '',
+    },
+
+    description: {
+      name: 'Plugin description using hub-specific template',
+      value: plugin?.name ?? '',
+    },
+
+    releaseDate: {
+      name: 'Release date',
+      value: plugin?.release_date ? formatDate(plugin.release_date) : '',
+    },
+
+    firstReleased: {
+      name: 'First released',
+      value: plugin?.first_released ? formatDate(plugin.first_released) : '',
+    },
+
+    authors: {
+      name: 'Authors',
+      value:
+        plugin?.authors && isArray(plugin.authors)
+          ? plugin.authors
+              ?.map((author) => author.name)
+              .filter((name): name is string => !!name)
+          : [],
+    },
+
+    projectSite: {
+      name: 'Project site',
+      value: plugin?.project_site ?? '',
+    },
+
+    reportIssues: {
+      name: 'Report issues',
+      previewName: 'Report issues site',
+      value: plugin?.report_issues ?? '',
+    },
+
+    twitter: {
+      name: 'Twitter',
+      previewName: 'Twitter handle',
+      value: plugin?.twitter ?? '',
+    },
+
+    sourceCode: {
+      name: 'Source code',
+      value: plugin?.code_repository ?? '',
+    },
+
+    supportSite: {
+      name: 'Support site',
+      value: plugin?.support ?? '',
+    },
+
+    documentationSite: {
+      name: 'Documentation',
+      previewName: 'Documentation site',
+      value: plugin?.documentation ?? '',
+    },
+
+    version: {
+      name: 'Version',
+      value: plugin?.version ?? '',
+    },
+
+    developmentStatus: {
+      name: 'Development status',
+      value:
+        plugin?.development_status && isArray(plugin.development_status)
+          ? plugin.development_status
+              ?.map(
+                (status) => status?.replace('Development Status :: ', '') ?? '',
+              )
+              .filter((value): value is string => !!value)
+          : [],
+    },
+
+    license: {
+      name: 'License',
+      value: plugin?.license ?? '',
+    },
+
+    pythonVersion: {
+      name: 'Python versions supported',
+      value: plugin?.python_version ?? '',
+    },
+
+    operatingSystems: {
+      name: 'Operating system',
+      value:
+        plugin?.operating_system && isArray(plugin.operating_system)
+          ? plugin.operating_system
+              .map((operatingSystem) =>
+                operatingSystem?.replace('Operating System :: ', ''),
+              )
+              .filter((value): value is string => !!value)
+          : [],
+    },
+
+    requirements: {
+      name: 'Requirements',
+      value:
+        plugin?.requirements && isArray(plugin.requirements)
+          ? plugin.requirements.filter(
+              (req): req is string => !req?.includes('; extra == '),
+            )
+          : [],
+    },
+  };
+}
+
+export type Metadata = ReturnType<typeof usePluginMetadata>;
+
+export type MetadataKeys = keyof Metadata;

--- a/frontend/src/context/plugin.tsx
+++ b/frontend/src/context/plugin.tsx
@@ -49,6 +49,16 @@ export function usePluginState(): PluginState {
   return context;
 }
 
+/**
+ * Hook for accessing plugin metadata and related information. This serves as a
+ * single-source of truth for plugin metadata so that multiple features can
+ * reference the same data, and therefore allow us to colocate extra information
+ * in this same object.
+ *
+ * TODO Refactor usages `usePluginState()` to use this hook.
+ *
+ * @returns The plugin metadata.
+ */
 export function usePluginMetadata() {
   const { plugin } = usePluginState();
 

--- a/frontend/src/pages/preview.tsx
+++ b/frontend/src/pages/preview.tsx
@@ -1,6 +1,7 @@
 import fs from 'fs-extra';
 import { GetStaticPropsResult } from 'next';
 import DefaultErrorPage from 'next/error';
+import { DeepPartial } from 'utility-types';
 
 import { PluginDetails } from '@/components/PluginDetails';
 import { DEFAULT_PLUGIN_DATA, DEFAULT_REPO_DATA } from '@/constants/plugin';
@@ -10,7 +11,7 @@ import { PluginData } from '@/types';
 import { fetchRepoData, FetchRepoDataResult } from '@/utils';
 
 interface Props extends FetchRepoDataResult {
-  plugin: PluginData;
+  plugin: DeepPartial<PluginData>;
 }
 
 const PLUGIN_PATH = process.env.PREVIEW;
@@ -27,13 +28,14 @@ export async function getStaticProps(): Promise<GetStaticPropsResult<Props>> {
   }
 
   const pluginData = await fs.readFile(PLUGIN_PATH, 'utf-8');
-  const plugin = JSON.parse(pluginData) as PluginData;
-  const repoFetchResult = await fetchRepoData(plugin.code_repository);
+  const plugin = JSON.parse(pluginData) as DeepPartial<PluginData>;
+  const repoFetchResult =
+    plugin.code_repository && (await fetchRepoData(plugin.code_repository));
 
   return {
     props: {
       plugin,
-      ...repoFetchResult,
+      ...(repoFetchResult || { repo: DEFAULT_REPO_DATA }),
     },
   };
 }

--- a/frontend/src/store/search/filters.ts
+++ b/frontend/src/store/search/filters.ts
@@ -3,7 +3,7 @@
  */
 
 import { satisfies } from '@renovate/pep440';
-import { flow, intersection, isEmpty, some } from 'lodash';
+import { flow, intersection, isArray, isEmpty, some } from 'lodash';
 
 import { DeriveGet } from '@/types';
 
@@ -50,7 +50,10 @@ function filterByOperatingSystem(
 
   return results.filter(({ plugin }) => {
     // Don't filter if plugin supports all operating systems
-    if (plugin.operating_system.some((os) => os.includes('OS Independent'))) {
+    if (
+      isArray(plugin.operating_system) &&
+      plugin.operating_system.some((os) => os.includes('OS Independent'))
+    ) {
       return true;
     }
 
@@ -59,17 +62,20 @@ function filterByOperatingSystem(
       return true;
     }
 
-    return plugin.operating_system.some((os) =>
-      some(state, (enabled, osKey) => {
-        if (enabled) {
-          const pattern =
-            FILTER_OS_PATTERN[osKey as keyof typeof FILTER_OS_PATTERN];
+    return (
+      isArray(plugin.operating_system) &&
+      plugin.operating_system.some((os) =>
+        some(state, (enabled, osKey) => {
+          if (enabled) {
+            const pattern =
+              FILTER_OS_PATTERN[osKey as keyof typeof FILTER_OS_PATTERN];
 
-          return !!pattern.exec(os);
-        }
+            return !!pattern.exec(os);
+          }
 
-        return false;
-      }),
+          return false;
+        }),
+      )
     );
   });
 }

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -10,6 +10,7 @@ const colors = {
   hover: '#98daff',
   hoverGray: '#f7f7f7',
   gray: '#6f6f6f',
+  darkGray: '#686868',
   light: '#d2efff',
   error: '#eb1000',
   previewGray: '#ededed',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -45,7 +45,7 @@ export interface PluginData extends PluginIndexData {
   project_site: string;
   release_date: string;
   report_issues: string;
-  requirements?: string[] | null | '';
+  requirements: string[] | '';
   support: string;
   twitter: string;
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -20,15 +20,15 @@ export interface CitationData {
  * Plugin data used for indexing. This is a subset of the full plugin data.
  */
 export interface PluginIndexData {
-  authors: PluginAuthor[];
+  authors: PluginAuthor[] | '';
   description_content_type: string;
   description: string;
   description_text: string;
-  development_status: string[];
+  development_status: string[] | '';
   first_released: string;
   license: string;
   name: string;
-  operating_system: string[];
+  operating_system: string[] | '';
   python_version: string;
   release_date: string;
   summary: string;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -42,6 +42,7 @@ module.exports = {
         'napari-light': colors.light,
         'napari-error': colors.error,
         'napari-gray': colors.gray,
+        'napari-dark-gray': colors.darkGray,
         'napari-preview-gray': colors.previewGray,
         'napari-preview-orange': colors.previewOrange,
         'napari-preview-orange-overlay': colors.previewOrangeOverlay,


### PR DESCRIPTION
## Description

Refactors for the preview page to make it easier to implement the scrolling functionality and adds missing fields for the preview page highlighting.

### Changes

- Make plugin page more null-safe so we support rendering preview pages with no metadata
- Refactored `<MetadataList />` component
- Add missing highlighting for plugin name, summary, and description. 

### `<MetadataList />` refactor

The `<MetadataList />`  component has been refactored to be easier to work with. The current problem with  implementation is that it has too many responsibilities, which are:

1. Render lists of lists
2. For each list, render an item
3. Each item can be text or a link.

This PR breaks down the component by making the API declarative and  delegating the responsibilities to separate components:

1.  The parent component is now responsible for rendering multiple `<MetadataList />` components
2. The `<MetadataList />` component now only handles rendering children and adding list-wide styles.
3. Items can be rendered using the `<MetadataListTextItem />` and `<MetadataListLinkItem />` components.

## Demo

https://napari-hub-preview-metadata-list-refactor.vercel.app/
