### PR TITLE
Preview page scroll to metadata

### DIFF
--- a/frontend/src/components/AppBar/AppBarPreview.tsx
+++ b/frontend/src/components/AppBar/AppBarPreview.tsx
@@ -10,13 +10,11 @@ import {
 import { Link } from '@/components/common/Link';
 import { Media } from '@/components/common/media';
 import { MetadataStatus } from '@/components/MetadataStatus';
+import { HUB_WIKI_LINK } from '@/constants/preview';
 
 import styles from './AppBarPreview.module.scss';
 import { useMetadataSections } from './metadataPreview.hooks';
 import { PreviewMetadataPanel } from './PreviewMetadataPanel';
-
-const HUB_WIKI_LINK =
-  'https://github.com/chanzuckerberg/napari-hub/blob/main/docs/customizing-plugin-listing.md';
 
 function MetadataStatusBar() {
   const sections = useMetadataSections();

--- a/frontend/src/components/AppBar/PreviewMetadataPanel.tsx
+++ b/frontend/src/components/AppBar/PreviewMetadataPanel.tsx
@@ -1,7 +1,10 @@
+import { Button } from '@material-ui/core';
 import clsx from 'clsx';
+import { createElement } from 'react';
 
 import { Media } from '@/components/common/media';
 import { MetadataStatus } from '@/components/MetadataStatus';
+import { setUrlHash } from '@/utils';
 
 import {
   MetadataSectionField,
@@ -20,6 +23,57 @@ function getOrderedFields(fields: MetadataSectionField[]) {
     ...fields.filter((field) => !field.hasValue),
     ...fields.filter((field) => field.hasValue),
   ];
+}
+
+interface MetadataFieldProps {
+  field: MetadataSectionField;
+}
+
+function MetadataField({ field }: MetadataFieldProps) {
+  const fieldBody = (
+    <>
+      <MetadataStatus hasValue={field.hasValue} />
+
+      <span
+        className={clsx(
+          'text-sm ml-3',
+          !field.hasValue && 'font-semibold leading-[17.5px]',
+        )}
+      >
+        {field.name}
+      </span>
+    </>
+  );
+
+  return (
+    <li className="flex">
+      {createElement(
+        // Use buttons for missing fields so that the user can click to scroll to the missing field.
+        field.hasValue ? 'span' : Button,
+        {
+          key: field.name,
+
+          className:
+            'flex items-center justify-start text-left m-0 p-1 flex-grow',
+
+          // Attach click listener if field is a button.
+          ...(field.hasValue
+            ? {}
+            : {
+                onClick() {
+                  // Scroll to the active metadata field.
+                  const element = document.getElementById(field.id);
+                  element?.scrollIntoView();
+
+                  // Replace current URL hash with selected metadata ID.
+                  setUrlHash(field.id);
+                },
+              }),
+        },
+        fieldBody,
+      )}
+    </li>
+  );
 }
 
 interface Props {
@@ -66,17 +120,7 @@ export function PreviewMetadataPanel({ missingFieldsOnly }: Props) {
                 // Allow all fields if `missingFieldsOnly` is disabled, Otherwise, filter out values that have a value.
                 .filter((field) => !missingFieldsOnly || !field.hasValue)
                 .map((field) => (
-                  <li className="flex items-center space-x-3" key={field.name}>
-                    <MetadataStatus hasValue={field.hasValue} />
-                    <span
-                      className={clsx(
-                        'text-sm',
-                        !field.hasValue && 'font-semibold leading-[17.5px]',
-                      )}
-                    >
-                      {field.name}
-                    </span>
-                  </li>
+                  <MetadataField field={field} />
                 ))}
             </ul>
           </section>

--- a/frontend/src/components/AppBar/PreviewMetadataPanel.tsx
+++ b/frontend/src/components/AppBar/PreviewMetadataPanel.tsx
@@ -4,6 +4,7 @@ import { createElement } from 'react';
 
 import { Media } from '@/components/common/media';
 import { MetadataStatus } from '@/components/MetadataStatus';
+import { previewStore } from '@/store/preview';
 import { setUrlHash } from '@/utils';
 
 import {
@@ -61,6 +62,8 @@ function MetadataField({ field }: MetadataFieldProps) {
             ? {}
             : {
                 onClick() {
+                  previewStore.activeMetadataField = field.id;
+
                   // Scroll to the active metadata field.
                   const element = document.getElementById(field.id);
                   element?.scrollIntoView();

--- a/frontend/src/components/AppBar/metadataPreview.hooks.ts
+++ b/frontend/src/components/AppBar/metadataPreview.hooks.ts
@@ -3,6 +3,7 @@ import { isEmpty } from 'lodash';
 import { MetadataKeys, usePluginMetadata } from '@/context/plugin';
 
 export interface MetadataSectionField {
+  id: MetadataKeys;
   name: string;
   hasValue: boolean;
 }
@@ -23,12 +24,15 @@ export function useMetadataSections(): MetadataSection[] {
   const metadata = usePluginMetadata();
 
   function getFields(...keys: MetadataKeys[]) {
-    return keys
-      .map((key) => metadata[key])
-      .map((data) => ({
+    return keys.map((key) => {
+      const data = metadata[key];
+
+      return {
+        id: key,
         name: hasPreviewName(data) ? data.previewName : data.name,
         hasValue: !isEmpty(data.value),
-      }));
+      };
+    });
   }
 
   return [

--- a/frontend/src/components/MetadataHighlighter/EmptyMetadataTooltip.tsx
+++ b/frontend/src/components/MetadataHighlighter/EmptyMetadataTooltip.tsx
@@ -1,0 +1,101 @@
+import { Tooltip } from '@material-ui/core';
+import { useSnapshot } from 'valtio';
+
+import { Link } from '@/components/common/Link';
+import { MetadataStatus } from '@/components/MetadataStatus';
+import { HUB_WIKI_LINK } from '@/constants/preview';
+import { MetadataKeys, usePluginMetadata } from '@/context/plugin';
+import { previewStore } from '@/store/preview';
+
+interface Props {
+  className?: string;
+  metadataId?: MetadataKeys;
+}
+
+/**
+ * Tooltip titles to render for each metadata field on the plugin page.
+ */
+const TOOLTIP_TEXT: Record<MetadataKeys, string> = {
+  // Plugin content
+  name: 'the name of the plugin',
+  description: 'long description of the plugin',
+  summary: 'short description of the plugin',
+
+  // Plugin metadata
+  developmentStatus: 'the current development status of the plugin',
+  license: 'the license of the plugin',
+  operatingSystems: 'list of supported operating systems',
+  pythonVersion: 'indicates which version of Python the user should install',
+  requirements: 'list of Python requirements for the plugin',
+  version: 'the current version of the plugin',
+
+  // Plugin support info
+  authors: 'lists authors of the plugin',
+  documentationSite: 'link to the documentation site',
+  reportIssues: 'link to site for users to report issues',
+  sourceCode: 'link to the source code of the plugin',
+  supportSite: 'link to a plugin support site',
+
+  // Currently not used in the preview UI
+  twitter: "link to the author's twitter",
+  projectSite: 'link to the project site of the plugin',
+
+  // Unused
+  releaseDate: '',
+  firstReleased: '',
+};
+
+/**
+ * Renders a tooltip and metadata status icon for with information for the
+ * metadata specified by `metadataId`.
+ */
+export function EmptyMetadataTooltip({ className, metadataId }: Props) {
+  const snap = useSnapshot(previewStore);
+  const metadata = usePluginMetadata();
+
+  if (!metadataId) {
+    return null;
+  }
+
+  return (
+    <Tooltip
+      classes={{
+        tooltip:
+          'bg-white text-black text-sm border-2 border-napari-gray relative',
+      }}
+      placement="bottom"
+      title={
+        <>
+          <h2 className="font-semibold">{metadata[metadataId].name}</h2>
+
+          {metadataId ? TOOLTIP_TEXT[metadataId] : ''}
+
+          <p className="text-xs mt-5 mb-3">
+            Learn how to add content for this field in the{' '}
+            <Link className="underline" href={HUB_WIKI_LINK} newTab>
+              napari hub GitHub Wiki.
+            </Link>
+          </p>
+
+          <p className="italic text-xs">
+            If this field remains incomplete, it will still be shown on your
+            plugin’s page, but without the orange overlay.
+          </p>
+        </>
+      }
+      // The `open` prop is not fully reactive when using controlled components
+      // for some reason, so we need to use `key` to force unmount / remount of
+      // the Tooltip component so that it can react to the tooltip correctly.
+      key={snap.activeMetadataField}
+      open={
+        snap.activeMetadataField
+          ? snap.activeMetadataField === metadataId
+          : undefined
+      }
+    >
+      <div className={className}>
+        <MetadataStatus hasValue={false} />
+      </div>
+    </Tooltip>
+  );
+}

--- a/frontend/src/components/MetadataHighlighter/EmptyMetadataTooltip.tsx
+++ b/frontend/src/components/MetadataHighlighter/EmptyMetadataTooltip.tsx
@@ -41,6 +41,7 @@ const TOOLTIP_TEXT: Record<MetadataKeys, string> = {
   projectSite: 'link to the project site of the plugin',
 
   // Unused
+  citations: '',
   releaseDate: '',
   firstReleased: '',
 };

--- a/frontend/src/components/MetadataHighlighter/MetadataHighlighter.tsx
+++ b/frontend/src/components/MetadataHighlighter/MetadataHighlighter.tsx
@@ -1,0 +1,109 @@
+import clsx from 'clsx';
+import { isFunction } from 'lodash';
+import { createElement, HTMLProps, ReactHTML, ReactNode } from 'react';
+import { useSnapshot } from 'valtio';
+
+import { MetadataKeys } from '@/context/plugin';
+import { useIsPreview } from '@/hooks';
+import { previewStore } from '@/store/preview';
+import { setUrlHash } from '@/utils';
+
+import { EmptyMetadataTooltip } from './EmptyMetadataTooltip';
+
+type HTMLKey = keyof ReactHTML;
+type RenderFn = (tooltip: ReactNode) => ReactNode;
+
+interface Props<T extends HTMLKey> extends HTMLProps<ReactHTML[T]> {
+  children: ReactNode | RenderFn;
+  className?: string;
+  tooltipClassName?: string;
+  component?: T;
+  highlight?: boolean;
+  id?: MetadataKeys;
+}
+
+/**
+ * Component for rendering an overlay around missing plugin metadata on the
+ * preview page. This
+ */
+export function MetadataHighlighter<T extends HTMLKey>({
+  children,
+  className,
+  component,
+  highlight = false,
+  id,
+  tooltipClassName,
+  ...props
+}: Props<T>) {
+  const isPreview = useIsPreview();
+  const snap = useSnapshot(previewStore);
+  const isActive = snap.activeMetadataField === id;
+
+  const tooltipNode = (
+    <>
+      {isPreview && highlight && (
+        <EmptyMetadataTooltip className={tooltipClassName} metadataId={id} />
+      )}
+    </>
+  );
+  const childNode = isFunction(children) ? (
+    children(tooltipNode)
+  ) : (
+    <>
+      {children}
+      {tooltipNode}
+    </>
+  );
+
+  return createElement(
+    // Use `button` when metadata is missing so that users can click on the
+    // metadata field to show / hide the tooltip.
+    isPreview && highlight ? 'button' : component ?? 'div',
+    {
+      ...props,
+
+      id,
+
+      className: clsx(
+        className,
+        isPreview &&
+          highlight && [
+            // Override button styles.
+            'text-left w-full',
+
+            // Give button border initially so that the space is reserved.
+            'border-2',
+
+            isActive
+              ? [
+                  // Render button with orange border and darker overlay color when active.
+                  'border-napari-preview-orange',
+                  'bg-napari-preview-orange-overlay-active',
+                ]
+              : [
+                  // Render border transparent and only show darker overlay color
+                  // when hovering.
+                  'border-transparent',
+                  'bg-napari-preview-orange-overlay',
+                  'hover:bg-napari-preview-orange-overlay-active',
+                ],
+          ],
+      ),
+
+      onClick(event: MouseEvent) {
+        // Stop propogation so that the event doesn't bubble up to
+        // `usePreviewClickAway()` event listeners.
+        event.stopPropagation();
+
+        // If the clicked metadata ID matches the active ID, then clear the
+        // active ID state. Otherwise, set it to the clicked metadata ID.
+        const nextId = id && id !== snap.activeMetadataField ? id : '';
+        previewStore.activeMetadataField = nextId;
+
+        // Replace current URL with active metadata ID.
+        setUrlHash(nextId);
+      },
+    },
+    childNode,
+  );
+}

--- a/frontend/src/components/MetadataHighlighter/index.ts
+++ b/frontend/src/components/MetadataHighlighter/index.ts
@@ -1,0 +1,1 @@
+export * from './MetadataHighlighter';

--- a/frontend/src/components/MetadataList/EmptyListItem.tsx
+++ b/frontend/src/components/MetadataList/EmptyListItem.tsx
@@ -1,15 +1,17 @@
-import { Tooltip } from '@material-ui/core';
 import clsx from 'clsx';
-
-import { MetadataStatus } from '@/components/MetadataStatus';
+import { ReactNode } from 'react';
 
 import { useMetadataContext } from './metadata.context';
+
+interface Props {
+  children?: ReactNode;
+}
 
 /**
  * Renders a special list item informing the user that the metadata has no
  * supplied value.
  */
-export function EmptyListItem() {
+export function EmptyListItem({ children }: Props) {
   const { inline } = useMetadataContext();
 
   return (
@@ -23,11 +25,7 @@ export function EmptyListItem() {
         information not submitted
       </span>
 
-      <Tooltip placement="right" title="MetadataStatus Text Placeholder">
-        <div>
-          <MetadataStatus hasValue={false} />
-        </div>
-      </Tooltip>
+      {children}
     </li>
   );
 }

--- a/frontend/src/components/MetadataList/MetadataList.tsx
+++ b/frontend/src/components/MetadataList/MetadataList.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx';
 import { ReactNode } from 'react';
 
 import { MetadataHighlighter } from '@/components/MetadataHighlighter';
+import { EmptyMetadataTooltip } from '@/components/MetadataHighlighter/EmptyMetadataTooltip';
 import { MetadataKeys } from '@/context/plugin';
 import { usePreviewClickAway } from '@/hooks/usePreviewClickAway';
 
@@ -52,38 +53,41 @@ export function MetadataList({
             'space-y-2',
           )}
           highlight={empty}
+          tooltip={null}
           id={id}
         >
-          {(tooltip) => (
-            <>
-              {/* List title */}
-              <h4
-                className={clsx(
-                  // Font
-                  'font-bold whitespace-nowrap',
+          {/* List title */}
+          <h4
+            className={clsx(
+              // Font
+              'font-bold whitespace-nowrap',
 
-                  // Render title inline with values.
-                  inline && 'inline',
-                )}
-              >
-                {title}:
-              </h4>
+              // Render title inline with values.
+              inline && 'inline',
+            )}
+          >
+            {title}:
+          </h4>
 
-              {/* List values */}
-              <ul
-                className={clsx(
-                  'list-none text-sm leading-normal',
+          {/* List values */}
+          <ul
+            className={clsx(
+              'list-none text-sm leading-normal',
 
-                  // Vertical and horizontal spacing.
-                  inline
-                    ? ['inline space-y-2', styles.inlineList]
-                    : [compact ? 'space-y-2' : 'space-y-5'],
-                )}
-              >
-                {empty ? <EmptyListItem>{tooltip}</EmptyListItem> : children}
-              </ul>
-            </>
-          )}
+              // Vertical and horizontal spacing.
+              inline
+                ? ['inline space-y-2', styles.inlineList]
+                : [compact ? 'space-y-2' : 'space-y-5'],
+            )}
+          >
+            {empty ? (
+              <EmptyListItem>
+                <EmptyMetadataTooltip metadataId={id} />
+              </EmptyListItem>
+            ) : (
+              children
+            )}
+          </ul>
         </MetadataHighlighter>
       </div>
     </MetadataContextProvider>

--- a/frontend/src/components/MetadataList/MetadataList.tsx
+++ b/frontend/src/components/MetadataList/MetadataList.tsx
@@ -1,8 +1,10 @@
 import clsx from 'clsx';
 import { ReactNode } from 'react';
+import { useSnapshot } from 'valtio';
 
 import { MetadataKeys } from '@/context/plugin';
 import { useIsPreview } from '@/hooks';
+import { previewStore } from '@/store/preview';
 
 import { EmptyListItem } from './EmptyListItem';
 import { MetadataContextProvider } from './metadata.context';
@@ -31,6 +33,7 @@ export function MetadataList({
   title,
 }: Props) {
   const isPreview = useIsPreview();
+  const snap = useSnapshot(previewStore);
 
   return (
     // Pass list props in context so that list items can render differently
@@ -45,8 +48,13 @@ export function MetadataList({
         <div
           className={clsx(
             // Render overlay if the list is empty.
-            isPreview && empty && 'bg-napari-preview-orange-overlay',
-
+            isPreview &&
+              empty && [
+                'bg-napari-preview-orange-overlay border-2',
+                snap.activeMetadataField === id
+                  ? 'border-napari-preview-orange'
+                  : 'border-transparent',
+              ],
             // Item spacing for inline lists.
             inline && 'space-x-2',
 

--- a/frontend/src/components/MetadataList/MetadataList.tsx
+++ b/frontend/src/components/MetadataList/MetadataList.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import { ReactNode } from 'react';
 
+import { MetadataKeys } from '@/context/plugin';
 import { useIsPreview } from '@/hooks';
 
 import { EmptyListItem } from './EmptyListItem';
@@ -10,10 +11,11 @@ import styles from './MetadataList.module.scss';
 interface Props {
   children: ReactNode;
   className?: string;
-  title: string;
-  inline?: boolean;
   compact?: boolean;
   empty?: boolean;
+  id?: MetadataKeys;
+  inline?: boolean;
+  title: string;
 }
 
 /**
@@ -24,8 +26,9 @@ export function MetadataList({
   className,
   compact,
   empty,
-  title,
+  id,
   inline,
+  title,
 }: Props) {
   const isPreview = useIsPreview();
 
@@ -37,7 +40,7 @@ export function MetadataList({
         Use list wrapper so that the preview highlight overlay only renders as
         tall as the content.
        */}
-      <div className={clsx('text-sm', className)}>
+      <div id={id} className={clsx('text-sm', className)}>
         {/* List container */}
         <div
           className={clsx(

--- a/frontend/src/components/MetadataList/MetadataList.tsx
+++ b/frontend/src/components/MetadataList/MetadataList.tsx
@@ -1,11 +1,9 @@
 import clsx from 'clsx';
 import { ReactNode } from 'react';
-import { useSnapshot } from 'valtio';
 
+import { MetadataHighlighter } from '@/components/MetadataHighlighter';
 import { MetadataKeys } from '@/context/plugin';
-import { useIsPreview } from '@/hooks';
 import { usePreviewClickAway } from '@/hooks/usePreviewClickAway';
-import { previewStore } from '@/store/preview';
 
 import { EmptyListItem } from './EmptyListItem';
 import { MetadataContextProvider } from './metadata.context';
@@ -34,8 +32,6 @@ export function MetadataList({
   title,
 }: Props) {
   usePreviewClickAway(id);
-  const isPreview = useIsPreview();
-  const snap = useSnapshot(previewStore);
 
   return (
     // Pass list props in context so that list items can render differently
@@ -47,50 +43,48 @@ export function MetadataList({
        */}
       <div id={id} className={clsx('text-sm', className)}>
         {/* List container */}
-        <div
+        <MetadataHighlighter
           className={clsx(
-            // Render overlay if the list is empty.
-            isPreview &&
-              empty && [
-                'bg-napari-preview-orange-overlay border-2',
-                snap.activeMetadataField === id
-                  ? 'border-napari-preview-orange'
-                  : 'border-transparent',
-              ],
             // Item spacing for inline lists.
             inline && 'space-x-2',
 
             // Vertical spacing.
             'space-y-2',
           )}
+          highlight={empty}
+          id={id}
         >
-          {/* List title */}
-          <h4
-            className={clsx(
-              // Font
-              'font-bold whitespace-nowrap',
+          {(tooltip) => (
+            <>
+              {/* List title */}
+              <h4
+                className={clsx(
+                  // Font
+                  'font-bold whitespace-nowrap',
 
-              // Render title inline with values.
-              inline && 'inline',
-            )}
-          >
-            {title}:
-          </h4>
+                  // Render title inline with values.
+                  inline && 'inline',
+                )}
+              >
+                {title}:
+              </h4>
 
-          {/* List values */}
-          <ul
-            className={clsx(
-              'list-none text-sm leading-normal',
+              {/* List values */}
+              <ul
+                className={clsx(
+                  'list-none text-sm leading-normal',
 
-              // Vertical and horizontal spacing.
-              inline
-                ? ['inline space-y-2', styles.inlineList]
-                : [compact ? 'space-y-2' : 'space-y-5'],
-            )}
-          >
-            {empty ? <EmptyListItem /> : children}
-          </ul>
-        </div>
+                  // Vertical and horizontal spacing.
+                  inline
+                    ? ['inline space-y-2', styles.inlineList]
+                    : [compact ? 'space-y-2' : 'space-y-5'],
+                )}
+              >
+                {empty ? <EmptyListItem>{tooltip}</EmptyListItem> : children}
+              </ul>
+            </>
+          )}
+        </MetadataHighlighter>
       </div>
     </MetadataContextProvider>
   );

--- a/frontend/src/components/MetadataList/MetadataList.tsx
+++ b/frontend/src/components/MetadataList/MetadataList.tsx
@@ -4,6 +4,7 @@ import { useSnapshot } from 'valtio';
 
 import { MetadataKeys } from '@/context/plugin';
 import { useIsPreview } from '@/hooks';
+import { usePreviewClickAway } from '@/hooks/usePreviewClickAway';
 import { previewStore } from '@/store/preview';
 
 import { EmptyListItem } from './EmptyListItem';
@@ -32,6 +33,7 @@ export function MetadataList({
   inline,
   title,
 }: Props) {
+  usePreviewClickAway(id);
   const isPreview = useIsPreview();
   const snap = useSnapshot(previewStore);
 

--- a/frontend/src/components/MetadataList/MetadataListLinkItem.tsx
+++ b/frontend/src/components/MetadataList/MetadataListLinkItem.tsx
@@ -3,8 +3,8 @@ import { ReactNode } from 'react-markdown';
 
 import { Link } from '@/components/common/Link/Link';
 import { MetadataStatus } from '@/components/MetadataStatus';
-import { usePluginState } from '@/context/plugin';
-import { usePlausible } from '@/hooks';
+import { MetadataKeys, usePluginState } from '@/context/plugin';
+import { useIsPreview, usePlausible } from '@/hooks';
 import { isExternalUrl } from '@/utils';
 
 import { useMetadataContext } from './metadata.context';
@@ -14,6 +14,7 @@ interface Props {
   children: string;
   href: string;
   icon?: ReactNode;
+  id?: MetadataKeys;
   missingIcon?: ReactNode;
 }
 
@@ -25,12 +26,13 @@ export function MetadataListLinkItem({
   children,
   href,
   icon,
+  id,
   missingIcon,
 }: Props) {
   const plausible = usePlausible();
   const { plugin } = usePluginState();
   const { inline } = useMetadataContext();
-  const isPreview = !!process.env.PREVIEW;
+  const isPreview = useIsPreview();
   const itemClassName = 'ml-2 -mt-1 flex-grow';
   const internalLink = !isExternalUrl(href);
 
@@ -41,6 +43,7 @@ export function MetadataListLinkItem({
         styles.linkItem,
         isPreview && !href && 'bg-napari-preview-orange-overlay',
       )}
+      id={id}
     >
       <span className="min-w-4">{href ? icon : missingIcon || icon}</span>
 
@@ -77,7 +80,7 @@ export function MetadataListLinkItem({
       {isPreview && !href && (
         <MetadataStatus
           hasValue={false}
-          variant={inline ? 'inline' : 'regular'}
+          variant={inline ? 'small' : 'regular'}
         />
       )}
     </li>

--- a/frontend/src/components/MetadataList/MetadataListLinkItem.tsx
+++ b/frontend/src/components/MetadataList/MetadataListLinkItem.tsx
@@ -6,6 +6,7 @@ import { Link } from '@/components/common/Link/Link';
 import { MetadataStatus } from '@/components/MetadataStatus';
 import { MetadataKeys, usePluginState } from '@/context/plugin';
 import { useIsPreview, usePlausible } from '@/hooks';
+import { usePreviewClickAway } from '@/hooks/usePreviewClickAway';
 import { previewStore } from '@/store/preview';
 import { isExternalUrl } from '@/utils';
 
@@ -31,6 +32,7 @@ export function MetadataListLinkItem({
   id,
   missingIcon,
 }: Props) {
+  usePreviewClickAway(id);
   const plausible = usePlausible();
   const { plugin } = usePluginState();
   const { inline } = useMetadataContext();

--- a/frontend/src/components/MetadataList/MetadataListLinkItem.tsx
+++ b/frontend/src/components/MetadataList/MetadataListLinkItem.tsx
@@ -1,16 +1,13 @@
 import clsx from 'clsx';
 import { ReactNode } from 'react-markdown';
-import { useSnapshot } from 'valtio';
 
 import { Link } from '@/components/common/Link/Link';
-import { MetadataStatus } from '@/components/MetadataStatus';
+import { MetadataHighlighter } from '@/components/MetadataHighlighter';
 import { MetadataKeys, usePluginState } from '@/context/plugin';
-import { useIsPreview, usePlausible } from '@/hooks';
+import { usePlausible } from '@/hooks';
 import { usePreviewClickAway } from '@/hooks/usePreviewClickAway';
-import { previewStore } from '@/store/preview';
 import { isExternalUrl } from '@/utils';
 
-import { useMetadataContext } from './metadata.context';
 import styles from './MetadataList.module.scss';
 
 interface Props {
@@ -35,27 +32,16 @@ export function MetadataListLinkItem({
   usePreviewClickAway(id);
   const plausible = usePlausible();
   const { plugin } = usePluginState();
-  const { inline } = useMetadataContext();
-  const isPreview = useIsPreview();
-  const snap = useSnapshot(previewStore);
 
   const itemClassName = 'ml-2 -mt-1 flex-grow';
   const internalLink = !isExternalUrl(href);
 
   return (
-    <li
-      className={clsx(
-        'flex',
-        styles.linkItem,
-        isPreview &&
-          !href && [
-            'bg-napari-preview-orange-overlay border-2',
-            id === snap.activeMetadataField
-              ? 'border-napari-preview-orange'
-              : 'border-transparent',
-          ],
-      )}
+    <MetadataHighlighter
       id={id}
+      component="li"
+      className={clsx('flex', styles.linkItem)}
+      highlight={!href}
     >
       <span className="min-w-4">{href ? icon : missingIcon || icon}</span>
 
@@ -88,13 +74,6 @@ export function MetadataListLinkItem({
           {children}
         </span>
       )}
-
-      {isPreview && !href && (
-        <MetadataStatus
-          hasValue={false}
-          variant={inline ? 'small' : 'regular'}
-        />
-      )}
-    </li>
+    </MetadataHighlighter>
   );
 }

--- a/frontend/src/components/MetadataList/MetadataListLinkItem.tsx
+++ b/frontend/src/components/MetadataList/MetadataListLinkItem.tsx
@@ -1,10 +1,12 @@
 import clsx from 'clsx';
 import { ReactNode } from 'react-markdown';
+import { useSnapshot } from 'valtio';
 
 import { Link } from '@/components/common/Link/Link';
 import { MetadataStatus } from '@/components/MetadataStatus';
 import { MetadataKeys, usePluginState } from '@/context/plugin';
 import { useIsPreview, usePlausible } from '@/hooks';
+import { previewStore } from '@/store/preview';
 import { isExternalUrl } from '@/utils';
 
 import { useMetadataContext } from './metadata.context';
@@ -33,6 +35,8 @@ export function MetadataListLinkItem({
   const { plugin } = usePluginState();
   const { inline } = useMetadataContext();
   const isPreview = useIsPreview();
+  const snap = useSnapshot(previewStore);
+
   const itemClassName = 'ml-2 -mt-1 flex-grow';
   const internalLink = !isExternalUrl(href);
 
@@ -41,7 +45,13 @@ export function MetadataListLinkItem({
       className={clsx(
         'flex',
         styles.linkItem,
-        isPreview && !href && 'bg-napari-preview-orange-overlay',
+        isPreview &&
+          !href && [
+            'bg-napari-preview-orange-overlay border-2',
+            id === snap.activeMetadataField
+              ? 'border-napari-preview-orange'
+              : 'border-transparent',
+          ],
       )}
       id={id}
     >

--- a/frontend/src/components/MetadataStatus.tsx
+++ b/frontend/src/components/MetadataStatus.tsx
@@ -5,7 +5,7 @@ import { Check, PriorityHigh } from '@/components/common/icons';
 interface MetadataStatusProps {
   className?: string;
   hasValue: boolean;
-  variant?: 'regular' | 'small' | 'inline';
+  variant?: 'regular' | 'small';
 }
 
 export function MetadataStatus({
@@ -20,7 +20,6 @@ export function MetadataStatus({
         className,
         hasValue ? 'bg-napari-primary' : 'bg-napari-preview-orange',
         variant === 'small' ? 'w-2 h-2' : 'w-[0.9375rem] h-[0.9375rem]',
-        variant === 'inline' && 'inline-flex',
       )}
     >
       {hasValue ? <Check /> : <PriorityHigh color="#fff" />}

--- a/frontend/src/components/PluginDetails/PluginDetails.tsx
+++ b/frontend/src/components/PluginDetails/PluginDetails.tsx
@@ -3,6 +3,7 @@ import { throttle } from 'lodash';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
+import { useSnapshot } from 'valtio';
 
 import { AppBarPreview } from '@/components/AppBar';
 import { ColumnLayout } from '@/components/common/ColumnLayout';
@@ -15,6 +16,7 @@ import { MetadataStatus } from '@/components/MetadataStatus';
 import { useLoadingState } from '@/context/loading';
 import { usePluginState } from '@/context/plugin';
 import { useIsPreview, usePlausible } from '@/hooks';
+import { previewStore } from '@/store/preview';
 
 import { CallToActionButton } from './CallToActionButton';
 import { CitationInfo } from './CitationInfo';
@@ -41,6 +43,7 @@ const EMPTY_DESCRIPTION_PLACEHOLDER =
 function PluginCenterColumn() {
   const { plugin } = usePluginState();
   const isPreview = useIsPreview();
+  const snap = useSnapshot(previewStore);
 
   // Check if body is an empty string or if it's set to the cookiecutter text.
   const isEmptyDescription =
@@ -63,7 +66,13 @@ function PluginCenterColumn() {
             id="name"
             className={clsx(
               'flex justify-between',
-              !plugin?.name && isPreview && 'bg-napari-preview-orange-overlay',
+              !plugin?.name &&
+                isPreview && [
+                  'bg-napari-preview-orange-overlay border-2',
+                  snap.activeMetadataField === 'name'
+                    ? 'border-napari-preview-orange'
+                    : 'border-transparent',
+                ],
             )}
           >
             <h1
@@ -90,8 +99,12 @@ function PluginCenterColumn() {
             className={clsx(
               'flex justify-between items-center my-6',
               !plugin?.summary &&
-                isPreview &&
-                'bg-napari-preview-orange-overlay',
+                isPreview && [
+                  'bg-napari-preview-orange-overlay border-2',
+                  snap.activeMetadataField === 'summary'
+                    ? 'border-napari-preview-orange'
+                    : 'border-transparent',
+                ],
             )}
           >
             <h2
@@ -169,8 +182,12 @@ function PluginCenterColumn() {
             className={clsx(
               'flex items-center justify-between mb-10',
               isPreview &&
-                isEmptyDescription &&
-                'bg-napari-preview-orange-overlay',
+                isEmptyDescription && [
+                  'bg-napari-preview-orange-overlay border-2',
+                  snap.activeMetadataField === 'description'
+                    ? 'border-napari-preview-orange'
+                    : 'border-transparent',
+                ],
             )}
           >
             <Markdown disableHeader placeholder={isEmptyDescription}>

--- a/frontend/src/components/PluginDetails/PluginDetails.tsx
+++ b/frontend/src/components/PluginDetails/PluginDetails.tsx
@@ -12,6 +12,7 @@ import { PageMetadata } from '@/components/common/PageMetadata';
 import { SkeletonLoader } from '@/components/common/SkeletonLoader';
 import { TOCHeader } from '@/components/common/TableOfContents';
 import { MetadataHighlighter } from '@/components/MetadataHighlighter';
+import { EmptyMetadataTooltip } from '@/components/MetadataHighlighter/EmptyMetadataTooltip';
 import { useLoadingState } from '@/context/loading';
 import { usePluginState } from '@/context/plugin';
 import { useIsPreview, usePlausible } from '@/hooks';
@@ -67,7 +68,9 @@ function PluginCenterColumn() {
             id="name"
             className="flex justify-between"
             highlight={!plugin?.name}
-            tooltipClassName="self-end"
+            tooltip={
+              <EmptyMetadataTooltip className="self-end" metadataId="name" />
+            }
           >
             <h1
               className={clsx(

--- a/frontend/src/components/PluginDetails/PluginDetails.tsx
+++ b/frontend/src/components/PluginDetails/PluginDetails.tsx
@@ -60,6 +60,7 @@ function PluginCenterColumn() {
         className="h-12"
         render={() => (
           <div
+            id="name"
             className={clsx(
               'flex justify-between',
               !plugin?.name && isPreview && 'bg-napari-preview-orange-overlay',
@@ -85,8 +86,9 @@ function PluginCenterColumn() {
         className="h-6 my-6"
         render={() => (
           <div
+            id="summary"
             className={clsx(
-              'flex justify-between items-center mt-6',
+              'flex justify-between items-center my-6',
               !plugin?.summary &&
                 isPreview &&
                 'bg-napari-preview-orange-overlay',
@@ -163,6 +165,7 @@ function PluginCenterColumn() {
         className="h-[600px] mb-10"
         render={() => (
           <div
+            id="description"
             className={clsx(
               'flex items-center justify-between mb-10',
               isPreview &&

--- a/frontend/src/components/PluginDetails/PluginDetails.tsx
+++ b/frontend/src/components/PluginDetails/PluginDetails.tsx
@@ -16,6 +16,7 @@ import { MetadataStatus } from '@/components/MetadataStatus';
 import { useLoadingState } from '@/context/loading';
 import { usePluginState } from '@/context/plugin';
 import { useIsPreview, usePlausible } from '@/hooks';
+import { usePreviewClickAway } from '@/hooks/usePreviewClickAway';
 import { previewStore } from '@/store/preview';
 
 import { CallToActionButton } from './CallToActionButton';
@@ -44,6 +45,10 @@ function PluginCenterColumn() {
   const { plugin } = usePluginState();
   const isPreview = useIsPreview();
   const snap = useSnapshot(previewStore);
+
+  usePreviewClickAway('name');
+  usePreviewClickAway('summary');
+  usePreviewClickAway('description');
 
   // Check if body is an empty string or if it's set to the cookiecutter text.
   const isEmptyDescription =

--- a/frontend/src/components/PluginDetails/PluginDetails.tsx
+++ b/frontend/src/components/PluginDetails/PluginDetails.tsx
@@ -3,7 +3,6 @@ import { throttle } from 'lodash';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
-import { useSnapshot } from 'valtio';
 
 import { AppBarPreview } from '@/components/AppBar';
 import { ColumnLayout } from '@/components/common/ColumnLayout';
@@ -12,12 +11,11 @@ import { Media, MediaFragment } from '@/components/common/media';
 import { PageMetadata } from '@/components/common/PageMetadata';
 import { SkeletonLoader } from '@/components/common/SkeletonLoader';
 import { TOCHeader } from '@/components/common/TableOfContents';
-import { MetadataStatus } from '@/components/MetadataStatus';
+import { MetadataHighlighter } from '@/components/MetadataHighlighter';
 import { useLoadingState } from '@/context/loading';
 import { usePluginState } from '@/context/plugin';
 import { useIsPreview, usePlausible } from '@/hooks';
 import { usePreviewClickAway } from '@/hooks/usePreviewClickAway';
-import { previewStore } from '@/store/preview';
 
 import { CallToActionButton } from './CallToActionButton';
 import { CitationInfo } from './CitationInfo';
@@ -43,8 +41,6 @@ const EMPTY_DESCRIPTION_PLACEHOLDER =
 
 function PluginCenterColumn() {
   const { plugin } = usePluginState();
-  const isPreview = useIsPreview();
-  const snap = useSnapshot(previewStore);
 
   usePreviewClickAway('name');
   usePreviewClickAway('summary');
@@ -67,18 +63,11 @@ function PluginCenterColumn() {
       <SkeletonLoader
         className="h-12"
         render={() => (
-          <div
+          <MetadataHighlighter
             id="name"
-            className={clsx(
-              'flex justify-between',
-              !plugin?.name &&
-                isPreview && [
-                  'bg-napari-preview-orange-overlay border-2',
-                  snap.activeMetadataField === 'name'
-                    ? 'border-napari-preview-orange'
-                    : 'border-transparent',
-                ],
-            )}
+            className="flex justify-between"
+            highlight={!plugin?.name}
+            tooltipClassName="self-end"
           >
             <h1
               className={clsx(
@@ -88,29 +77,17 @@ function PluginCenterColumn() {
             >
               {plugin?.name ?? 'Plugin name'}
             </h1>
-
-            {isPreview && !plugin?.name && (
-              <MetadataStatus className="self-end" hasValue={false} />
-            )}
-          </div>
+          </MetadataHighlighter>
         )}
       />
 
       <SkeletonLoader
         className="h-6 my-6"
         render={() => (
-          <div
+          <MetadataHighlighter
             id="summary"
-            className={clsx(
-              'flex justify-between items-center my-6',
-              !plugin?.summary &&
-                isPreview && [
-                  'bg-napari-preview-orange-overlay border-2',
-                  snap.activeMetadataField === 'summary'
-                    ? 'border-napari-preview-orange'
-                    : 'border-transparent',
-                ],
-            )}
+            className="flex justify-between items-center my-6"
+            highlight={!plugin?.summary}
           >
             <h2
               className={clsx(
@@ -120,11 +97,7 @@ function PluginCenterColumn() {
             >
               {plugin?.summary ?? 'Brief description'}
             </h2>
-
-            {isPreview && !plugin?.summary && (
-              <MetadataStatus hasValue={false} />
-            )}
-          </div>
+          </MetadataHighlighter>
         )}
       />
 
@@ -182,27 +155,15 @@ function PluginCenterColumn() {
       <SkeletonLoader
         className="h-[600px] mb-10"
         render={() => (
-          <div
+          <MetadataHighlighter
             id="description"
-            className={clsx(
-              'flex items-center justify-between mb-10',
-              isPreview &&
-                isEmptyDescription && [
-                  'bg-napari-preview-orange-overlay border-2',
-                  snap.activeMetadataField === 'description'
-                    ? 'border-napari-preview-orange'
-                    : 'border-transparent',
-                ],
-            )}
+            className="flex items-center justify-between mb-10"
+            highlight={isEmptyDescription}
           >
             <Markdown disableHeader placeholder={isEmptyDescription}>
               {plugin?.description ?? EMPTY_DESCRIPTION_PLACEHOLDER}
             </Markdown>
-
-            {isPreview && isEmptyDescription && (
-              <MetadataStatus hasValue={false} />
-            )}
-          </div>
+          </MetadataHighlighter>
         )}
       />
 

--- a/frontend/src/components/PluginDetails/PluginMetadata.tsx
+++ b/frontend/src/components/PluginDetails/PluginMetadata.tsx
@@ -103,7 +103,7 @@ function PluginMetadataBase({
     const { name, value } = metadata[key];
 
     return (
-      <MetadataList inline={inline} title={name} empty={!value}>
+      <MetadataList id={key} inline={inline} title={name} empty={!value}>
         <MetadataListTextItem>{value}</MetadataListTextItem>
       </MetadataList>
     );
@@ -113,7 +113,12 @@ function PluginMetadataBase({
     const { name, value: values } = metadata[key];
 
     return (
-      <MetadataList inline={inline} title={name} empty={isEmpty(values)}>
+      <MetadataList
+        id={key}
+        inline={inline}
+        title={name}
+        empty={isEmpty(values)}
+      >
         {values.map((value) => (
           <MetadataListTextItem key={value}>{value}</MetadataListTextItem>
         ))}

--- a/frontend/src/components/PluginDetails/SupportInfo.tsx
+++ b/frontend/src/components/PluginDetails/SupportInfo.tsx
@@ -50,6 +50,7 @@ interface CommonProps {
 }
 
 interface MetadataLinkItem {
+  id: MetadataKeys;
   text: string;
   href: string;
   icon?: ReactNode;
@@ -71,6 +72,7 @@ export function SupportInfoBase({ className, inline }: SupportInfoBaseProps) {
     const data = metadata[key];
 
     return {
+      id: key,
       text: data.name,
       href: data.value as string,
     };
@@ -104,9 +106,10 @@ export function SupportInfoBase({ className, inline }: SupportInfoBaseProps) {
   );
 
   if (metadata.twitter.value) {
-    const { href } = getLink('twitter');
+    const { id, href } = getLink('twitter');
 
     learnMoreItems.push({
+      id,
       href,
       text: formatTwitter(href),
       icon: <Twitter />,
@@ -136,6 +139,7 @@ export function SupportInfoBase({ className, inline }: SupportInfoBaseProps) {
       )}
     >
       <MetadataList
+        id="authors"
         title={metadata.authors.name}
         empty={isEmpty(metadata.authors.value)}
         inline={inline}
@@ -146,14 +150,19 @@ export function SupportInfoBase({ className, inline }: SupportInfoBaseProps) {
       </MetadataList>
 
       <MetadataList title="Learn more" inline={inline}>
-        {learnMoreItems.map(({ text, ...linkProps }) => (
-          <MetadataListLinkItem key={linkProps.href} {...linkProps}>
+        {learnMoreItems.map(({ text, id, ...linkProps }) => (
+          <MetadataListLinkItem
+            key={linkProps.href + text}
+            id={id}
+            {...linkProps}
+          >
             {text}
           </MetadataListLinkItem>
         ))}
       </MetadataList>
 
       <MetadataList
+        id="sourceCode"
         title={metadata.sourceCode.name}
         empty={!metadata.sourceCode.value}
         inline={inline}

--- a/frontend/src/components/PluginDetails/SupportInfo.tsx
+++ b/frontend/src/components/PluginDetails/SupportInfo.tsx
@@ -118,6 +118,7 @@ export function SupportInfoBase({ className, inline }: SupportInfoBaseProps) {
 
   if (metadata.citations.value) {
     learnMoreItems.push({
+      id: 'citations',
       href: `${metadata.name.value}#${ANCHOR}`,
       text: metadata.citations.name,
       icon: <Quotes />,

--- a/frontend/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
+++ b/frontend/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
@@ -23,9 +23,11 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
         >
           <div
             class="text-sm"
+            id="version"
           >
             <div
               class="space-y-2"
+              id="version"
             >
               <h4
                 class="font-bold whitespace-nowrap"
@@ -46,9 +48,11 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
           </div>
           <div
             class="text-sm"
+            id="releaseDate"
           >
             <div
               class="space-y-2"
+              id="releaseDate"
             >
               <h4
                 class="font-bold whitespace-nowrap"
@@ -69,9 +73,11 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
           </div>
           <div
             class="text-sm"
+            id="firstReleased"
           >
             <div
               class="space-y-2"
+              id="firstReleased"
             >
               <h4
                 class="font-bold whitespace-nowrap"
@@ -92,9 +98,11 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
           </div>
           <div
             class="text-sm"
+            id="developmentStatus"
           >
             <div
               class="space-y-2"
+              id="developmentStatus"
             >
               <h4
                 class="font-bold whitespace-nowrap"
@@ -115,9 +123,11 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
           </div>
           <div
             class="text-sm"
+            id="license"
           >
             <div
               class="space-y-2"
+              id="license"
             >
               <h4
                 class="font-bold whitespace-nowrap"
@@ -213,9 +223,11 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
         >
           <div
             class="text-sm"
+            id="pythonVersion"
           >
             <div
               class="space-y-2"
+              id="pythonVersion"
             >
               <h4
                 class="font-bold whitespace-nowrap"
@@ -236,9 +248,11 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
           </div>
           <div
             class="text-sm"
+            id="operatingSystems"
           >
             <div
               class="space-y-2"
+              id="operatingSystems"
             >
               <h4
                 class="font-bold whitespace-nowrap"
@@ -259,9 +273,11 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
           </div>
           <div
             class="text-sm"
+            id="requirements"
           >
             <div
               class="space-y-2"
+              id="requirements"
             >
               <h4
                 class="font-bold whitespace-nowrap"
@@ -418,6 +434,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
   >
     <div
       class="flex justify-between"
+      id="name"
     >
       <h1
         class="font-bold text-4xl"
@@ -426,7 +443,8 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       </h1>
     </div>
     <div
-      class="flex justify-between items-center mt-6"
+      class="flex justify-between items-center my-6"
+      id="summary"
     >
       <h2
         class="font-semibold text-lg"
@@ -458,9 +476,11 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       >
         <div
           class="text-sm"
+          id="authors"
         >
           <div
             class="space-y-2"
+            id="authors"
           >
             <h4
               class="font-bold whitespace-nowrap"
@@ -496,6 +516,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
             >
               <li
                 class="flex linkItem"
+                id="projectSite"
               >
                 <span
                   class="min-w-4"
@@ -537,6 +558,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
               </li>
               <li
                 class="flex linkItem"
+                id="documentationSite"
               >
                 <span
                   class="min-w-4"
@@ -574,6 +596,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
               </li>
               <li
                 class="flex linkItem"
+                id="supportSite"
               >
                 <span
                   class="min-w-4"
@@ -631,6 +654,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
               </li>
               <li
                 class="flex linkItem"
+                id="reportIssues"
               >
                 <span
                   class="min-w-4"
@@ -673,6 +697,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
               </li>
               <li
                 class="flex linkItem"
+                id="twitter"
               >
                 <span
                   class="min-w-4"
@@ -704,9 +729,11 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
         </div>
         <div
           class="text-sm"
+          id="sourceCode"
         >
           <div
             class="space-y-2"
+            id="sourceCode"
           >
             <h4
               class="font-bold whitespace-nowrap"
@@ -758,9 +785,11 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       >
         <div
           class="text-sm"
+          id="authors"
         >
           <div
             class="space-x-2 space-y-2"
+            id="authors"
           >
             <h4
               class="font-bold whitespace-nowrap inline"
@@ -796,6 +825,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
             >
               <li
                 class="flex linkItem"
+                id="projectSite"
               >
                 <span
                   class="min-w-4"
@@ -837,6 +867,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
               </li>
               <li
                 class="flex linkItem"
+                id="documentationSite"
               >
                 <span
                   class="min-w-4"
@@ -874,6 +905,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
               </li>
               <li
                 class="flex linkItem"
+                id="supportSite"
               >
                 <span
                   class="min-w-4"
@@ -931,6 +963,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
               </li>
               <li
                 class="flex linkItem"
+                id="reportIssues"
               >
                 <span
                   class="min-w-4"
@@ -973,6 +1006,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
               </li>
               <li
                 class="flex linkItem"
+                id="twitter"
               >
                 <span
                   class="min-w-4"
@@ -1004,9 +1038,11 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
         </div>
         <div
           class="text-sm"
+          id="sourceCode"
         >
           <div
             class="space-x-2 space-y-2"
+            id="sourceCode"
           >
             <h4
               class="font-bold whitespace-nowrap inline"
@@ -1052,6 +1088,7 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
     </div>
     <div
       class="flex items-center justify-between mb-10"
+      id="description"
     >
       <div
         class="markdown"
@@ -1481,9 +1518,11 @@ the coverage at least stays the same before you submit a pull request.
         >
           <div
             class="text-sm"
+            id="version"
           >
             <div
               class="space-x-2 space-y-2"
+              id="version"
             >
               <h4
                 class="font-bold whitespace-nowrap inline"
@@ -1504,9 +1543,11 @@ the coverage at least stays the same before you submit a pull request.
           </div>
           <div
             class="text-sm"
+            id="releaseDate"
           >
             <div
               class="space-x-2 space-y-2"
+              id="releaseDate"
             >
               <h4
                 class="font-bold whitespace-nowrap inline"
@@ -1527,9 +1568,11 @@ the coverage at least stays the same before you submit a pull request.
           </div>
           <div
             class="text-sm"
+            id="firstReleased"
           >
             <div
               class="space-x-2 space-y-2"
+              id="firstReleased"
             >
               <h4
                 class="font-bold whitespace-nowrap inline"
@@ -1550,9 +1593,11 @@ the coverage at least stays the same before you submit a pull request.
           </div>
           <div
             class="text-sm"
+            id="developmentStatus"
           >
             <div
               class="space-x-2 space-y-2"
+              id="developmentStatus"
             >
               <h4
                 class="font-bold whitespace-nowrap inline"
@@ -1573,9 +1618,11 @@ the coverage at least stays the same before you submit a pull request.
           </div>
           <div
             class="text-sm"
+            id="license"
           >
             <div
               class="space-x-2 space-y-2"
+              id="license"
             >
               <h4
                 class="font-bold whitespace-nowrap inline"
@@ -1671,9 +1718,11 @@ the coverage at least stays the same before you submit a pull request.
         >
           <div
             class="text-sm"
+            id="pythonVersion"
           >
             <div
               class="space-x-2 space-y-2"
+              id="pythonVersion"
             >
               <h4
                 class="font-bold whitespace-nowrap inline"
@@ -1694,9 +1743,11 @@ the coverage at least stays the same before you submit a pull request.
           </div>
           <div
             class="text-sm"
+            id="operatingSystems"
           >
             <div
               class="space-x-2 space-y-2"
+              id="operatingSystems"
             >
               <h4
                 class="font-bold whitespace-nowrap inline"
@@ -1717,9 +1768,11 @@ the coverage at least stays the same before you submit a pull request.
           </div>
           <div
             class="text-sm"
+            id="requirements"
           >
             <div
               class="space-x-2 space-y-2"
+              id="requirements"
             >
               <h4
                 class="font-bold whitespace-nowrap inline"
@@ -1768,9 +1821,11 @@ the coverage at least stays the same before you submit a pull request.
         >
           <div
             class="text-sm"
+            id="version"
           >
             <div
               class="space-y-2"
+              id="version"
             >
               <h4
                 class="font-bold whitespace-nowrap"
@@ -1791,9 +1846,11 @@ the coverage at least stays the same before you submit a pull request.
           </div>
           <div
             class="text-sm"
+            id="releaseDate"
           >
             <div
               class="space-y-2"
+              id="releaseDate"
             >
               <h4
                 class="font-bold whitespace-nowrap"
@@ -1814,9 +1871,11 @@ the coverage at least stays the same before you submit a pull request.
           </div>
           <div
             class="text-sm"
+            id="firstReleased"
           >
             <div
               class="space-y-2"
+              id="firstReleased"
             >
               <h4
                 class="font-bold whitespace-nowrap"
@@ -1837,9 +1896,11 @@ the coverage at least stays the same before you submit a pull request.
           </div>
           <div
             class="text-sm"
+            id="developmentStatus"
           >
             <div
               class="space-y-2"
+              id="developmentStatus"
             >
               <h4
                 class="font-bold whitespace-nowrap"
@@ -1860,9 +1921,11 @@ the coverage at least stays the same before you submit a pull request.
           </div>
           <div
             class="text-sm"
+            id="license"
           >
             <div
               class="space-y-2"
+              id="license"
             >
               <h4
                 class="font-bold whitespace-nowrap"
@@ -1958,9 +2021,11 @@ the coverage at least stays the same before you submit a pull request.
         >
           <div
             class="text-sm"
+            id="pythonVersion"
           >
             <div
               class="space-y-2"
+              id="pythonVersion"
             >
               <h4
                 class="font-bold whitespace-nowrap"
@@ -1981,9 +2046,11 @@ the coverage at least stays the same before you submit a pull request.
           </div>
           <div
             class="text-sm"
+            id="operatingSystems"
           >
             <div
               class="space-y-2"
+              id="operatingSystems"
             >
               <h4
                 class="font-bold whitespace-nowrap"
@@ -2004,9 +2071,11 @@ the coverage at least stays the same before you submit a pull request.
           </div>
           <div
             class="text-sm"
+            id="requirements"
           >
             <div
               class="space-y-2"
+              id="requirements"
             >
               <h4
                 class="font-bold whitespace-nowrap"

--- a/frontend/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
+++ b/frontend/src/components/PluginDetails/__snapshots__/PluginDetails.test.tsx.snap
@@ -441,6 +441,32 @@ exports[`<PluginDetails /> should match snapshot 1`] = `
       >
         napari-compressed-labels-io
       </h1>
+      <div
+        class="self-end"
+      >
+        <div
+          class="flex items-center justify-center bg-napari-preview-orange w-[0.9375rem] h-[0.9375rem]"
+        >
+          <svg
+            fill="none"
+            height="15"
+            viewBox="0 0 15 15"
+            width="15"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="7.5"
+              cy="11"
+              fill="#fff"
+              r="1"
+            />
+            <path
+              d="M6.5 2H8.5V8H6.5V2Z"
+              fill="#fff"
+            />
+          </svg>
+        </div>
+      </div>
     </div>
     <div
       class="flex justify-between items-center my-6"

--- a/frontend/src/constants/preview.ts
+++ b/frontend/src/constants/preview.ts
@@ -1,0 +1,2 @@
+export const HUB_WIKI_LINK =
+  'https://github.com/chanzuckerberg/napari-hub/blob/main/docs/customizing-plugin-listing.md';

--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -22,6 +22,13 @@ html {
     https://stackoverflow.com/questions/63965489/safari-14-min-max-clamp-not-working-with-vw-and-px-values#comment116930866_65093383
   */
   min-height: 0.0001vw;
+
+  // Scroll behavior for preview page.
+  /* stylelint-disable-next-line selector-no-qualifying-type */
+  &.preview {
+    scroll-behavior: smooth;
+    scroll-padding-top: 4rem;
+  }
 }
 
 body {

--- a/frontend/src/hooks/useIsPreview.ts
+++ b/frontend/src/hooks/useIsPreview.ts
@@ -2,5 +2,5 @@ import { useRouter } from 'next/router';
 
 export function useIsPreview() {
   const router = useRouter();
-  return process.env.PREVIEW && router.pathname.includes('/preview');
+  return !!(process.env.PREVIEW && router.pathname.includes('/preview'));
 }

--- a/frontend/src/hooks/usePreviewClickAway.ts
+++ b/frontend/src/hooks/usePreviewClickAway.ts
@@ -1,4 +1,3 @@
-import { debounce } from 'lodash';
 import { useEffect, useRef } from 'react';
 import { useSnapshot } from 'valtio';
 
@@ -7,8 +6,6 @@ import { previewStore } from '@/store/preview';
 import { setUrlHash } from '@/utils';
 
 import { useIsPreview } from './useIsPreview';
-
-const CLICK_AWAY_DEBOUNCE_MS = 200;
 
 /**
  * Hook that registers a click away listener for a particular metadata field.
@@ -21,15 +18,13 @@ const CLICK_AWAY_DEBOUNCE_MS = 200;
 export function usePreviewClickAway(id: MetadataKeys | undefined) {
   const isPreview = useIsPreview();
   const snap = useSnapshot(previewStore);
-  const handleClickAwayRef = useRef(
-    debounce(() => {
-      // Clear active metadata field for the current metadata if the IDs match.
-      if (previewStore.activeMetadataField === id) {
-        previewStore.activeMetadataField = '';
-        setUrlHash('');
-      }
-    }, CLICK_AWAY_DEBOUNCE_MS),
-  );
+  const handleClickAwayRef = useRef(() => {
+    // Clear active metadata field for the current metadata if the IDs match.
+    if (previewStore.activeMetadataField === id) {
+      previewStore.activeMetadataField = '';
+      setUrlHash('');
+    }
+  });
 
   useEffect(() => {
     const handleClickAway = handleClickAwayRef.current;

--- a/frontend/src/hooks/usePreviewClickAway.ts
+++ b/frontend/src/hooks/usePreviewClickAway.ts
@@ -1,0 +1,49 @@
+import { debounce } from 'lodash';
+import { useEffect, useRef } from 'react';
+import { useSnapshot } from 'valtio';
+
+import { MetadataKeys } from '@/context/plugin';
+import { previewStore } from '@/store/preview';
+import { setUrlHash } from '@/utils';
+
+import { useIsPreview } from './useIsPreview';
+
+const CLICK_AWAY_DEBOUNCE_MS = 200;
+
+/**
+ * Hook that registers a click away listener for a particular metadata field.
+ * The handler is only registered if the `id` matches the current active
+ * metadata ID. When the user clicks outside of the metadata field, the preview
+ * page will automatically defocus the field.
+ *
+ * @param id The ID of the field to check for in the click away handler.
+ */
+export function usePreviewClickAway(id: MetadataKeys | undefined) {
+  const isPreview = useIsPreview();
+  const snap = useSnapshot(previewStore);
+  const handleClickAwayRef = useRef(
+    debounce(() => {
+      // Clear active metadata field for the current metadata if the IDs match.
+      if (previewStore.activeMetadataField === id) {
+        previewStore.activeMetadataField = '';
+        setUrlHash('');
+      }
+    }, CLICK_AWAY_DEBOUNCE_MS),
+  );
+
+  useEffect(() => {
+    const handleClickAway = handleClickAwayRef.current;
+
+    if (
+      isPreview &&
+      snap.activeMetadataField &&
+      id === snap.activeMetadataField
+    ) {
+      setTimeout(() => {
+        document.addEventListener('click', handleClickAway);
+      });
+    }
+
+    return () => document.removeEventListener('click', handleClickAway);
+  }, [id, isPreview, snap.activeMetadataField]);
+}

--- a/frontend/src/pages/_document.tsx
+++ b/frontend/src/pages/_document.tsx
@@ -1,4 +1,5 @@
 import { ServerStyleSheets } from '@material-ui/styles';
+import clsx from 'clsx';
 import Document, {
   DocumentContext,
   Head,
@@ -10,7 +11,7 @@ import Document, {
 import { mediaStyles } from '@/components/common/media';
 import { theme } from '@/theme';
 
-const FAVICON = `${process.env.BASE_PATH}/icons/favicon`;
+const FAVICON = `${process.env.BASE_PATH || ''}/icons/favicon`;
 
 export default class HubDocument extends Document {
   static async getInitialProps(context: DocumentContext) {
@@ -37,8 +38,10 @@ export default class HubDocument extends Document {
   }
 
   render() {
+    const isPreview = !!process.env.PREVIEW;
+
     return (
-      <Html lang="en">
+      <Html className={clsx(isPreview && 'preview')} lang="en">
         <Head>
           <meta name="theme-color" content={theme.palette.primary.main} />
           <link

--- a/frontend/src/pages/preview.tsx
+++ b/frontend/src/pages/preview.tsx
@@ -1,12 +1,14 @@
 import fs from 'fs-extra';
 import { GetStaticPropsResult } from 'next';
 import DefaultErrorPage from 'next/error';
+import { useEffect } from 'react';
 import { DeepPartial } from 'utility-types';
 
 import { PluginDetails } from '@/components/PluginDetails';
 import { DEFAULT_PLUGIN_DATA, DEFAULT_REPO_DATA } from '@/constants/plugin';
-import { PluginStateProvider } from '@/context/plugin';
+import { MetadataKeys, PluginStateProvider } from '@/context/plugin';
 import { PROD } from '@/env';
+import { previewStore } from '@/store/preview';
 import { PluginData } from '@/types';
 import { fetchRepoData, FetchRepoDataResult } from '@/utils';
 
@@ -41,6 +43,14 @@ export async function getStaticProps(): Promise<GetStaticPropsResult<Props>> {
 }
 
 export default function PreviewPage({ plugin, repo, repoFetchError }: Props) {
+  // Set active metadata ID on initial load if the hash is already set.
+  useEffect(() => {
+    const id = window.location.hash.replace('#', '');
+    if (id) {
+      previewStore.activeMetadataField = id as MetadataKeys;
+    }
+  }, []);
+
   // Return 404 page in production or if the plugin path is not defined.
   if (PROD || !PLUGIN_PATH) {
     return <DefaultErrorPage statusCode={404} />;

--- a/frontend/src/store/preview.ts
+++ b/frontend/src/store/preview.ts
@@ -1,0 +1,11 @@
+import { proxy } from 'valtio';
+
+import { MetadataKeys } from '@/context/plugin';
+
+export const previewStore = proxy({
+  /**
+   * Currently focused metadata field. This is used for rendering the focus
+   * border and opening the tooltip.
+   */
+  activeMetadataField: '' as MetadataKeys | '',
+});

--- a/frontend/src/store/search/queryParameters.ts
+++ b/frontend/src/store/search/queryParameters.ts
@@ -2,7 +2,7 @@ import { set } from 'lodash';
 import { snapshot, subscribe } from 'valtio';
 
 import { BEGINNING_PAGE, RESULTS_PER_PAGE } from '@/constants/search';
-import { isSearchPage } from '@/utils';
+import { isSearchPage, replaceUrlState } from '@/utils';
 
 import { SearchQueryParams, SearchSortType } from './constants';
 import { searchFormStore } from './form.store';
@@ -189,20 +189,8 @@ function updateQueryParameters(initialLoad?: boolean) {
     params.set(SearchQueryParams.Page, String(searchFormStore.page));
   }
 
-  const nextUrl = url.href;
-  if (window.location.href !== nextUrl) {
-    window.history.replaceState(
-      {
-        // Pass existing history state because next.js stores data in here.
-        // Without, the back / forward functionality will be broken:
-        // https://github.com/vercel/next.js/discussions/18072
-        ...window.history.state,
-        as: nextUrl,
-        url: nextUrl,
-      },
-      '',
-      nextUrl,
-    );
+  if (window.location.href !== url.href) {
+    replaceUrlState(url);
   }
 }
 

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -16,6 +16,7 @@ const colors = {
   previewGray: '#ededed',
   previewOrange: '#d85e38',
   previewOrangeOverlay: 'rgba(216, 94, 56, 0.1)',
+  previewOrangeOverlayActive: 'rgba(216, 94, 56, 0.15)',
 };
 
 const breakpoints = {

--- a/frontend/src/utils/url.ts
+++ b/frontend/src/utils/url.ts
@@ -1,3 +1,5 @@
+import { isString } from 'lodash';
+
 /**
  * Checks if the string is an external URL. This works by using the value to
  * create a URL object. URL objects will throw errors for relative URLs if a
@@ -33,4 +35,37 @@ export function createUrl(urlOrPath: string, baseUrl?: string): URL {
   }
 
   return new URL(urlOrPath, base);
+}
+
+/**
+ * Wrapper over `history.replaceState()` that also includes history data
+ * required for the Next.js router to function correctly.
+ * https://github.com/vercel/next.js/discussions/18072
+ *
+ * @param nextUrl The next URL to replace the current one.
+ */
+export function replaceUrlState(nextUrl: string | URL) {
+  const url = isString(nextUrl) ? nextUrl : nextUrl.href;
+
+  window.history.replaceState(
+    {
+      ...window.history.state,
+      url,
+      as: url,
+    },
+    '',
+    url,
+  );
+}
+
+/**
+ * Replaces the current URL with a new URL with the hash updated to the value of `hash`.
+ *
+ * @param hash The new URL hash.
+ */
+export function setUrlHash(hash: string | undefined | null) {
+  // Replace current URL with selected key.
+  const nextUrl = createUrl(window.location.href);
+  nextUrl.hash = hash ?? '';
+  replaceUrlState(nextUrl);
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -46,6 +46,8 @@ module.exports = {
         'napari-preview-gray': colors.previewGray,
         'napari-preview-orange': colors.previewOrange,
         'napari-preview-orange-overlay': colors.previewOrangeOverlay,
+        'napari-preview-orange-overlay-active':
+          colors.previewOrangeOverlayActive,
       },
 
       width: (theme) => ({


### PR DESCRIPTION
## Description

Implements the scroll-to-metadata feature on the preview page. This works by making the following key changes:'

1. Adds IDs to metadata list components, allowing us to create anchor links for specific metadata fields. The anchor links allows us to share a specific metadata field in a URL and allows us to use the native browser scrolling functionality for anchor links.
2. Adds hook `usePreviewClickAway()` to defocusing the metadata field when the user clicks outside of it.
3. Implements `<MetadataHighlighter />`, a reusable component that handles rendering the overlay and also switching to a button when so that the user can click the metadata to show / hide the tooltip. 

## Demo

- All empty data: https://napari-hub-preview-page-scroll.vercel.app
- Partially empty data: https://napari-hub-page-scroll-partial-data.vercel.app/

### Clicking on metadata show / hide the tooltip

https://user-images.githubusercontent.com/2176050/139308927-b815c16d-2960-4038-bb8b-06d0092a1ffb.mp4

### Opening anchor link in another tab will scroll to the metadata

https://user-images.githubusercontent.com/2176050/139309408-dced7227-9fa7-4d21-b2c9-2e58e2e8bbe7.mp4

### Click to scroll to metadata

https://user-images.githubusercontent.com/70177777/139918191-cf4c78f9-3964-408f-b480-895290dee692.mov

https://user-images.githubusercontent.com/2176050/139309866-af401e90-416c-430e-a7b6-252e9b2f9ce3.mp4