### PR TITLE
preview action repo check

### DIFF
--- a/backend/preview/_tests/test_preview_meta.py
+++ b/backend/preview/_tests/test_preview_meta.py
@@ -61,6 +61,7 @@ def test_parse_preview_matches_hub(tmpdir):
     hub_metadata = json.loads(requests.get(hub_plugin_url).text)
 
     # get preview metadata for example-plugin
+    os.environ["GITHUB_REPOSITORY"] = "DragaDoncila/example-plugin"
     get_plugin_preview(code_plugin_url, dest_dir)
     with open(os.path.join(dest_dir, 'preview_meta.json')) as f:
         preview_meta = json.load(f)

--- a/backend/preview/preview.py
+++ b/backend/preview/preview.py
@@ -45,8 +45,8 @@ def get_plugin_preview(repo_pth: str, dest_dir: str, is_local: bool = False, bra
     if action_github_repo:
         action_repo_url = f'https://github.com/{action_github_repo}'
         meta.update(get_github_metadata(action_repo_url, branch=branch))
-        if "code_repository" in meta and action_github_repo != meta["code_repository"]:
-            meta['action_repo'] = action_github_repo
+        if "code_repository" in meta and action_repo_url != meta["code_repository"]:
+            meta['action_repository'] = action_repo_url
     elif "code_repository" in meta:
         meta.update(get_github_metadata(meta["code_repository"], branch=branch))
 

--- a/backend/preview/preview.py
+++ b/backend/preview/preview.py
@@ -41,9 +41,14 @@ def get_plugin_preview(repo_pth: str, dest_dir: str, is_local: bool = False, bra
     meta = parse_meta(wheel_pth)
 
     # parse additional metadata from URL
-    if meta.get("code_repository"):
-        extra_meta = get_github_metadata(meta["code_repository"], branch=branch)
-        meta.update(extra_meta)
+    action_github_repo = os.getenv("GITHUB_REPOSITORY")
+    if action_github_repo:
+        action_repo_url = f'https://github.com/{action_github_repo}'
+        meta.update(get_github_metadata(action_repo_url, branch=branch))
+        if "code_repository" in meta and action_github_repo != meta["code_repository"]:
+            meta['action_repo'] = action_github_repo
+    elif "code_repository" in meta:
+        meta.update(get_github_metadata(meta["code_repository"], branch=branch))
 
     # get release date and first released
     get_pypi_date_meta(meta)


### PR DESCRIPTION
check if action repo and code repository has inconsistency
Use action repo in GitHub metadata querying
But should warn the user of this potential error

tested on https://github.com/potating-potato/napari-demo/pull/3/files
generated the correct preview page https://preview.napari-hub.org/potating-potato/napari-demo/3 
(notice that the source code repo is clearly wrong as /typo, but this doesn't stop the preview page from using the new description)