### PR TITLE
Category UI state

### DIFF
--- a/frontend/src/context/plugin.tsx
+++ b/frontend/src/context/plugin.tsx
@@ -2,7 +2,12 @@ import { isArray } from 'lodash';
 import { createContext, ReactNode, useContext } from 'react';
 import { DeepPartial } from 'utility-types';
 
-import { PluginData, PluginRepoData, PluginRepoFetchError } from '@/types';
+import {
+  HubDimension,
+  PluginData,
+  PluginRepoData,
+  PluginRepoFetchError,
+} from '@/types';
 import { formatDate } from '@/utils';
 
 /**
@@ -61,6 +66,10 @@ export function usePluginState(): PluginState {
  */
 export function usePluginMetadata() {
   const { plugin } = usePluginState();
+
+  function getCategoryValue(dimension: HubDimension) {
+    return plugin?.category ? plugin.category[dimension] ?? [] : [];
+  }
 
   return {
     name: {
@@ -185,16 +194,26 @@ export function usePluginMetadata() {
       value: plugin?.citations,
     },
 
-    category: {
-      value: plugin?.category || undefined,
+    workflowSteps: {
+      name: 'Workflow step',
+      value: getCategoryValue('Workflow step'),
     },
 
-    categoryHierarchy: {
-      value: plugin?.category_hierarchy || undefined,
+    imageModality: {
+      name: 'Image modality',
+      value: getCategoryValue('Image modality'),
+    },
+
+    supportedData: {
+      name: 'Supported data',
+      value: getCategoryValue('Supported data'),
     },
   };
 }
 
 export type Metadata = ReturnType<typeof usePluginMetadata>;
 
-export type MetadataKeys = keyof Metadata;
+export type MetadataKeys = keyof Omit<
+  Metadata,
+  'workflowSteps' | 'imageModality' | 'supportedData'
+>;

--- a/frontend/src/context/plugin.tsx
+++ b/frontend/src/context/plugin.tsx
@@ -184,6 +184,14 @@ export function usePluginMetadata() {
       name: 'Citation information',
       value: plugin?.citations,
     },
+
+    category: {
+      value: plugin?.category || undefined,
+    },
+
+    categoryHierarchy: {
+      value: plugin?.category_hierarchy || undefined,
+    },
   };
 }
 

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -8,6 +8,7 @@ import { ErrorMessage } from '@/components/common/ErrorMessage';
 import { PluginSearch } from '@/components/PluginSearch';
 import { useLoadingState } from '@/context/loading';
 import {
+  initCategoryFilters,
   initOsiApprovedLicenseSet,
   initPageResetListener,
   initSearchEngine,
@@ -51,6 +52,7 @@ export default function Home({ error, index, licenses }: Props) {
 
     if (index) {
       initSearchEngine(index);
+      initCategoryFilters(index);
     }
 
     if (licenses) {

--- a/frontend/src/store/search/filters.test.ts
+++ b/frontend/src/store/search/filters.test.ts
@@ -2,7 +2,12 @@ import { defaultsDeep } from 'lodash';
 import { DeepPartial } from 'utility-types';
 
 import pluginIndex from '@/fixtures/index.json';
-import { DeriveGet, PluginIndexData } from '@/types';
+import {
+  DeriveGet,
+  PluginCategory,
+  PluginCategoryHierarchy,
+  PluginIndexData,
+} from '@/types';
 
 import { filterResults } from './filters';
 import { DEFAULT_STATE, SearchFormStore } from './form.store';
@@ -49,6 +54,23 @@ function getLicenseResults(...licenses: string[]): SearchResult[] {
   const plugins = licenses.map((license) => ({
     ...pluginIndex[0],
     license,
+  }));
+
+  return getResults(...plugins);
+}
+
+interface CategoryResultData {
+  category?: PluginCategory;
+  category_hierarchy?: PluginCategoryHierarchy;
+}
+
+function getCategoryResults(
+  ...categoryData: CategoryResultData[]
+): SearchResult[] {
+  const plugins = categoryData.map(({ category, category_hierarchy }) => ({
+    ...pluginIndex[0],
+    category,
+    category_hierarchy,
   }));
 
   return getResults(...plugins);
@@ -237,6 +259,117 @@ describe('filterResults()', () => {
         results,
       );
       expect(filtered).toEqual(getLicenseResults('valid'));
+    });
+  });
+
+  describe('filter by workflow step', () => {
+    const results = getCategoryResults(
+      {
+        category: {
+          'Workflow step': ['foo', 'bar'],
+        },
+      },
+      {
+        category: {
+          'Workflow step': ['bar'],
+        },
+      },
+      {
+        category: {
+          'Image modality': ['foo', 'bar'],
+        },
+      },
+    );
+
+    it('should allow all plugins when no filters are enabled', () => {
+      const filtered = filterResults(createMockFilterGet(), results);
+      expect(filtered).toEqual(results);
+    });
+
+    it('should filter plugins with matching workflow steps', () => {
+      const filtered = filterResults(
+        createMockFilterGet({
+          workflowStep: {
+            bar: true,
+          },
+        }),
+        results,
+      );
+      expect(filtered).toEqual(results.slice(0, 2));
+    });
+  });
+
+  describe('filter by image modality', () => {
+    const results = getCategoryResults(
+      {
+        category: {
+          'Workflow step': ['foo', 'bar'],
+        },
+      },
+      {
+        category: {
+          'Workflow step': ['bar'],
+        },
+      },
+      {
+        category: {
+          'Image modality': ['foo', 'bar'],
+        },
+      },
+    );
+
+    it('should allow all plugins when no filters are enabled', () => {
+      const filtered = filterResults(createMockFilterGet(), results);
+      expect(filtered).toEqual(results);
+    });
+
+    it('should filter plugins with matching workflow steps', () => {
+      const filtered = filterResults(
+        createMockFilterGet({
+          imageModality: {
+            bar: true,
+          },
+        }),
+        results,
+      );
+      expect(filtered).toEqual(results.slice(2, 3));
+    });
+  });
+
+  describe('filter by supported data', () => {
+    const results = getCategoryResults(
+      {
+        category: {
+          'Supported data': ['2d', '3d'],
+        },
+      },
+      {
+        category: {
+          'Workflow step': ['bar'],
+        },
+      },
+      {
+        category: {
+          'Supported data': ['3d'],
+        },
+      },
+    );
+
+    it('should allow all plugins when no filters are enabled', () => {
+      const filtered = filterResults(createMockFilterGet(), results);
+      expect(filtered).toEqual(results);
+    });
+
+    it('should filter plugins with matching workflow steps', () => {
+      const filtered = filterResults(
+        createMockFilterGet({
+          supportedData: {
+            '3d': true,
+          },
+        }),
+        results,
+      );
+      expect(filtered).toEqual([results[0], results[2]]);
     });
   });
 });

--- a/frontend/src/store/search/filters.test.ts
+++ b/frontend/src/store/search/filters.test.ts
@@ -262,28 +262,30 @@ describe('filterResults()', () => {
     });
   });
 
-  describe('filter by workflow step', () => {
-    const results = getCategoryResults(
-      {
-        category: {
-          'Workflow step': ['foo', 'bar'],
-        },
+  const categoryResults = getCategoryResults(
+    {
+      category: {
+        'Supported data': ['2d', '3d'],
+        'Workflow step': ['foo', 'bar'],
       },
-      {
-        category: {
-          'Workflow step': ['bar'],
-        },
+    },
+    {
+      category: {
+        'Workflow step': ['bar'],
       },
-      {
-        category: {
-          'Image modality': ['foo', 'bar'],
-        },
+    },
+    {
+      category: {
+        'Image modality': ['foo', 'bar'],
+        'Supported data': ['3d'],
       },
-    );
+    },
+  );
 
+  describe('filter by workflow step', () => {
     it('should allow all plugins when no filters are enabled', () => {
-      const filtered = filterResults(createMockFilterGet(), results);
-      expect(filtered).toEqual(results);
+      const filtered = filterResults(createMockFilterGet(), categoryResults);
+      expect(filtered).toEqual(categoryResults);
     });
 
     it('should filter plugins with matching workflow steps', () => {
@@ -293,34 +295,16 @@ describe('filterResults()', () => {
             bar: true,
           },
         }),
-        results,
+        categoryResults,
       );
-      expect(filtered).toEqual(results.slice(0, 2));
+      expect(filtered).toEqual(categoryResults.slice(0, 2));
     });
   });
 
   describe('filter by image modality', () => {
-    const results = getCategoryResults(
-      {
-        category: {
-          'Workflow step': ['foo', 'bar'],
-        },
-      },
-      {
-        category: {
-          'Workflow step': ['bar'],
-        },
-      },
-      {
-        category: {
-          'Image modality': ['foo', 'bar'],
-        },
-      },
-    );
-
     it('should allow all plugins when no filters are enabled', () => {
-      const filtered = filterResults(createMockFilterGet(), results);
-      expect(filtered).toEqual(results);
+      const filtered = filterResults(createMockFilterGet(), categoryResults);
+      expect(filtered).toEqual(categoryResults);
     });
 
     it('should filter plugins with matching workflow steps', () => {
@@ -330,34 +314,16 @@ describe('filterResults()', () => {
             bar: true,
           },
         }),
-        results,
+        categoryResults,
       );
-      expect(filtered).toEqual(results.slice(2, 3));
+      expect(filtered).toEqual(categoryResults.slice(2, 3));
     });
   });
 
   describe('filter by supported data', () => {
-    const results = getCategoryResults(
-      {
-        category: {
-          'Supported data': ['2d', '3d'],
-        },
-      },
-      {
-        category: {
-          'Workflow step': ['bar'],
-        },
-      },
-      {
-        category: {
-          'Supported data': ['3d'],
-        },
-      },
-    );
-
     it('should allow all plugins when no filters are enabled', () => {
-      const filtered = filterResults(createMockFilterGet(), results);
-      expect(filtered).toEqual(results);
+      const filtered = filterResults(createMockFilterGet(), categoryResults);
+      expect(filtered).toEqual(categoryResults);
     });
 
     it('should filter plugins with matching workflow steps', () => {
@@ -367,9 +333,9 @@ describe('filterResults()', () => {
             '3d': true,
           },
         }),
-        results,
+        categoryResults,
       );
-      expect(filtered).toEqual([results[0], results[2]]);
+      expect(filtered).toEqual([categoryResults[0], categoryResults[2]]);
     });
   });
 });

--- a/frontend/src/store/search/filters.test.ts
+++ b/frontend/src/store/search/filters.test.ts
@@ -316,7 +316,7 @@ describe('filterResults()', () => {
         }),
         categoryResults,
       );
-      expect(filtered).toEqual(categoryResults.slice(2, 3));
+      expect(filtered).toEqual([categoryResults[2]]);
     });
   });
 

--- a/frontend/src/store/search/form.store.ts
+++ b/frontend/src/store/search/form.store.ts
@@ -1,5 +1,4 @@
 import { over } from 'lodash';
-import { DeepPartial } from 'utility-types';
 import { proxy, ref } from 'valtio';
 import { derive, subscribeKey } from 'valtio/utils';
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -8,7 +8,6 @@ export interface PluginAuthor {
 /**
  * Citation formats.
  * */
-
 export interface CitationData {
   citation: string;
   RIS: string;
@@ -16,11 +15,25 @@ export interface CitationData {
   APA: string;
 }
 
+export type HubDimension =
+  | 'Workflow step'
+  | 'Supported data'
+  | 'Image modality';
+
+export type PluginCategory = Partial<{
+  [key in HubDimension]: string[];
+}>;
+
+export type PluginCategoryHierarchy = Partial<{
+  [key in HubDimension]: string[][];
+}>;
+
 /**
  * Plugin data used for indexing. This is a subset of the full plugin data.
  */
 export interface PluginIndexData {
   authors: PluginAuthor[] | '';
+  category?: PluginCategory | '';
   description_content_type: string;
   description: string;
   description_text: string;
@@ -39,6 +52,7 @@ export interface PluginIndexData {
  * Interface for plugin data response from backend.
  */
 export interface PluginData extends PluginIndexData {
+  category_hierarchy?: PluginCategoryHierarchy;
   citations?: CitationData | null;
   code_repository: string;
   documentation: string;


### PR DESCRIPTION
Sets up the UI state necessary for storing category and category hierarchy data from the backend, and reading that data for filtering and rendering.

The TypeScript interfaces for the category data were taken from the `napari-demo` plugin:

https://api.staging.napari-hub.org/plugins/napari-demo

```json
  "category": {
    "Supported data": [
      "2D", 
      "3D"
    ], 
    "Workflow step": [
      "Image Segmentation", 
      "Image annotation"
    ]
  }, 
  "category_hierarchy": {
    "Supported data": [
      [
        "2D"
      ], 
      [
        "3D"
      ]
    ], 
    "Workflow step": [
      [
        "Image Segmentation", 
        "Manual segmentation"
      ], 
      [
        "Image annotation", 
        "Dense image annotation", 
        "Manual segmentation"
      ], 
      [
        "Image Segmentation", 
        "Semi-automatic segmentation"
      ]
    ]
  }, 
```