### PR TITLE
attempt to read fork PR number when pull request does not present

### DIFF
--- a/backend/api/model.py
+++ b/backend/api/model.py
@@ -235,7 +235,14 @@ def move_artifact_to_s3(payload, client):
     repo = get_attribute(payload, ["repository", "name"])
     pull_request_number = get_attribute(payload, ['workflow_run', 'pull_requests', 0, 'number'])
     if not pull_request_number:
-        return
+        repo = client.repository(owner, repo)
+        head_owner = get_attribute(payload, ['workflow_run', 'head_repository', 'owner', 'login'])
+        head_branch = get_attribute(payload, ['workflow_run', 'head_branch'])
+        pull_requests = list(repo.pull_requests(head=f'{head_owner}:{head_branch}'))
+        if len(pull_requests) == 1:
+            pull_request_number = pull_requests[0].number
+        else:
+            return
 
     artifact_url = get_attribute(payload, ["workflow_run", "artifacts_url"])
     if artifact_url:


### PR DESCRIPTION
attempt to read fork PR number when pull request does not present

This fix is to address pull_requests being none in the payload when the PR is from a fork