### PR TITLE
correct preview project url to use Bug Tracker from setup configuration

### DIFF
--- a/backend/preview/preview.py
+++ b/backend/preview/preview.py
@@ -149,7 +149,7 @@ def parse_meta(pkg_pth):
     project_url_meta = {
         "documentation": "Documentation",
         "support": "User Support",
-        "report_issues": "Report Issues",
+        "report_issues": "Bug Tracker",
         "twitter": "Twitter",
         "code_repository": "Source Code",
     }


### PR DESCRIPTION
according to our own [documentation](https://github.com/chanzuckerberg/napari-hub/blob/main/docs/customizing-plugin-listing.md), we first look at the .napari/config.yml, and use Report Issues if present, if not we would read the setup config Bug Tracker