### PR TITLE
More robust value checking for preview metadata

### DIFF
--- a/frontend/src/components/AppBar/metadataPreview.hooks.ts
+++ b/frontend/src/components/AppBar/metadataPreview.hooks.ts
@@ -1,4 +1,4 @@
-import { isEmpty } from 'lodash';
+import { isArray, isEmpty, isString } from 'lodash';
 
 import { MetadataKeys, usePluginMetadata } from '@/context/plugin';
 
@@ -26,11 +26,20 @@ export function useMetadataSections(): MetadataSection[] {
   function getFields(...keys: MetadataKeys[]) {
     return keys.map((key) => {
       const data = metadata[key];
+      let hasValue = false;
+
+      if (isString(data.value)) {
+        hasValue = !isEmpty(data.value.trim());
+      } else if (isArray(data.value)) {
+        hasValue = data.value.every((value) => !isEmpty(value));
+      } else {
+        hasValue = !!data.value;
+      }
 
       return {
+        hasValue,
         id: key,
         name: hasPreviewName(data) ? data.previewName : data.name,
-        hasValue: !isEmpty(data.value),
       };
     });
   }

--- a/frontend/src/components/AppBar/metadataPreview.hooks.ts
+++ b/frontend/src/components/AppBar/metadataPreview.hooks.ts
@@ -29,11 +29,17 @@ export function useMetadataSections(): MetadataSection[] {
       let hasValue = false;
 
       if (isString(data.value)) {
+        // If value is string, check if the trimmed string is empty.
         hasValue = !isEmpty(data.value.trim());
       } else if (isArray(data.value)) {
-        hasValue = data.value.every((value) => !isEmpty(value));
+        // If value is array, filter out empty strings after trimming, and check
+        // if the array is empty.
+        hasValue = !isEmpty(
+          data.value.filter((value) => !isEmpty(value.trim())),
+        );
       } else {
-        hasValue = !!data.value;
+        // If value is something else, just check if it's empty.
+        hasValue = !isEmpty(data.value);
       }
 
       return {


### PR DESCRIPTION
## Description

Closes #339

This fixes an issue with newline characters displaying incorrect information for the metadata panel. This works by trimming the metadata strings so that newline (and any other whitespace characters) do not contribute to the metadata value checking.

## Demo

PR: https://github.com/chanzuckerberg/napari-demo/pull/9
Preview Page: https://preview.napari-hub.org/chanzuckerberg/napari-demo/9