### PR TITLE
Update preview action used to the latest release

### DIFF
--- a/docs/setting-up-preview.md
+++ b/docs/setting-up-preview.md
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: napari hub Preview Page Builder
-        uses: chanzuckerberg/napari-hub-preview-action@v0.1.4
+        uses: chanzuckerberg/napari-hub-preview-action@v0.1.5
         with:
           hub-ref: main
 ```


### PR DESCRIPTION
Having confirmed the latest release of the preview action fixes the build fails on Mac, this PR updates the docs example workflow snippet to use the latest version.