### PR TITLE
Categories filter feature flag

### DIFF
--- a/frontend/src/components/PluginSearch/PluginFilterByForm.tsx
+++ b/frontend/src/components/PluginSearch/PluginFilterByForm.tsx
@@ -6,6 +6,7 @@ import { Accordion } from '@/components/common/Accordion';
 import { Media } from '@/components/common/media';
 import { useSearchStore } from '@/store/search/context';
 import { FilterKey } from '@/store/search/search.store';
+import { isFeatureFlagEnabled } from '@/utils/featureFlags';
 
 import { PluginComplexFilter } from './PluginComplexFilter';
 
@@ -47,12 +48,18 @@ function ClearAllButton({ filters, filterType }: Props) {
   );
 }
 
+function getLabel(filterType: FilterType) {
+  return isFeatureFlagEnabled('categoryFilters')
+    ? FILTER_LABEL_MAP[filterType]
+    : 'Filter';
+}
+
 /**
  * Component for the form for selecting the plugin filter type.
  */
 function FilterForm(props: Props) {
   const { filters, filterType } = props;
-  const label = FILTER_LABEL_MAP[filterType];
+  const label = getLabel(filterType);
 
   return (
     <div
@@ -92,7 +99,7 @@ function FilterForm(props: Props) {
 export function PluginFilterByForm(props: Props) {
   const form = <FilterForm {...props} />;
   const { filterType } = props;
-  const label = FILTER_LABEL_MAP[filterType];
+  const label = getLabel(filterType);
 
   return (
     <>

--- a/frontend/src/components/PluginSearch/PluginSearchControls.tsx
+++ b/frontend/src/components/PluginSearch/PluginSearchControls.tsx
@@ -3,6 +3,8 @@ import clsx from 'clsx';
 import { AnimateSharedLayout, motion } from 'framer-motion';
 
 import { Media } from '@/components/common/media';
+import { FilterKey } from '@/store/search/search.store';
+import { isFeatureFlagEnabled } from '@/utils/featureFlags';
 
 import { PluginFilterByForm } from './PluginFilterByForm';
 import { PluginSortByForm } from './PluginSortByForm';
@@ -16,6 +18,15 @@ export function PluginSearchControls() {
       <Divider layout component={motion.div} className="bg-black h-1" />
     </Media>
   );
+
+  const isCategoryFiltersEnabled = isFeatureFlagEnabled('categoryFilters');
+  const requirementFilters: FilterKey[] = [];
+
+  if (isCategoryFiltersEnabled) {
+    requirementFilters.push('supportedData');
+  }
+
+  requirementFilters.push('pythonVersions', 'operatingSystems', 'license');
 
   return (
     <aside
@@ -32,24 +43,23 @@ export function PluginSearchControls() {
 
         {divider}
 
-        <motion.div layout>
-          <PluginFilterByForm
-            filterType="category"
-            filters={['workflowStep', 'imageModality']}
-          />
-        </motion.div>
+        {isCategoryFiltersEnabled && (
+          <>
+            <motion.div layout>
+              <PluginFilterByForm
+                filterType="category"
+                filters={['workflowStep', 'imageModality']}
+              />
+            </motion.div>
 
-        {divider}
+            {divider}
+          </>
+        )}
 
         <motion.div layout>
           <PluginFilterByForm
             filterType="requirement"
-            filters={[
-              'supportedData',
-              'pythonVersions',
-              'operatingSystems',
-              'license',
-            ]}
+            filters={requirementFilters}
           />
         </motion.div>
       </AnimateSharedLayout>

--- a/frontend/src/utils/featureFlags.ts
+++ b/frontend/src/utils/featureFlags.ts
@@ -1,0 +1,78 @@
+import { PROD, STAGING } from '@/env';
+
+import { createUrl } from '.';
+
+export type FeatureFlagEnvironment = 'dev' | 'staging' | 'prod';
+
+export interface FeatureFlag {
+  environments: FeatureFlagEnvironment[];
+}
+
+/**
+ * Helper to preserve the keys in the type while forcing each value to be of
+ * type `FeatureFlag`.
+ */
+function createFeatureFlags<T>(flags: { [key in keyof T]: FeatureFlag }) {
+  return flags;
+}
+
+export const FEATURE_FLAGS = createFeatureFlags({
+  categoryFilters: {
+    environments: ['dev'],
+  },
+});
+
+/**
+ * Type storing all available feature flag keys.
+ */
+export type FeatureFlagKey = keyof typeof FEATURE_FLAGS;
+
+const ENABLE_FEATURE_FLAG_QUERY_PARAM = 'enable-feature';
+const DISABLE_FEATURE_FLAG_QUERY_PARAM = 'disable-feature';
+
+/**
+ * Helper that checks if a feature flag is enabled using the feature flag key. A
+ * flag can be enabled in two ways:
+ *
+ * - Local storage
+ * - Environment
+ *
+ * Local storage will always override whatever is in the environment.
+ *
+ * @param key The feature flag key.
+ * @returns True or false depending on if the feature flag is enabled.
+ */
+export function isFeatureFlagEnabled(key: FeatureFlagKey): boolean {
+  const flag = FEATURE_FLAGS[key];
+
+  // If the flag is enabled / disabled in a URL parameter, then override the
+  // environment check.
+  if (process.browser) {
+    const params = createUrl(window.location.href).searchParams;
+
+    const enabledFeatures = new Set(
+      params.getAll(ENABLE_FEATURE_FLAG_QUERY_PARAM),
+    );
+    const disabledFetures = new Set(
+      params.getAll(DISABLE_FEATURE_FLAG_QUERY_PARAM),
+    );
+
+    if (enabledFeatures.has(key)) {
+      return true;
+    }
+
+    if (disabledFetures.has(key)) {
+      return false;
+    }
+  }
+
+  if (PROD) {
+    return flag.environments.includes('prod');
+  }
+
+  if (STAGING) {
+    return flag.environments.includes('staging');
+  }
+
+  return flag.environments.includes('dev');
+}


### PR DESCRIPTION
## Description

Implements basic feature flagging architecture for hiding / showing features. This will allow us to merge code for new features into production without releasing the feature to the public.

The only feature flag I added is `categoryFilters`, which will hide the category filter components added in #343. The timeline for our current release schedule plans for us to release the category filters on January 13th, so the feature will be disabled for `staging` and `prod` until then.

## Enabling / Disabling a feature flag

Feature flags can be enabled by adding new environments to the `FEATURE_FLAGS` constant, or by using the query parameters `enable-feature=<feature-key` and `disable-feature=<feature-key>`.

## Future Work

The Aspen team is looking into integrating with a full fledged feature flag (FFFF) service that we may want to look into in the future. I've made this implementation as simple and lightweight as possible so it would be easy to refactor if we do end up switching.

## Demo

### Category filters enabled

https://filter-ff-frontend.dev.imaging.cziscience.com/?enable-feature=categoryFilters

<img width="250" src="https://user-images.githubusercontent.com/2176050/144331015-b5f9def4-bcd1-459c-97e4-3bb21dd011f4.png">

### Category filters disabled

https://filter-ff-frontend.dev.imaging.cziscience.com/?disable-feature=categoryFilters

<img width="250" src="https://user-images.githubusercontent.com/2176050/144332989-0a6473c2-0fd6-4739-b348-4173499ad17a.png">
