### PR TITLE
Fix Plausible events not sending

### DIFF
--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/store/search/form.store';
 import { initQueryParameterListener } from '@/store/search/queryParameters';
 import { SpdxLicenseData, SpdxLicenseResponse } from '@/store/search/types';
+import { usePlausibleSearchEvents } from '@/store/search/usePlausibleSearchEvents';
 import { PluginIndexData } from '@/types';
 
 interface Props {
@@ -66,6 +67,8 @@ export default function Home({ error, index, licenses }: Props) {
 
     return unsubscribe as () => void;
   }, [index, isLoading, licenses]);
+
+  usePlausibleSearchEvents();
 
   return (
     <>

--- a/frontend/src/store/search/usePlausibleSearchEvents.ts
+++ b/frontend/src/store/search/usePlausibleSearchEvents.ts
@@ -1,0 +1,48 @@
+import { over } from 'lodash';
+import { useEffect } from 'react';
+import { subscribeKey } from 'valtio/utils';
+
+import { usePlausible } from '@/hooks';
+
+import { SearchFormStore, searchFormStore } from './form.store';
+
+type Unsubscriber = () => void;
+
+/**
+ * Hook that sends plausible events when portions of the Valtio state changes.
+ */
+export function usePlausibleSearchEvents() {
+  const plausible = usePlausible();
+
+  useEffect(() => {
+    const unsubscribers: Unsubscriber[] = [
+      // Search events.
+      subscribeKey(searchFormStore.search, 'query', () => plausible('Search')),
+
+      // Sort events.
+      subscribeKey(searchFormStore, 'sort', (sortType) =>
+        plausible('Sort', { by: sortType }),
+      ),
+    ];
+
+    // Add subscribers for filter events.
+    for (const key of Object.keys(searchFormStore.filters)) {
+      const filterKey = key as keyof SearchFormStore['filters'];
+      const filterState = searchFormStore.filters[filterKey];
+
+      for (const stateKey of Object.keys(filterState)) {
+        unsubscribers.push(
+          subscribeKey(filterState, stateKey as never, (checked: boolean) =>
+            plausible('Filter', {
+              checked,
+              field: filterKey,
+              value: stateKey,
+            }),
+          ),
+        );
+      }
+    }
+
+    return over(unsubscribers) as () => void;
+  }, [plausible]);
+}


### PR DESCRIPTION
## Description

The state management refactor PR #254 unfortunately didn't include the Plausible events, so this PR re-adds them using Valtio subscribers.

## Demo

![image](https://user-images.githubusercontent.com/2176050/144505135-5010c029-c82d-4c77-af7d-b58073dbbea9.png)
