### PR TITLE
Fixes color for filter pills

### DIFF
--- a/frontend/src/components/PluginSearch/PluginFilterByForm.tsx
+++ b/frontend/src/components/PluginSearch/PluginFilterByForm.tsx
@@ -6,7 +6,7 @@ import { Accordion } from '@/components/common/Accordion';
 import { Media } from '@/components/common/media';
 import { useSearchStore } from '@/store/search/context';
 import { FilterKey } from '@/store/search/search.store';
-import { isFeatureFlagEnabled } from '@/utils/featureFlags';
+import { useIsFeatureFlagEnabled } from '@/utils/featureFlags';
 
 import { PluginComplexFilter } from './PluginComplexFilter';
 
@@ -48,8 +48,8 @@ function ClearAllButton({ filters, filterType }: Props) {
   );
 }
 
-function getLabel(filterType: FilterType) {
-  return isFeatureFlagEnabled('categoryFilters')
+function useFilterLabel(filterType: FilterType) {
+  return useIsFeatureFlagEnabled('categoryFilters')
     ? FILTER_LABEL_MAP[filterType]
     : 'Filter';
 }
@@ -59,7 +59,7 @@ function getLabel(filterType: FilterType) {
  */
 function FilterForm(props: Props) {
   const { filters, filterType } = props;
-  const label = getLabel(filterType);
+  const label = useFilterLabel(filterType);
 
   return (
     <div
@@ -99,7 +99,7 @@ function FilterForm(props: Props) {
 export function PluginFilterByForm(props: Props) {
   const form = <FilterForm {...props} />;
   const { filterType } = props;
-  const label = getLabel(filterType);
+  const label = useFilterLabel(filterType);
 
   return (
     <>

--- a/frontend/src/components/PluginSearch/PluginSearchControls.tsx
+++ b/frontend/src/components/PluginSearch/PluginSearchControls.tsx
@@ -4,7 +4,7 @@ import { AnimateSharedLayout, motion } from 'framer-motion';
 
 import { Media } from '@/components/common/media';
 import { FilterKey } from '@/store/search/search.store';
-import { isFeatureFlagEnabled } from '@/utils/featureFlags';
+import { useIsFeatureFlagEnabled } from '@/utils/featureFlags';
 
 import { PluginFilterByForm } from './PluginFilterByForm';
 import { PluginSortByForm } from './PluginSortByForm';
@@ -19,7 +19,7 @@ export function PluginSearchControls() {
     </Media>
   );
 
-  const isCategoryFiltersEnabled = isFeatureFlagEnabled('categoryFilters');
+  const isCategoryFiltersEnabled = useIsFeatureFlagEnabled('categoryFilters');
   const requirementFilters: FilterKey[] = [];
 
   if (isCategoryFiltersEnabled) {

--- a/frontend/src/utils/featureFlags.ts
+++ b/frontend/src/utils/featureFlags.ts
@@ -1,6 +1,8 @@
+import { useRouter } from 'next/router';
+
 import { PROD, STAGING } from '@/env';
 
-import { createUrl } from '.';
+import { createUrl } from './url';
 
 export type FeatureFlagEnvironment = 'dev' | 'staging' | 'prod';
 
@@ -42,28 +44,27 @@ const DISABLE_FEATURE_FLAG_QUERY_PARAM = 'disable-feature';
  * @param key The feature flag key.
  * @returns True or false depending on if the feature flag is enabled.
  */
-export function isFeatureFlagEnabled(key: FeatureFlagKey): boolean {
+export function useIsFeatureFlagEnabled(key: FeatureFlagKey): boolean {
+  const router = useRouter();
   const flag = FEATURE_FLAGS[key];
 
   // If the flag is enabled / disabled in a URL parameter, then override the
   // environment check.
-  if (process.browser) {
-    const params = createUrl(window.location.href).searchParams;
+  const params = createUrl(router.asPath).searchParams;
 
-    const enabledFeatures = new Set(
-      params.getAll(ENABLE_FEATURE_FLAG_QUERY_PARAM),
-    );
-    const disabledFetures = new Set(
-      params.getAll(DISABLE_FEATURE_FLAG_QUERY_PARAM),
-    );
+  const enabledFeatures = new Set(
+    params.getAll(ENABLE_FEATURE_FLAG_QUERY_PARAM),
+  );
+  const disabledFetures = new Set(
+    params.getAll(DISABLE_FEATURE_FLAG_QUERY_PARAM),
+  );
 
-    if (enabledFeatures.has(key)) {
-      return true;
-    }
+  if (enabledFeatures.has(key)) {
+    return true;
+  }
 
-    if (disabledFetures.has(key)) {
-      return false;
-    }
+  if (disabledFetures.has(key)) {
+    return false;
   }
 
   if (PROD) {


### PR DESCRIPTION
## Description

This fixes the incorrect color showing up for the filter pills. The issue was caused by a server mismatch because of code running on the browser, but not the server. The issue is that the feature flag function was parsing the query parameters only on the client, so the server would render the HTML for the category filters and the client would not render it.

This caused React hydration step to behave weirdly by keeping some of the CSS classes on the server still attached in the client, but to the wrong element.

The fix is to make the feature flag function universal, so I refactored it into a hook that uses the Next.js router path. That way, both the server and client render the same HTML for a particular feature flag.

