### PR TITLE
Reduce zoom on filter component for mobile

### DIFF
--- a/frontend/src/components/PluginSearch/PluginComplexFilter.module.scss
+++ b/frontend/src/components/PluginSearch/PluginComplexFilter.module.scss
@@ -32,3 +32,7 @@ div.complexFilter {
   @apply border-t-0 border-l-0 border-r-0;
   @apply border-black rounded-none;
 }
+
+.hiddenInputCaret {
+  caret-color: transparent;
+}

--- a/frontend/src/components/PluginSearch/PluginComplexFilter.module.scss.d.ts
+++ b/frontend/src/components/PluginSearch/PluginComplexFilter.module.scss.d.ts
@@ -2,6 +2,7 @@ export type Styles = {
   autoComplete: string;
   categories: string;
   complexFilter: string;
+  hiddenInputCaret: string;
 };
 
 export type ClassNames = keyof Styles;

--- a/frontend/src/components/PluginSearch/PluginComplexFilter.tsx
+++ b/frontend/src/components/PluginSearch/PluginComplexFilter.tsx
@@ -295,6 +295,11 @@ export function PluginComplexFilter({ filterKey }: Props) {
                 // mobile input focus:
                 // https://css-tricks.com/16px-or-larger-text-prevents-ios-form-zoom
                 'text-lg',
+
+                // Render transparent text caret when search is not enabled so
+                // that it doesn't render a blinking caret. Remove this when the above issue is fixed.
+                !isSearchEnabled && styles.hiddenInputCaret,
+
                 'border-b border-black',
               ),
               disableUnderline: true,

--- a/frontend/src/components/PluginSearch/PluginComplexFilter.tsx
+++ b/frontend/src/components/PluginSearch/PluginComplexFilter.tsx
@@ -282,14 +282,21 @@ export function PluginComplexFilter({ filterKey }: Props) {
 
         renderInput: (params: AutocompleteRenderInputParams) => (
           <TextField
+            {...params}
             autoFocus
             fullWidth
             placeholder="search for a category"
-            ref={params.InputProps.ref}
-            inputProps={params.inputProps}
-            // eslint-disable-next-line react/jsx-no-duplicate-props
             InputProps={{
-              className: 'text-[0.6875rem] border-b border-black',
+              ...params.InputProps,
+              className: clsx(
+                // Use large text for now until
+                // https://github.com/chanzuckerberg/napari-hub/issues/367 is
+                // fixed properly. Large text will reduce the amount of zoom for
+                // mobile input focus:
+                // https://css-tricks.com/16px-or-larger-text-prevents-ios-form-zoom
+                'text-lg',
+                'border-b border-black',
+              ),
               disableUnderline: true,
               endAdornment: <Search />,
             }}


### PR DESCRIPTION
## Description

Reduces the zoom that happens as a result of #367. While not a proper fix, this will reduce the impact on UX while we look into one.

## Demos

### Before

Notice that opening each filter requires us to zoom out each time.

https://user-images.githubusercontent.com/2176050/146458838-b432f875-0800-4e6b-a0f5-7d622fd2cb43.mp4

### After

Using a larger font size, we can force the mobile browser to not zoom in: https://css-tricks.com/16px-or-larger-text-prevents-ios-form-zoom/

https://user-images.githubusercontent.com/2176050/146458831-f2677bf7-cce7-4f0a-a644-87ecd2ac69a9.mp4