### PR TITLE
Hide keyboard for plugin filter

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,7 +50,7 @@
     "axios": "^0.23.0",
     "cheerio": "^1.0.0-rc.10",
     "clsx": "^1.1.1",
-    "czifui": "^1.5.0",
+    "czifui": "^1.5.6",
     "dayjs": "^1.10.7",
     "framer-motion": "^4.1.17",
     "fs-extra": "^10.0.0",

--- a/frontend/src/components/PluginSearch/PluginComplexFilter.module.scss
+++ b/frontend/src/components/PluginSearch/PluginComplexFilter.module.scss
@@ -27,10 +27,12 @@ div.complexFilter {
   }
 }
 
-.autoComplete > div {
-  @apply p-0 m-0;
-  @apply border-t-0 border-l-0 border-r-0;
-  @apply border-black rounded-none;
+.autoComplete {
+  & > div {
+    @apply p-0 m-0;
+    @apply border-t-0 border-l-0 border-r-0;
+    @apply border-black rounded-none;
+  }
 }
 
 .hiddenInputCaret {

--- a/frontend/src/components/PluginSearch/PluginComplexFilter.module.scss
+++ b/frontend/src/components/PluginSearch/PluginComplexFilter.module.scss
@@ -27,12 +27,10 @@ div.complexFilter {
   }
 }
 
-.autoComplete {
-  & > div {
-    @apply p-0 m-0;
-    @apply border-t-0 border-l-0 border-r-0;
-    @apply border-black rounded-none;
-  }
+.autoComplete > div {
+  @apply p-0 m-0;
+  @apply border-t-0 border-l-0 border-r-0;
+  @apply border-black rounded-none;
 }
 
 .hiddenInputCaret {

--- a/frontend/src/components/PluginSearch/PluginComplexFilter.tsx
+++ b/frontend/src/components/PluginSearch/PluginComplexFilter.tsx
@@ -1,10 +1,6 @@
 import styled from '@emotion/styled';
 import Popper from '@material-ui/core/Popper';
-import TextField from '@material-ui/core/TextField';
-import {
-  AutocompleteRenderInputParams,
-  AutocompleteRenderOptionState,
-} from '@material-ui/lab/Autocomplete';
+import { AutocompleteRenderOptionState } from '@material-ui/lab/Autocomplete';
 import clsx from 'clsx';
 import {
   Button,
@@ -14,6 +10,7 @@ import {
 } from 'czifui';
 import { get, isEqual } from 'lodash';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { render } from 'react-dom';
 import { subscribe, useSnapshot } from 'valtio';
 
 import { useSearchStore } from '@/store/search/context';
@@ -79,6 +76,10 @@ const StyledPopper = styled(Popper)`
     background: #fff;
     position: relative;
     width: 100% !important;
+  }
+
+  .MuiAutocomplete-option {
+    min-height: 0;
   }
 `;
 
@@ -235,6 +236,27 @@ export function PluginComplexFilter({ filterKey }: Props) {
               // for sizes <300px.
               tooltip.style.maxWidth =
                 window.outerWidth < 300 ? '100%' : `${width}px`;
+
+              // Manually set the placeholder of the input component. This
+              // workaround is required until props are added to the
+              // ComplexFilter component that'll let us pass props to the nested
+              // Autocomplete input component.
+              const searchInput = tooltip.querySelector('input');
+              if (searchInput) {
+                searchInput.placeholder = 'search for a category';
+              }
+
+              // Manually replace the filter input adornment. This workaround is
+              // required for the same reasons as above.
+              if (filterKey === 'workflowStep') {
+                const svgContainer = tooltip.querySelector(
+                  '.MuiInputAdornment-root',
+                );
+
+                if (svgContainer) {
+                  render(<Search />, svgContainer);
+                }
+              }
             }
           }
         }),
@@ -279,34 +301,6 @@ export function PluginComplexFilter({ filterKey }: Props) {
 
         groupBy: (option: PluginMenuSelectOption) =>
           WORKFLOW_STEP_GROUP_MAP[option.stateKey] ?? '',
-
-        renderInput: (params: AutocompleteRenderInputParams) => (
-          <TextField
-            {...params}
-            autoFocus
-            fullWidth
-            placeholder="search for a category"
-            InputProps={{
-              ...params.InputProps,
-              className: clsx(
-                // Use large text for now until
-                // https://github.com/chanzuckerberg/napari-hub/issues/367 is
-                // fixed properly. Large text will reduce the amount of zoom for
-                // mobile input focus:
-                // https://css-tricks.com/16px-or-larger-text-prevents-ios-form-zoom
-                'text-lg',
-
-                // Render transparent text caret when search is not enabled so
-                // that it doesn't render a blinking caret. Remove this when the above issue is fixed.
-                !isSearchEnabled && styles.hiddenInputCaret,
-
-                'border-b border-black',
-              ),
-              disableUnderline: true,
-              endAdornment: <Search />,
-            }}
-          />
-        ),
 
         renderOption: (
           option: PluginMenuSelectOption,

--- a/frontend/src/components/PluginSearch/PluginFilterByForm.tsx
+++ b/frontend/src/components/PluginSearch/PluginFilterByForm.tsx
@@ -104,7 +104,7 @@ export function PluginFilterByForm(props: Props) {
   return (
     <>
       <Media lessThan="screen-875">
-        <Accordion title={label}>
+        <Accordion className="uppercase" title={label}>
           <ClearAllButton {...props} />
 
           {form}

--- a/frontend/src/components/PluginSearch/PluginSortByForm.tsx
+++ b/frontend/src/components/PluginSearch/PluginSortByForm.tsx
@@ -102,7 +102,9 @@ export function PluginSortByForm() {
   return (
     <>
       <Media lessThan="screen-875">
-        <Accordion title="Sort">{form}</Accordion>
+        <Accordion className="uppercase" title="Sort">
+          {form}
+        </Accordion>
       </Media>
 
       <Media greaterThanOrEqual="screen-875">{form}</Media>

--- a/frontend/src/global.scss
+++ b/frontend/src/global.scss
@@ -51,3 +51,22 @@ body {
   @apply min-w-napari-xs;
 }
 /* stylelint-enable */
+
+// Styles for complex filter tooltips.
+[role='tooltip'] {
+  /* stylelint-disable-next-line selector-class-pattern */
+  .MuiAutocomplete-root[data-filter] {
+    input {
+      @apply text-xs;
+    }
+
+    // Use larger font size for touch devices to prevent zoom when the filter
+    // input is focused:
+    // https://css-tricks.com/16px-or-larger-text-prevents-ios-form-zoom/
+    @media (any-hover: none) {
+      input {
+        @apply text-lg;
+      }
+    }
+  }
+}

--- a/frontend/tests/pages/home/filter.test.ts
+++ b/frontend/tests/pages/home/filter.test.ts
@@ -33,7 +33,7 @@ const FILTER_KEY_METADATA_LABEL_MAP: Partial<Record<FilterKey, MetadataLabel>> =
 
 const CATEGORY_FILTERS = new Set<FilterKey>(['imageModality', 'workflowStep']);
 
-async function openFilter(filterKey: FilterKey) {
+async function clickOnFilterButton(filterKey: FilterKey) {
   const filterButton = await page.$(
     `[data-testid=pluginFilter][data-filter=${filterKey}]`,
   );
@@ -132,21 +132,16 @@ async function testPluginFilter({
   async function testClickingOnOptions() {
     await page.goto(getSearchUrl());
     await openAccordion();
+    await clickOnFilterButton(filterKey);
 
     for (let i = 0; i < options.length; i += 1) {
-      await openFilter(filterKey);
       const optionResults = await getOptions(options);
       const { node } =
         optionResults.find((result) => result.label === options[i]) ?? {};
       node?.click();
     }
 
-    // Close filter by clicking on chevron.
-    const chevron = await page.$(
-      `[data-testid=pluginFilter][data-filter=${filterKey}] svg`,
-    );
-    await chevron?.click();
-
+    await clickOnFilterButton(filterKey);
     await testResults();
   }
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3808,10 +3808,10 @@ cwd@^0.10.0:
     find-pkg "^0.1.2"
     fs-exists-sync "^0.1.0"
 
-czifui@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/czifui/-/czifui-1.5.0.tgz#9766e1335271917ba3e55e80650893ed2f82f007"
-  integrity sha512-7MnrDsZvM5mDdxAqVsoj2ugvRch9cOiV62RV10TMv+MRHu/nH+azIZ78+kk2IlVPrbL/HIU4aXn3vd0V8SskdA==
+czifui@^1.5.6:
+  version "1.5.6"
+  resolved "https://registry.yarnpkg.com/czifui/-/czifui-1.5.6.tgz#92e367b655869d8145b80f8daddeaeef815d1c6d"
+  integrity sha512-XQKXFT35EG7NOaDrMjFlY+bDkvU2IqN9JIhlEDeERqQrSOpuITQs9PNSgN/i9Z8QbxhcFLxlADqKuljxE5SfvQ==
 
 damerau-levenshtein@^1.0.6:
   version "1.0.6"


### PR DESCRIPTION
## Description

Upgrades the `czifui` package to hide the virtual keyboard when the plugin filter is opened.

## Demo

### Before

Before this fix, the virtual keyboard would pop up even if there was no input element.

https://user-images.githubusercontent.com/2176050/146989844-fa585382-2d49-4e27-88fc-f45f17e0cdf8.mp4

### After

With the fix, the virtual keyboard will now only show up if there is an input element.

https://user-images.githubusercontent.com/2176050/146989858-01c4f5b3-4fe5-4ef9-b41c-f6a45d5515a5.mp4

## Future work

There is still the issue where the viewport jumps when focusing on the input. I'll continue working with the SDS team to figure out a fix for this.
