### PR TITLE
Allow to miss `.napari/DESCRIPTION.md` or `CITATION.cff` 

### DIFF
--- a/backend/utils/github.py
+++ b/backend/utils/github.py
@@ -47,8 +47,11 @@ def get_file(download_url: str, file: str, branch: str = 'HEAD') -> [dict, None]
     """
     local_workspace = os.getenv("GITHUB_WORKSPACE")
     if local_workspace:
+        file_path = os.path.join(local_workspace, file)
+        if not os.path.exists(file_path):
+            return
         # read files locally since github action already checked it out
-        with open(os.path.join(local_workspace, file)) as f:
+        with open(file_path) as f:
             return f.read()
 
     api_url = download_url.replace("https://github.com/",


### PR DESCRIPTION
fix  #376