### PR TITLE
Fix file not found error for get_preview script

### DIFF
--- a/backend/utils/github.py
+++ b/backend/utils/github.py
@@ -48,8 +48,11 @@ def get_file(download_url: str, file: str, branch: str = 'HEAD') -> [dict, None]
     local_workspace = os.getenv("GITHUB_WORKSPACE")
     if local_workspace:
         # read files locally since github action already checked it out
-        with open(os.path.join(local_workspace, file)) as f:
-            return f.read()
+        try:
+            with open(os.path.join(local_workspace, file)) as f:
+                return f.read()
+        except FileNotFoundError:
+            return None
 
     api_url = download_url.replace("https://github.com/",
                                    "https://raw.githubusercontent.com/")

--- a/backend/utils/github.py
+++ b/backend/utils/github.py
@@ -48,10 +48,10 @@ def get_file(download_url: str, file: str, branch: str = 'HEAD') -> [dict, None]
     local_workspace = os.getenv("GITHUB_WORKSPACE")
     if local_workspace:
         # read files locally since github action already checked it out
-        try:
+        if os.path.exists(os.path.join(local_workspace, file)):
             with open(os.path.join(local_workspace, file)) as f:
                 return f.read()
-        except FileNotFoundError:
+        else:
             return None
 
     api_url = download_url.replace("https://github.com/",


### PR DESCRIPTION
I noticed there was an issue with the recent PR to napari-zelda resulting in the preview page throwing an error on build: https://github.com/RoccoDAnt/napari-zelda/runs/4719127633?check_suite_focus=true

```
Traceback (most recent call last):
  File "napari-hub/backend/get_preview.py", line 17, in <module>
    get_plugin_preview(repo_pth, dest_pth, args.local, args.branch)
  File "/home/runner/work/napari-zelda/napari-zelda/napari-hub/backend/preview/preview.py", line 48, in get_plugin_preview
    github_metadata = get_github_metadata(action_repo_url, branch=branch)
  File "/home/runner/work/napari-zelda/napari-zelda/napari-hub/backend/utils/github.py", line 123, in get_github_metadata
    citation_file = get_file(repo_url, "CITATION.cff", branch=branch)
  File "/home/runner/work/napari-zelda/napari-zelda/napari-hub/backend/utils/github.py", line 51, in get_file
    with open(os.path.join(local_workspace, file)) as f:
FileNotFoundError: [Errno 2] No such file or directory: '/home/runner/work/napari-zelda/napari-zelda/CITATION.cff'
```

 It looks like this is because there isn't error handling for when a file doesn't exist in a local workspace 🤔 
 
 https://github.com/chanzuckerberg/napari-hub/blob/e2ee13d7b75bb9c99ea1f64295d1dd16d935ce68/backend/utils/github.py#L49-L52

Adding exception handling for `FileNotFoundError` should fix the issue 😄 