### PR TITLE
Fix i18n for preview pages

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -4,37 +4,37 @@ const { i18n } = require('./next-i18next.config');
 
 const { PREVIEW } = process.env;
 const PROD = process.env.NODE_ENV === 'production';
+const isPreview = !!(PROD && PREVIEW);
 
 // Enable static HTML export of the preview page in production and if the
 // preview file is provided.
-const previewOptions =
-  PROD && PREVIEW
-    ? {
-        // The Image API doesn't work for exported apps, so we need to use a
-        // different image loader to supplement it. The workaround is to use imgix
-        // with a root path for Next.js v10: https://git.io/J0k6G.
-        images: {
-          loader: 'imgix',
-          path: process.env.BASE_PATH || '/',
-        },
+const previewOptions = isPreview
+  ? {
+      // The Image API doesn't work for exported apps, so we need to use a
+      // different image loader to supplement it. The workaround is to use imgix
+      // with a root path for Next.js v10: https://git.io/J0k6G.
+      images: {
+        loader: 'imgix',
+        path: process.env.BASE_PATH || '/',
+      },
 
-        // Override default pages being exported to be only the preview page:
-        // https://stackoverflow.com/a/64071979
-        exportPathMap() {
-          return {
-            '/preview': { page: '/preview' },
-          };
-        },
-      }
-    : {};
+      // Override default pages being exported to be only the preview page:
+      // https://stackoverflow.com/a/64071979
+      exportPathMap() {
+        return {
+          '/preview': { page: '/preview' },
+        };
+      },
+    }
+  : {};
 
-if (PROD && PREVIEW) {
+if (isPreview) {
   console.log('Building preview page for plugin file', PREVIEW);
 }
 
 module.exports = {
   ...previewOptions,
-  i18n,
+  i18n: isPreview ? undefined : i18n,
 
   basePath: process.env.BASE_PATH || '',
   pageExtensions: ['ts', 'tsx'],

--- a/frontend/src/pages/[...parts].tsx
+++ b/frontend/src/pages/[...parts].tsx
@@ -19,6 +19,10 @@ interface Props extends SSRConfig {
 
 const LOCALE_DIR = __dirname.replace('.next/server/pages', 'i18n');
 
+const isPreview = !!(
+  process.env.NODE_ENV === 'production' && process.env.PREVIEW
+);
+
 /**
  * Special Next.js function responsible for returning all possible paths that
  * can be built by this page at build time. Since we use `getStaticPaths()` to
@@ -39,7 +43,7 @@ export function getStaticPaths(): GetStaticPathsResult {
   for (const locale of supportedLocales) {
     for (const file of mdxFiles) {
       paths.push({
-        locale,
+        locale: isPreview ? undefined : locale,
         params: {
           parts: file.split('/'),
         },


### PR DESCRIPTION
Closes #386

This disables i18n for preview pages since Next.js doesn't support internationalized routing for static exports. This works by passing an undefined `i18n` object in `next.config.js` and passing an undefined `locale` in the `getStaticPaths()` function for the `/[...parts]` route.