### PR TITLE
Change lambda provisioning

### DIFF
--- a/.happy/terraform/modules/lambda-container/main.tf
+++ b/.happy/terraform/modules/lambda-container/main.tf
@@ -27,6 +27,16 @@ module lambda {
   cloudwatch_logs_retention_in_days = var.log_retention_in_days
   attach_network_policy             = true
   reserved_concurrent_executions    = var.reserved_concurrent_executions
-  provisioned_concurrent_executions = var.provisioned_lambda
   allowed_triggers                  = var.allowed_triggers
+}
+
+resource "aws_lambda_provisioned_concurrency_config" "provisioned" {
+  count = var.provisioned_lambda > 0 ? 1 : 0
+  function_name                     = module.lambda.lambda_function_name
+  provisioned_concurrent_executions = var.provisioned_lambda
+  qualifier                         = module.lambda.lambda_function_version
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }


### PR DESCRIPTION
Change lambda provisioning to use own resource to avoid failures during concurrent execution.

Currently, our lambda update on prod would fail to go through with this error message:
```
Error: error modifying Lambda Function (prod-backend) configuration : ResourceConflictException: The function could not be updated due to a concurrent update operation.
{
  RespMetadata: {
    StatusCode: 409,
    RequestID: "90dc1b91-b93a-4051-985b-2053a1a7c34b"
  },
  Message_: "The function could not be updated due to a concurrent update operation.",
  Type: "User"
}```

This change attempt to avoid this concurrent update by adding dependency between lambda update and concurrency update