### PR TITLE
add datadog integration

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -112,6 +112,7 @@ module backend_lambda {
     "GITHUBAPP_SECRET" = local.github_app_secret
     "DD_API_KEY" = local.datadog_api_key
     "DD_ENV" = var.env
+    "DD_SERVICE" = local.custom_stack_name
   }
 
   log_retention_in_days = 14

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -44,6 +44,7 @@ locals {
   github_app_id = try(local.secret["github"]["app_id"], "")
   github_app_key = try(local.secret["github"]["app_key"], "")
   github_app_secret = try(local.secret["github"]["app_secret"], "")
+  datadog_api_key = try(local.secret["datadog"]["api_key"], "")
 
   frontend_url = var.frontend_url != "" ? var.frontend_url: try(join("", ["https://", module.frontend_dns.dns_prefix, ".", local.external_dns]), var.frontend_url)
 }
@@ -107,6 +108,7 @@ module backend_lambda {
     "GITHUBAPP_ID" = local.github_app_id
     "GITHUBAPP_KEY" = local.github_app_key
     "GITHUBAPP_SECRET" = local.github_app_secret
+    "DD_API_KEY" = local.datadog_api_key
   }
 
   log_retention_in_days = 14

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -98,8 +98,6 @@ module backend_lambda {
   }
 
   environment = {
-    "ENV" = var.env
-    "SERVICE" = "napari-hub-backend"
     "BUCKET" = local.data_bucket_name
     "BUCKET_PATH" = var.env == "dev" ? local.custom_stack_name : ""
     "GOOGLE_APPLICATION_CREDENTIALS" = "./credentials.json"

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -111,6 +111,7 @@ module backend_lambda {
     "GITHUBAPP_KEY" = local.github_app_key
     "GITHUBAPP_SECRET" = local.github_app_secret
     "DD_API_KEY" = local.datadog_api_key
+    "DD_ENV" = var.env
   }
 
   log_retention_in_days = 14

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -98,6 +98,8 @@ module backend_lambda {
   }
 
   environment = {
+    "ENV" = var.env
+    "SERVICE" = "napari-hub-backend"
     "BUCKET" = local.data_bucket_name
     "BUCKET_PATH" = var.env == "dev" ? local.custom_stack_name : ""
     "GOOGLE_APPLICATION_CREDENTIALS" = "./credentials.json"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,6 +2,9 @@ FROM public.ecr.aws/lambda/python:3.8
 
 COPY requirements.txt .
 RUN ["pip", "install", "-r", "requirements.txt"]
+COPY --from=public.ecr.aws/datadog/lambda-extension:latest /opt/extensions/ /opt/extensions
 
 COPY . .
-CMD ["api.app.handler"]
+ENV DD_LAMBDA_HANDLER="api.app.handler"
+ENV DD_TRACE_ENABLED="true"
+CMD ["datadog_lambda.handler.handler"]

--- a/backend/api/model.py
+++ b/backend/api/model.py
@@ -9,6 +9,7 @@ from utils.github import get_github_metadata, get_artifact
 from utils.pypi import query_pypi, get_plugin_pypi_metadata
 from api.s3 import get_cache, cache
 from utils.utils import render_description, send_alert, get_attribute, get_category_mapping
+from utils.datadog import report_metrics
 from api.zulip import notify_new_packages
 
 index_subset = {'name', 'summary', 'description_text', 'description_content_type',
@@ -172,6 +173,9 @@ def update_cache():
         cache(visibility_plugins['hidden'], 'cache/hidden-plugins.json')
         cache(slice_metadata_to_index_columns(list(plugins_metadata.values())), 'cache/index.json')
         notify_new_packages(existing_public_plugins, visibility_plugins['public'])
+        report_metrics('napari_hub.plugins.count', len(visibility_plugins['public']), ['visibility:public'])
+        report_metrics('napari_hub.plugins.count', len(visibility_plugins['hidden']), ['visibility:hidden'])
+        report_metrics('napari_hub.plugins.excluded', len(excluded_plugins))
     else:
         send_alert(f"({datetime.now()})Actions Required! Failed to query pypi for "
                    f"napari plugin packages, switching to backup analysis dump")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,10 +5,11 @@ flask-githubapp
 gunicorn[gevent]
 pyyaml
 requests
-markdown==3.3.4
+markdown
 bs4
 cffconvert
 GitPython
 setuptools
 wheel
 pkginfo
+datadog-lambda

--- a/backend/utils/datadog.py
+++ b/backend/utils/datadog.py
@@ -1,12 +1,9 @@
 import time
-import os
 from datadog_lambda.metric import lambda_metric
 
 
 def report_metrics(metric_name: str, value, tags: list = None):
     tags = tags if tags else []
-    tags.append(f'env:{os.getenv("ENV")}')
-    tags.append(f'service:{os.getenv("SERVICE")}')
     lambda_metric(
         metric_name=metric_name,
         value=value,

--- a/backend/utils/datadog.py
+++ b/backend/utils/datadog.py
@@ -6,7 +6,7 @@ from datadog_lambda.metric import lambda_metric
 def report_metrics(metric_name: str, value, tags: list = None):
     tags = tags if tags else []
     tags.append(f'env:{os.getenv("ENV")}')
-    tags.append(f'service:{os.getenv("ENV")}')
+    tags.append(f'service:{os.getenv("SERVICE")}')
     lambda_metric(
         metric_name=metric_name,
         value=value,

--- a/backend/utils/datadog.py
+++ b/backend/utils/datadog.py
@@ -1,0 +1,15 @@
+import time
+import os
+from datadog_lambda.metric import lambda_metric
+
+
+def report_metrics(metric_name: str, value, tags: list = None):
+    tags = tags if tags else []
+    tags.append(f'env:{os.getenv("ENV")}')
+    tags.append(f'service:{os.getenv("ENV")}')
+    lambda_metric(
+        metric_name=metric_name,
+        value=value,
+        timestamp=int(time.time()),  # optional, must be within last 20 mins
+        tags=tags
+    )


### PR DESCRIPTION
This PR adds datadog integration to backend lambda.

The default integration allows datadog to report metrics like invoking time and aws s3 request times.
In terms of custom metrics, currently it is tracking plugin counts, but we can build other metrics on top of it