### PR TITLE
Disables highlighting for `Supported data`

### DIFF
--- a/frontend/src/components/MetadataHighlighter/EmptyMetadataTooltip.tsx
+++ b/frontend/src/components/MetadataHighlighter/EmptyMetadataTooltip.tsx
@@ -20,6 +20,7 @@ import { previewStore } from '@/store/preview';
 interface Props {
   className?: string;
   metadataId?: MetadataKeys;
+  showStatus?: boolean;
 }
 
 const TOOLTIP_CLASS_NAME = 'metadata-tooltip';
@@ -61,7 +62,11 @@ function useTooltipLabels() {
  * Renders a tooltip and metadata status icon for with information for the
  * metadata specified by `metadataId`.
  */
-export function EmptyMetadataTooltip({ className, metadataId }: Props) {
+export function EmptyMetadataTooltip({
+  className,
+  metadataId,
+  showStatus = true,
+}: Props) {
   const [t] = useTranslation(['pluginPage', 'preview']);
   const snap = useSnapshot(previewStore);
   const metadata = usePluginMetadata();
@@ -155,7 +160,9 @@ export function EmptyMetadataTooltip({ className, metadataId }: Props) {
       open={snap.activeMetadataField === metadataId}
     >
       <div className={className}>
-        <MetadataStatus className={className} hasValue={false} />
+        {showStatus && (
+          <MetadataStatus className={className} hasValue={false} />
+        )}
       </div>
     </Tooltip>
   );

--- a/frontend/src/components/MetadataList/MetadataList.tsx
+++ b/frontend/src/components/MetadataList/MetadataList.tsx
@@ -10,13 +10,14 @@ import { EmptyListItem } from './EmptyListItem';
 import { MetadataContextProvider } from './metadata.context';
 import styles from './MetadataList.module.scss';
 
-interface Props {
+export interface Props {
   children: ReactNode;
   className?: string;
   empty?: boolean;
   id?: MetadataKeys;
   inline?: boolean;
   label: string;
+  highlight?: boolean;
 }
 
 /**
@@ -26,6 +27,7 @@ export function MetadataList({
   children,
   className,
   empty,
+  highlight = true,
   id,
   inline,
   label,
@@ -49,7 +51,7 @@ export function MetadataList({
               empty ? 'flex items-center screen-875:inline' : 'inline',
             ],
           )}
-          highlight={empty}
+          highlight={highlight && empty}
           tooltip={null}
           id={id}
         >
@@ -84,7 +86,10 @@ export function MetadataList({
             {empty ? (
               <EmptyListItem>
                 {process.env.PREVIEW && (
-                  <EmptyMetadataTooltip metadataId={id} />
+                  <EmptyMetadataTooltip
+                    metadataId={id}
+                    showStatus={highlight}
+                  />
                 )}
               </EmptyListItem>
             ) : (

--- a/frontend/src/components/PluginDetails/PluginMetadata.tsx
+++ b/frontend/src/components/PluginDetails/PluginMetadata.tsx
@@ -6,7 +6,11 @@ import { ReactNode } from 'react';
 import { Divider } from '@/components/common/Divider';
 import { Media } from '@/components/common/media';
 import { SkeletonLoader } from '@/components/common/SkeletonLoader';
-import { MetadataList, MetadataListTextItem } from '@/components/MetadataList';
+import {
+  MetadataList,
+  MetadataListTextItem,
+  Props as MetadataListProps,
+} from '@/components/MetadataList';
 import {
   Metadata,
   MetadataKeys,
@@ -108,17 +112,29 @@ function PluginMetadataBase({
 }: PluginMetadataBaseProps) {
   const metadata = usePluginMetadata();
 
-  function renderSingleItemList(key: PickMetadataKeys<string>) {
+  function renderSingleItemList(
+    key: PickMetadataKeys<string>,
+    props?: Partial<MetadataListProps>,
+  ) {
     const { label, value } = metadata[key];
 
     return (
-      <MetadataList id={key} inline={inline} label={label} empty={!value}>
+      <MetadataList
+        id={key}
+        inline={inline}
+        label={label}
+        empty={!value}
+        {...props}
+      >
         <MetadataListTextItem>{value}</MetadataListTextItem>
       </MetadataList>
     );
   }
 
-  function renderItemList(key: PickMetadataKeys<string[]>) {
+  function renderItemList(
+    key: PickMetadataKeys<string[]>,
+    props?: Partial<MetadataListProps>,
+  ) {
     const { label, value: values } = metadata[key];
 
     return (
@@ -127,6 +143,7 @@ function PluginMetadataBase({
         inline={inline}
         label={label}
         empty={isEmpty(values)}
+        {...props}
       >
         {values.map((value) => (
           <MetadataListTextItem key={value}>{value}</MetadataListTextItem>
@@ -140,8 +157,8 @@ function PluginMetadataBase({
       className="h-56"
       render={() => (
         <>
-          {renderSingleItemList('version')}
-          {renderSingleItemList('releaseDate')}
+          {renderSingleItemList('version', { highlight: false })}
+          {renderSingleItemList('releaseDate', { highlight: false })}
           {renderSingleItemList('firstReleased')}
           {renderSingleItemList('license')}
         </>
@@ -152,7 +169,9 @@ function PluginMetadataBase({
   const categoryMetadata = (
     <SkeletonLoader
       className="h-56"
-      render={() => <>{renderItemList('supportedData')}</>}
+      render={() => (
+        <>{renderItemList('supportedData', { highlight: false })}</>
+      )}
     />
   );
 


### PR DESCRIPTION
## Description

Closes #394

This disables highlighting for the `Support data` metadata:

![image](https://user-images.githubusercontent.com/2176050/150856027-c293e865-3dd8-4c18-95c9-440535b5265f.png)
