### PR TITLE
Fix preview page error when no source code URL is provided

### DIFF
--- a/backend/preview/_tests/test_preview_meta.py
+++ b/backend/preview/_tests/test_preview_meta.py
@@ -6,7 +6,7 @@ import requests
 import dateutil.parser
 from datetime import datetime
 
-from ..preview import clone_repo, build_dist, parse_meta, get_plugin_preview, get_pypi_date_meta
+from ..preview import clone_repo, build_dist, parse_meta, get_plugin_preview, get_pypi_date_meta, populate_source_code_url
 
 code_plugin_url = "https://github.com/chanzuckerberg/napari-demo"
 hub_plugin_url = "https://api.napari-hub.org/plugins/napari-demo"
@@ -95,3 +95,20 @@ def test_release_date_logic():
     get_pypi_date_meta(meta)
     assert dateutil.parser.isoparse(meta['first_released']).date() == dateutil.parser.isoparse(example_plugin_first_released).date()
     assert dateutil.parser.isoparse(meta['release_date']).date() == dateutil.parser.isoparse(example_plugin_release_date).date()
+
+
+def test_source_code_match():
+    # providing code_repository doesn't change url
+    meta = {'name': 'example-plugin', 'code_repository': code_plugin_url}
+    populate_source_code_url(meta)
+    assert meta['code_repository'] == code_plugin_url
+
+    # providing github project site gives us code_repository
+    meta = {'name': 'example-plugin', 'project_site': code_plugin_url}
+    populate_source_code_url(meta)
+    assert meta['code_repository'] == code_plugin_url
+
+    # non github project site leaves code_repository empty
+    meta = {'name': 'example-plugin', 'project_site': 'www.somesite.com'}
+    populate_source_code_url(meta)
+    assert 'code_repository' not in meta

--- a/backend/preview/preview.py
+++ b/backend/preview/preview.py
@@ -214,14 +214,8 @@ def parse_meta(pkg_pth):
         else:
             meta[field] = getattr(pkg_info, attr)
 
-    # try to github pattern match home page if code_repository still hasn't been found
-    if not meta.get("code_repository"):
-        proj_site = meta["project_site"]
-        if not proj_site:
-            raise RuntimeError(f"Cannot find GitHub repository link for plugin {meta['name']}. Have you added a Sourec Code url?")
-        match = github_pattern.match(proj_site)
-        if match:
-            meta["code_repository"] = match.group(0)
+    # try to github pattern match project site for source code URL if needed
+    populate_source_code_url(meta)
 
     return meta
 
@@ -268,3 +262,12 @@ def get_pypi_date_meta(meta):
     meta["release_date"] = release_date
     meta["first_released"] = first_released
 
+def populate_source_code_url(meta):
+    """Pattern match project_site as GitHub URL when source code url missing
+
+    :param meta: dictionary of plugin metadata
+    """
+    if not "code_repository" in meta and "project_site" in meta:
+        match = github_pattern.match(meta["project_site"])
+        if match:
+            meta["code_repository"] = match.group(0)

--- a/backend/preview/preview.py
+++ b/backend/preview/preview.py
@@ -217,6 +217,8 @@ def parse_meta(pkg_pth):
     # try to github pattern match home page if code_repository still hasn't been found
     if not meta.get("code_repository"):
         proj_site = meta["project_site"]
+        if not proj_site:
+            raise RuntimeError(f"Cannot find GitHub repository link for plugin {meta['name']}. Have you added a Sourec Code url?")
         match = github_pattern.match(proj_site)
         if match:
             meta["code_repository"] = match.group(0)


### PR DESCRIPTION
This PR fixes build error when plugin doesn't provide source code URL. If source code URL can't be found, simply don't assign it, and no GitHub metadata will be available for preview.

Fixes #396.