### PR TITLE
Fix preview page build for /404 page

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -23,6 +23,11 @@ const previewOptions = isPreview
       exportPathMap() {
         return {
           '/preview': { page: '/preview' },
+
+          // By default Next.js, will assign the /404 page to the /_error page,
+          // so we need to manually reassign it to the /404 page to prevent i18n
+          // build errors: https://bit.ly/3G6WyvA
+          '/404': { page: '/404' },
         };
       },
     }


### PR DESCRIPTION
Closes #414

The issue is that Next.js [automatically assigns the `/404` page to the `/_error` page when exporting](https://github.com/vercel/next.js/blob/eea3adc53d217523ca2595b6403f832d060ed2d1/packages/next/export/index.ts#L417-L425):

```ts
if (
  !options.buildExport &&
  !exportPathMap['/404'] &&
  !exportPathMap['/404.html']
) {
  exportPathMap['/404'] = exportPathMap['/404.html'] = {
    page: '/_error',
  }
}
```

Since we override the `/_error` page, it doesn't import our i18n data, causing it to throw an error saying there isn't any. The fix is to manually assign the `/404` page to our custom `/404` page that reads the i18n data.
