### PR TITLE
Fix link for category pill

### DIFF
--- a/frontend/src/components/CategoryChip/CategoryChip.tsx
+++ b/frontend/src/components/CategoryChip/CategoryChip.tsx
@@ -44,7 +44,10 @@ export function CategoryChip({
     : categoryHierarchy?.map((term, index) => (
         <Fragment key={`${dimension}-${term}`}>
           {index === 0 ? (
-            <Link className="underline" href={`/?workflowStep=${term}`}>
+            <Link
+              className="underline"
+              href={`/?${STATE_KEY_MAP[dimension] ?? ''}=${term}`}
+            >
               {t(`pluginData:category.labels.${term}` as I18nKeys<'common'>)}
             </Link>
           ) : (


### PR DESCRIPTION
Closes #416

The `workflowStep` param was hardcoded into the URL 😢 This updates it so that it uses the correct dimension for the pill.