### PR TITLE
only enable cache for prod api

### DIFF
--- a/.happy/terraform/modules/api-gateway-proxy-stage/main.tf
+++ b/.happy/terraform/modules/api-gateway-proxy-stage/main.tf
@@ -2,7 +2,7 @@ resource aws_api_gateway_stage api_stage {
   stage_name            = var.custom_stack_name
   rest_api_id           = var.rest_api_id
   deployment_id         = var.deployment_id
-  cache_cluster_enabled = true
+  cache_cluster_enabled = if var.tags.env == "prod" ? true : false
   cache_cluster_size    = 0.5
 
   # See sci-imaging/terraform/modules/happy-napari-hub/api_gateway.tf


### PR DESCRIPTION
This will speed up dev stack creation, as well as lower cost for our dev and staging environment