### PR TITLE
correct cache path to use ~1 to represent root

### DIFF
--- a/.happy/terraform/modules/api-gateway-proxy-stage/main.tf
+++ b/.happy/terraform/modules/api-gateway-proxy-stage/main.tf
@@ -28,7 +28,7 @@ resource aws_api_gateway_method_settings root_cache {
   count = var.tags.env == "prod" ? 1 : 0
   rest_api_id = var.rest_api_id
   stage_name  = aws_api_gateway_stage.api_stage.stage_name
-  method_path = "/GET"
+  method_path = "~1/GET"
 
   settings {
     caching_enabled = true


### PR DESCRIPTION
correct the path used to cache the API doc. The current one is incorrectly formatted

details see:
https://stackoverflow.com/questions/65807902/how-do-i-get-resource-path-for-root-resource-in-apigateway