### PR TITLE
Fix plugin metadata IDs

### DIFF
--- a/frontend/src/components/AppBar/PreviewMetadataPanel.tsx
+++ b/frontend/src/components/AppBar/PreviewMetadataPanel.tsx
@@ -30,6 +30,13 @@ interface MetadataFieldProps {
   field: MetadataSectionField;
 }
 
+/**
+ * Static class name to assign on metadata fields. This class name is used to
+ * query the metadata fields so that we can check if the field is being clicked
+ * on or not (see `usePreviewClickAway.ts`).
+ */
+export const PREVIEW_METADATA_FIELD_CLASS_NAME = 'preview-metadata-field';
+
 function MetadataField({ field }: MetadataFieldProps) {
   const fieldBody = (
     <>
@@ -54,8 +61,10 @@ function MetadataField({ field }: MetadataFieldProps) {
         {
           key: field.name,
 
-          className:
+          className: clsx(
+            PREVIEW_METADATA_FIELD_CLASS_NAME,
             'flex items-start justify-start text-left m-0 p-1 flex-grow',
+          ),
 
           // Attach click listener if field is a button.
           ...(field.hasValue

--- a/frontend/src/components/AppBar/useMetadataSections.ts
+++ b/frontend/src/components/AppBar/useMetadataSections.ts
@@ -1,11 +1,11 @@
 import { isArray, isEmpty, isString } from 'lodash';
 import { useTranslation } from 'next-i18next';
 
-import { MetadataKeys, usePluginMetadata } from '@/context/plugin';
+import { MetadataId, MetadataKeys, usePluginMetadata } from '@/context/plugin';
 import { I18nPreviewSection } from '@/types/i18n';
 
 export interface MetadataSectionField {
-  id: MetadataKeys;
+  id: MetadataId;
   name: string;
   hasValue: boolean;
 }
@@ -41,9 +41,9 @@ export function useMetadataSections(): MetadataSection[] {
 
       return {
         hasValue,
-        id: key,
+        id: `metadata-${key}`,
         name: data.previewLabel,
-      };
+      } as MetadataSectionField;
     });
   }
 

--- a/frontend/src/components/MetadataHighlighter/EmptyMetadataTooltip.tsx
+++ b/frontend/src/components/MetadataHighlighter/EmptyMetadataTooltip.tsx
@@ -3,7 +3,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import clsx from 'clsx';
 import { useTranslation } from 'next-i18next';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { usePrevious } from 'react-use';
 import {
   parse as parseTransformStr,
@@ -14,12 +14,12 @@ import { useSnapshot } from 'valtio';
 import { I18n } from '@/components/common/I18n';
 import { Link } from '@/components/common/Link';
 import { MetadataStatus } from '@/components/MetadataStatus';
-import { MetadataKeys, usePluginMetadata } from '@/context/plugin';
+import { MetadataId, MetadataKeys, usePluginMetadata } from '@/context/plugin';
 import { previewStore } from '@/store/preview';
 
 interface Props {
   className?: string;
-  metadataId?: MetadataKeys;
+  metadataId?: MetadataId;
   showStatus?: boolean;
 }
 
@@ -113,7 +113,13 @@ export function EmptyMetadataTooltip({
 
   const tooltipLabels = useTooltipLabels();
 
-  if (!metadataId) {
+  // Get metadata key from metadata ID by removing `metadata-` prefix.
+  const metadataKey = useMemo(
+    () => metadataId?.replace(/^metadata-/, '') as MetadataKeys | undefined,
+    [metadataId],
+  );
+
+  if (!metadataId || !metadataKey) {
     return null;
   }
 
@@ -132,9 +138,9 @@ export function EmptyMetadataTooltip({
       interactive
       title={
         <>
-          <h2 className="font-semibold">{metadata[metadataId].label}</h2>
+          <h2 className="font-semibold">{metadata[metadataKey].label}</h2>
 
-          <p>{tooltipLabels[metadataId] ?? ''}</p>
+          <p>{tooltipLabels[metadataKey] ?? ''}</p>
 
           <p className="text-xs mt-5 mb-3">
             <I18n

--- a/frontend/src/components/MetadataHighlighter/MetadataHighlighter.tsx
+++ b/frontend/src/components/MetadataHighlighter/MetadataHighlighter.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 import { createElement, HTMLProps, ReactHTML, ReactNode } from 'react';
 import { useSnapshot } from 'valtio';
 
-import { MetadataKeys } from '@/context/plugin';
+import { MetadataId } from '@/context/plugin';
 import { previewStore } from '@/store/preview';
 import { setUrlHash } from '@/utils';
 
@@ -15,7 +15,7 @@ interface Props<T extends HTMLKey> extends HTMLProps<ReactHTML[T]> {
   className?: string;
   component?: T;
   highlight?: boolean;
-  id?: MetadataKeys;
+  metadataId?: MetadataId;
   tooltip?: ReactNode;
   variant?: 'regular' | 'small';
 }
@@ -29,13 +29,13 @@ export function MetadataHighlighter<T extends HTMLKey>({
   className,
   component,
   highlight = false,
-  id,
+  metadataId,
   tooltip,
   variant,
   ...props
 }: Props<T>) {
   const snap = useSnapshot(previewStore);
-  const isActive = snap.activeMetadataField === id;
+  const isActive = snap.activeMetadataField === metadataId;
   const highlightEnabled = process.env.PREVIEW && highlight;
 
   const childNode = (
@@ -47,7 +47,7 @@ export function MetadataHighlighter<T extends HTMLKey>({
           {tooltip !== undefined ? (
             tooltip
           ) : (
-            <EmptyMetadataTooltip metadataId={id} />
+            <EmptyMetadataTooltip metadataId={metadataId} />
           )}
         </>
       )}
@@ -61,7 +61,7 @@ export function MetadataHighlighter<T extends HTMLKey>({
     {
       ...props,
 
-      id,
+      id: metadataId,
 
       className: clsx(
         className,
@@ -108,7 +108,10 @@ export function MetadataHighlighter<T extends HTMLKey>({
 
               // If the clicked metadata ID matches the active ID, then clear the
               // active ID state. Otherwise, set it to the clicked metadata ID.
-              const nextId = id && id !== snap.activeMetadataField ? id : '';
+              const nextId =
+                metadataId && metadataId !== snap.activeMetadataField
+                  ? metadataId
+                  : '';
               previewStore.activeMetadataField = nextId;
 
               // Replace current URL with active metadata ID.

--- a/frontend/src/components/MetadataList/MetadataList.tsx
+++ b/frontend/src/components/MetadataList/MetadataList.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from 'react';
 
 import { MetadataHighlighter } from '@/components/MetadataHighlighter';
 import { EmptyMetadataTooltip } from '@/components/MetadataHighlighter/EmptyMetadataTooltip';
-import { MetadataKeys } from '@/context/plugin';
+import { MetadataId } from '@/context/plugin';
 import { usePreviewClickAway } from '@/hooks/usePreviewClickAway';
 
 import { EmptyListItem } from './EmptyListItem';
@@ -14,7 +14,7 @@ export interface Props {
   children: ReactNode;
   className?: string;
   empty?: boolean;
-  id?: MetadataKeys;
+  id?: MetadataId;
   inline?: boolean;
   label: string;
   highlight?: boolean;
@@ -42,9 +42,10 @@ export function MetadataList({
         Use list wrapper so that the preview highlight overlay only renders as
         tall as the content.
        */}
-      <div id={id} className={clsx('text-sm', className)}>
+      <div className={clsx('text-sm', className)}>
         {/* List container */}
         <MetadataHighlighter
+          metadataId={id}
           className={clsx(
             // Item spacing for inline lists.
             inline && [
@@ -53,7 +54,6 @@ export function MetadataList({
           )}
           highlight={highlight && empty}
           tooltip={null}
-          id={id}
         >
           {/* List title */}
           <h4

--- a/frontend/src/components/MetadataList/MetadataListLinkItem.tsx
+++ b/frontend/src/components/MetadataList/MetadataListLinkItem.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from 'react-markdown';
 
 import { Link } from '@/components/common/Link/Link';
 import { MetadataHighlighter } from '@/components/MetadataHighlighter';
-import { MetadataKeys, usePluginState } from '@/context/plugin';
+import { MetadataId, usePluginState } from '@/context/plugin';
 import { usePlausible } from '@/hooks';
 import { usePreviewClickAway } from '@/hooks/usePreviewClickAway';
 import { isExternalUrl } from '@/utils';
@@ -15,7 +15,7 @@ interface Props {
   children: string;
   href: string;
   icon?: ReactNode;
-  id?: MetadataKeys;
+  id?: MetadataId;
   missingIcon?: ReactNode;
 }
 
@@ -40,7 +40,7 @@ export function MetadataListLinkItem({
 
   return (
     <MetadataHighlighter
-      id={id}
+      metadataId={id}
       component="li"
       className={clsx(
         'flex',

--- a/frontend/src/components/PluginDetails/PluginDetails.tsx
+++ b/frontend/src/components/PluginDetails/PluginDetails.tsx
@@ -37,9 +37,9 @@ function PluginCenterColumn() {
   const { plugin } = usePluginState();
   const [t] = useTranslation(['common', 'pluginPage', 'preview', 'pluginData']);
 
-  usePreviewClickAway('name');
-  usePreviewClickAway('summary');
-  usePreviewClickAway('description');
+  usePreviewClickAway('metadata-name');
+  usePreviewClickAway('metadata-summary');
+  usePreviewClickAway('metadata-description');
 
   // Check if body is an empty string or if it's set to the cookiecutter text.
   const isEmptyDescription =
@@ -60,11 +60,14 @@ function PluginCenterColumn() {
         className="h-12"
         render={() => (
           <MetadataHighlighter
-            id="name"
+            metadataId="metadata-name"
             className="flex justify-between"
             highlight={!plugin?.name}
             tooltip={
-              <EmptyMetadataTooltip className="self-end" metadataId="name" />
+              <EmptyMetadataTooltip
+                className="self-end"
+                metadataId="metadata-name"
+              />
             }
           >
             <h1
@@ -83,7 +86,7 @@ function PluginCenterColumn() {
         className="h-6 my-6"
         render={() => (
           <MetadataHighlighter
-            id="summary"
+            metadataId="metadata-summary"
             className="flex justify-between items-center my-6"
             highlight={!plugin?.summary}
           >
@@ -179,7 +182,7 @@ function PluginCenterColumn() {
         className="h-[600px] mb-10"
         render={() => (
           <MetadataHighlighter
-            id="description"
+            metadataId="metadata-description"
             className="flex items-center justify-between mb-10"
             highlight={isEmptyDescription}
           >

--- a/frontend/src/components/PluginDetails/PluginMetadata.tsx
+++ b/frontend/src/components/PluginDetails/PluginMetadata.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/MetadataList';
 import {
   Metadata,
+  MetadataId,
   MetadataKeys,
   usePluginMetadata,
   usePluginState,
@@ -120,7 +121,7 @@ function PluginMetadataBase({
 
     return (
       <MetadataList
-        id={key}
+        id={`metadata-${key}`}
         inline={inline}
         label={label}
         empty={!value}
@@ -139,7 +140,7 @@ function PluginMetadataBase({
 
     return (
       <MetadataList
-        id={key as MetadataKeys}
+        id={`metadata-${key}` as MetadataId}
         inline={inline}
         label={label}
         empty={isEmpty(values)}
@@ -157,7 +158,7 @@ function PluginMetadataBase({
       className="h-56"
       render={() => (
         <>
-          {renderSingleItemList('version', { highlight: false })}
+          {renderSingleItemList('version')}
           {renderSingleItemList('releaseDate', { highlight: false })}
           {renderSingleItemList('firstReleased')}
           {renderSingleItemList('license')}

--- a/frontend/src/components/PluginDetails/SupportInfo.tsx
+++ b/frontend/src/components/PluginDetails/SupportInfo.tsx
@@ -18,7 +18,7 @@ import {
   MetadataListLinkItem,
   MetadataListTextItem,
 } from '@/components/MetadataList';
-import { MetadataKeys, usePluginMetadata } from '@/context/plugin';
+import { MetadataId, MetadataKeys, usePluginMetadata } from '@/context/plugin';
 
 import { ANCHOR } from './CitationInfo.constants';
 import styles from './SupportInfo.module.scss';
@@ -56,7 +56,7 @@ interface CommonProps {
 }
 
 interface MetadataLinkItem {
-  id: MetadataKeys;
+  id: MetadataId;
   text: string;
   href: string;
   icon?: ReactNode;
@@ -75,11 +75,11 @@ export function SupportInfoBase({ className, inline }: SupportInfoBaseProps) {
   const metadata = usePluginMetadata();
   const learnMoreItems: MetadataLinkItem[] = [];
 
-  function getLink(key: MetadataKeys) {
+  function getLink(key: MetadataKeys): MetadataLinkItem {
     const data = metadata[key];
 
     return {
-      id: key,
+      id: `metadata-${key}`,
       text: data.label,
       href: data.value as string,
     };
@@ -125,7 +125,7 @@ export function SupportInfoBase({ className, inline }: SupportInfoBaseProps) {
 
   if (metadata.citations.value) {
     learnMoreItems.push({
-      id: 'citations',
+      id: 'metadata-citations',
       href: `${metadata.name.value}#${ANCHOR}`,
       text: metadata.citations.label,
       icon: <Quotes />,
@@ -147,7 +147,7 @@ export function SupportInfoBase({ className, inline }: SupportInfoBaseProps) {
       )}
     >
       <MetadataList
-        id="authors"
+        id="metadata-authors"
         label={metadata.authors.label}
         empty={isEmpty(metadata.authors.value)}
         inline={inline}
@@ -170,7 +170,7 @@ export function SupportInfoBase({ className, inline }: SupportInfoBaseProps) {
       </MetadataList>
 
       <MetadataList
-        id="sourceCode"
+        id="metadata-sourceCode"
         label={metadata.sourceCode.label}
         empty={!metadata.sourceCode.value}
         inline={inline}

--- a/frontend/src/context/plugin.tsx
+++ b/frontend/src/context/plugin.tsx
@@ -275,3 +275,5 @@ export type MetadataKeys = keyof Omit<
   Metadata,
   'actionRepository' | 'workflowSteps' | 'imageModality' | 'supportedData'
 >;
+
+export type MetadataId = `metadata-${MetadataKeys}`;

--- a/frontend/src/hooks/usePreviewClickAway.ts
+++ b/frontend/src/hooks/usePreviewClickAway.ts
@@ -1,7 +1,8 @@
 import { useEffect, useRef } from 'react';
 import { useSnapshot } from 'valtio';
 
-import { MetadataKeys } from '@/context/plugin';
+import { PREVIEW_METADATA_FIELD_CLASS_NAME } from '@/components/AppBar/PreviewMetadataPanel';
+import { MetadataId } from '@/context/plugin';
 import { previewStore } from '@/store/preview';
 import { setUrlHash } from '@/utils';
 
@@ -13,9 +14,22 @@ import { setUrlHash } from '@/utils';
  *
  * @param id The ID of the field to check for in the click away handler.
  */
-export function usePreviewClickAway(id: MetadataKeys | undefined) {
+export function usePreviewClickAway(id?: MetadataId) {
   const snap = useSnapshot(previewStore);
-  const handleClickAwayRef = useRef(() => {
+  const handleClickAwayRef = useRef((event: MouseEvent) => {
+    const metadataHighlighters = document.getElementsByClassName(
+      PREVIEW_METADATA_FIELD_CLASS_NAME,
+    );
+
+    // Do not close metadata field if clicking on preview metadata field.
+    if (
+      Array.from(metadataHighlighters).some((node) =>
+        node.contains(event.target as Node),
+      )
+    ) {
+      return;
+    }
+
     // Clear active metadata field for the current metadata if the IDs match.
     if (previewStore.activeMetadataField === id) {
       previewStore.activeMetadataField = '';

--- a/frontend/src/pages/preview.tsx
+++ b/frontend/src/pages/preview.tsx
@@ -9,7 +9,7 @@ import { DeepPartial } from 'utility-types';
 
 import { PluginDetails } from '@/components/PluginDetails';
 import { DEFAULT_PLUGIN_DATA, DEFAULT_REPO_DATA } from '@/constants/plugin';
-import { MetadataKeys, PluginStateProvider } from '@/context/plugin';
+import { MetadataId, PluginStateProvider } from '@/context/plugin';
 import { PROD } from '@/env';
 import { previewStore } from '@/store/preview';
 import { PluginData } from '@/types';
@@ -67,8 +67,8 @@ export default function PreviewPage({ plugin, repo, repoFetchError }: Props) {
   // Set active metadata ID on initial load if the hash is already set.
   useEffect(() => {
     const id = window.location.hash.replace('#', '');
-    if (id) {
-      previewStore.activeMetadataField = id as MetadataKeys;
+    if (id && id.startsWith('metadata-')) {
+      previewStore.activeMetadataField = id as MetadataId;
     }
   }, []);
 

--- a/frontend/src/store/preview.ts
+++ b/frontend/src/store/preview.ts
@@ -1,11 +1,11 @@
 import { proxy } from 'valtio';
 
-import { MetadataKeys } from '@/context/plugin';
+import { MetadataId } from '@/context/plugin';
 
 export const previewStore = proxy({
   /**
    * Currently focused metadata field. This is used for rendering the focus
    * border and opening the tooltip.
    */
-  activeMetadataField: '' as MetadataKeys | '',
+  activeMetadataField: '' as MetadataId | '',
 });


### PR DESCRIPTION
Fixes:

- https://github.com/chanzuckerberg/napari-hub/issues/364
- https://github.com/chanzuckerberg/napari-hub/issues/451

This works by adding a the prefix `metadata-` to plugin metadata IDs. 

FYI: @justinelarsen @neuromusic 
For review: @klai95 @kne42 