### PR TITLE
Manifest available through API call

### DIFF
--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -74,7 +74,7 @@ def plugin_manifest(plugin: str, version: str = None) -> Response:
         if manifest['process_count'] >= max_failure_tries:
             return app.make_response(("Plugin Manifest Not Found", 404))
         elif manifest['process_count'] < max_failure_tries:
-            response = app.make_response(("Temporarily Unavailable", 503))
+            response = app.make_response(("Temporarily Unavailable my plugin!", 503))
             response.headers["Retry-After"] = 300
             return response
     else:

--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -69,17 +69,18 @@ def versioned_plugin(plugin: str, version: str = None) -> Response:
 @app.route('/manifest/<plugin>/versions/<version>')
 def plugin_manifest(plugin: str, version: str = None) -> Response:
     max_failure_tries = 2
-    print(plugin)
     manifest = get_manifest(plugin, version)
 
     if 'process_count' in manifest:
-        print("Oops")
         if manifest['process_count'] >= max_failure_tries:
-            return app.make_response(("Plugin Manifest Not Found", 404))
+            return app.make_response(("Plugin Manifest Not Found. Installation failed or plugin does not implement npe2", 404))
         elif manifest['process_count'] < max_failure_tries:
-            response = app.make_response(("Temporarily Unavailable my plugin!", 503))
+            response = app.make_response(("Temporarily Unavailable. Attempting to build manifest. Please check back "
+                                          "in 5 minutes.", 503))
             response.headers["Retry-After"] = 300
             return response
+    elif manifest == {}:
+        return app.make_response(("Plugin does not exist", 404))
     else:
         return yaml.dump(manifest)
 

--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -5,7 +5,7 @@ from flask import Flask, Response, jsonify, render_template
 from flask_githubapp.core import GitHubApp
 
 from api.model import get_public_plugins, get_index, get_plugin, get_excluded_plugins, update_cache, \
-    move_artifact_to_s3, get_category_mapping, get_categories_mapping
+    move_artifact_to_s3, get_category_mapping, get_categories_mapping, get_manifest
 from api.shield import get_shield
 from utils.utils import send_alert, reformat_ssh_key_to_pem_bytes
 
@@ -62,6 +62,19 @@ def plugins() -> Response:
 @app.route('/plugins/<plugin>/versions/<version>')
 def versioned_plugin(plugin: str, version: str = None) -> Response:
     return jsonify(get_plugin(plugin, version))
+
+
+@app.route('/manifest/<plugin>', defaults={'version': None})
+@app.route('/manifest/<plugin>/versions/<version>')
+def plugin_manifest(plugin: str, version: str = None) -> Response:
+    max_failure_tries = 2
+    manifest = get_manifest(plugin, version)
+    if manifest and 'process_count' in manifest:
+        if manifest['process_count'] >= max_failure_tries:
+            return app.make_response(("Plugin Manifest Not Found", 404))
+        elif manifest['process_count'] < max_failure_tries:
+            return app.make_response(("Temporarily Unavailable", 503))
+    return jsonify(manifest)
 
 
 @app.route('/shields/<plugin>')

--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -69,8 +69,11 @@ def versioned_plugin(plugin: str, version: str = None) -> Response:
 @app.route('/manifest/<plugin>/versions/<version>')
 def plugin_manifest(plugin: str, version: str = None) -> Response:
     max_failure_tries = 2
+    print(plugin)
     manifest = get_manifest(plugin, version)
+
     if 'process_count' in manifest:
+        print("Oops")
         if manifest['process_count'] >= max_failure_tries:
             return app.make_response(("Plugin Manifest Not Found", 404))
         elif manifest['process_count'] < max_failure_tries:

--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -71,18 +71,21 @@ def plugin_manifest(plugin: str, version: str = None) -> Response:
     max_failure_tries = 2
     manifest = get_manifest(plugin, version)
 
-    if 'process_count' in manifest:
-        if manifest['process_count'] >= max_failure_tries:
-            return app.make_response(("Plugin Manifest Not Found. Installation failed or plugin does not implement npe2", 404))
-        elif manifest['process_count'] < max_failure_tries:
-            response = app.make_response(("Temporarily Unavailable. Attempting to build manifest. Please check back "
-                                          "in 5 minutes.", 503))
-            response.headers["Retry-After"] = 300
-            return response
-    elif manifest == {}:
+    if not manifest:
         return app.make_response(("Plugin does not exist", 404))
+
+    if 'process_count' not in manifest:
+        return manifest
+
+    current_tries = manifest['process_count']
+    if current_tries >= max_failure_tries:
+        return app.make_response(
+            ("Plugin Manifest Not Found. Installation failed or plugin does not implement npe2", 404))
     else:
-        return yaml.dump(manifest)
+        response = app.make_response(("Temporarily Unavailable. Attempting to build manifest. Please check back"
+                                      " in 5 minutes.", 503))
+        response.headers["Retry-After"] = 300
+        return response
 
 
 @app.route('/shields/<plugin>')

--- a/backend/api/model.py
+++ b/backend/api/model.py
@@ -4,7 +4,6 @@ from typing import Tuple, Dict, List
 from zipfile import ZipFile
 from io import BytesIO
 from collections import defaultdict
-from flask import abort
 
 from utils.github import get_github_metadata, get_artifact
 from utils.pypi import query_pypi, get_plugin_pypi_metadata

--- a/backend/api/model.py
+++ b/backend/api/model.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 
 from utils.github import get_github_metadata, get_artifact
 from utils.pypi import query_pypi, get_plugin_pypi_metadata
-from api.s3 import get_cache, cache, get_cache_manifest, write_cache_manifest
+from api.s3 import get_cache, cache, write_cache_manifest
 from utils.utils import render_description, send_alert, get_attribute, get_category_mapping
 from utils.datadog import report_metrics
 from api.zulip import notify_new_packages
@@ -86,7 +86,7 @@ def get_manifest(plugin: str, version: str = None) -> dict:
         return {}
     elif version is None:
         version = plugins[plugin]
-    plugin = get_cache_manifest(f'cache/{plugin}/{version}.yaml')
+    plugin = get_cache(f'cache/{plugin}/{version}.yaml', 'yaml')
     if plugin:
         return plugin
     else:

--- a/backend/api/model.py
+++ b/backend/api/model.py
@@ -86,7 +86,9 @@ def get_manifest(plugin: str, version: str = None) -> dict:
         return {}
     elif version is None:
         version = plugins[plugin]
+    print(version)
     plugin = get_cache(f'cache/{plugin}/{version}.yaml', 'yaml')
+    print(plugin)
     if plugin:
         return plugin
     else:

--- a/backend/api/model.py
+++ b/backend/api/model.py
@@ -61,10 +61,10 @@ def get_plugin(plugin: str, version: str = None) -> dict:
     :param version: version of the plugin
     :return: plugin metadata dictionary
     """
-    if version is None:
-        plugins = get_valid_plugins()
-        if plugin not in plugins:
-            return {}
+    plugins = get_valid_plugins()
+    if plugin not in plugins:
+        return {}
+    elif version is None:
         version = plugins[plugin]
     plugin = get_cache(f'cache/{plugin}/{version}.json')
     if plugin:

--- a/backend/api/model.py
+++ b/backend/api/model.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 
 from utils.github import get_github_metadata, get_artifact
 from utils.pypi import query_pypi, get_plugin_pypi_metadata
-from api.s3 import get_cache, cache, write_cache_manifest
+from api.s3 import get_cache, cache
 from utils.utils import render_description, send_alert, get_attribute, get_category_mapping
 from utils.datadog import report_metrics
 from api.zulip import notify_new_packages
@@ -90,8 +90,8 @@ def get_manifest(plugin: str, version: str = None) -> dict:
     if plugin:
         return plugin
     else:
-        write_cache_manifest({"process_count": 0}, f'cache/{plugin}/{version}.yaml')
-        return {"process_count": 0}
+        cache({"process_count": 3}, f'cache/{plugin}/{version}.yaml', format = 'yaml')
+        return {"process_count": 3}
 
 
 def get_index() -> dict:

--- a/backend/api/model.py
+++ b/backend/api/model.py
@@ -4,6 +4,7 @@ from typing import Tuple, Dict, List
 from zipfile import ZipFile
 from io import BytesIO
 from collections import defaultdict
+from flask import abort
 
 from utils.github import get_github_metadata, get_artifact
 from utils.pypi import query_pypi, get_plugin_pypi_metadata
@@ -67,6 +68,26 @@ def get_plugin(plugin: str, version: str = None) -> dict:
     elif version is None:
         version = plugins[plugin]
     plugin = get_cache(f'cache/{plugin}/{version}.json')
+    if plugin:
+        return plugin
+    else:
+        return {}
+
+
+def get_manifest(plugin: str, version: str = None) -> dict:
+    """
+    Get plugin manifest file for a particular plugin, get latest if version is None.
+
+    :param plugin: name of the plugin to get
+    :param version: version of the plugin manifest
+    :return: plugin manifest dictionary
+    """
+    plugins = get_valid_plugins()
+    if plugin not in plugins:
+        return {}
+    elif version is None:
+        version = plugins[plugin]
+    plugin = get_cache(f'cache/{plugin}/{version}.yaml')
     if plugin:
         return plugin
     else:

--- a/backend/api/model.py
+++ b/backend/api/model.py
@@ -61,10 +61,10 @@ def get_plugin(plugin: str, version: str = None) -> dict:
     :param version: version of the plugin
     :return: plugin metadata dictionary
     """
-    plugins = get_valid_plugins()
-    if plugin not in plugins:
-        return {}
-    elif version is None:
+    if version is None:
+        plugins = get_valid_plugins()
+        if plugin not in plugins:
+            return {}
         version = plugins[plugin]
     plugin = get_cache(f'cache/{plugin}/{version}.json')
     if plugin:

--- a/backend/api/model.py
+++ b/backend/api/model.py
@@ -8,7 +8,7 @@ from flask import abort
 
 from utils.github import get_github_metadata, get_artifact
 from utils.pypi import query_pypi, get_plugin_pypi_metadata
-from api.s3 import get_cache, cache
+from api.s3 import get_cache, cache, get_cache_manifest, write_cache_manifest
 from utils.utils import render_description, send_alert, get_attribute, get_category_mapping
 from utils.datadog import report_metrics
 from api.zulip import notify_new_packages
@@ -87,11 +87,12 @@ def get_manifest(plugin: str, version: str = None) -> dict:
         return {}
     elif version is None:
         version = plugins[plugin]
-    plugin = get_cache(f'cache/{plugin}/{version}.yaml')
+    plugin = get_cache_manifest(f'cache/{plugin}/{version}.yaml')
     if plugin:
         return plugin
     else:
-        return {}
+        write_cache_manifest({"process_count": 0}, f'cache/{plugin}/{version}.yaml')
+        return {"process_count": 0}
 
 
 def get_index() -> dict:

--- a/backend/api/model.py
+++ b/backend/api/model.py
@@ -86,14 +86,12 @@ def get_manifest(plugin: str, version: str = None) -> dict:
         return {}
     elif version is None:
         version = plugins[plugin]
-    print(version)
     plugin = get_cache(f'cache/{plugin}/{version}.yaml', 'yaml')
-    print(plugin)
     if plugin:
         return plugin
     else:
-        cache({"process_count": 3}, f'cache/{plugin}/{version}.yaml', format = 'yaml')
-        return {"process_count": 3}
+        cache({"process_count": 0}, f'cache/{plugin}/{version}.yaml', format='yaml')
+        return {"process_count": 0}
 
 
 def get_index() -> dict:

--- a/backend/api/s3.py
+++ b/backend/api/s3.py
@@ -7,6 +7,7 @@ from typing import Union, IO, List, Dict
 import mimetypes
 
 import boto3
+import yaml
 from botocore.exceptions import ClientError
 from botocore.client import Config
 
@@ -32,6 +33,40 @@ def get_cache(key: str) -> Union[Dict, List, None]:
     except ClientError:
         print(f"Not cached: {key}")
         return None
+
+
+def get_cache_manifest(key: str) -> Union[Dict, List, None]:
+    """
+    Get the cached manifest file for a given key if exists, None otherwise.
+
+    :param key: key to the cache to get
+    :return: file content for the key if exists, None otherwise
+    """
+    try:
+        return yaml.safe_load(s3_client.get_object(Bucket=bucket, Key=os.path.join(bucket_path, key))['Body'])
+    except ClientError:
+        print(f"Not cached: {key}")
+        return None
+
+
+def write_cache_manifest(content: dict, key: str):
+    """
+    Cache the given content to the key location in yaml format
+
+    :param key: key path in s3
+    :param content: content to cache
+    """
+
+    extra_args = None
+    if bucket is None:
+        send_alert(f"({datetime.now()}) Unable to find bucket for lambda "
+                   f"configuration, skipping caching for napari hub."
+                   f"Check terraform setup to add environment variable for "
+                   f"napari hub lambda")
+        return content
+    with io.BytesIO(yaml.dump(content).encode('utf8')) as stream:
+        s3_client.upload_fileobj(Fileobj=stream, Bucket=bucket,
+                                 Key=os.path.join(bucket_path, key), ExtraArgs=extra_args)
 
 
 def cache(content: Union[dict, list, IO[bytes]], key: str, mime: str = None):

--- a/backend/api/s3.py
+++ b/backend/api/s3.py
@@ -29,6 +29,7 @@ def get_cache(key: str, format: str = 'json') -> Union[Dict, List, None]:
     :return: file content for the key if exists, None otherwise
     """
     try:
+        print("Get Cache function ")
         if format == 'json':
             return json.loads(s3_client.get_object(Bucket=bucket, Key=os.path.join(bucket_path, key))['Body'].read())
         elif format == 'yaml':
@@ -61,6 +62,7 @@ def cache(content: Union[dict, list, IO[bytes]], key: str, mime: str = None, for
         s3_client.upload_fileobj(Fileobj=content, Bucket=bucket,
                                  Key=os.path.join(bucket_path, key), ExtraArgs=extra_args)
     else:
+        print("Write cache function")
         with io.BytesIO(json.dumps(content).encode('utf8') if format == 'json' else
                         yaml.dump(content).encode('utf8')) as stream:
             s3_client.upload_fileobj(Fileobj=stream, Bucket=bucket,

--- a/backend/api/s3.py
+++ b/backend/api/s3.py
@@ -29,7 +29,6 @@ def get_cache(key: str, format: str = 'json') -> Union[Dict, List, None]:
     :return: file content for the key if exists, None otherwise
     """
     try:
-        print("Get Cache function ")
         if format == 'json':
             return json.loads(s3_client.get_object(Bucket=bucket, Key=os.path.join(bucket_path, key))['Body'].read())
         elif format == 'yaml':
@@ -62,7 +61,6 @@ def cache(content: Union[dict, list, IO[bytes]], key: str, mime: str = None, for
         s3_client.upload_fileobj(Fileobj=content, Bucket=bucket,
                                  Key=os.path.join(bucket_path, key), ExtraArgs=extra_args)
     else:
-        print("Write cache function")
         with io.BytesIO(json.dumps(content).encode('utf8') if format == 'json' else
                         yaml.dump(content).encode('utf8')) as stream:
             s3_client.upload_fileobj(Fileobj=stream, Bucket=bucket,

--- a/backend/api/s3.py
+++ b/backend/api/s3.py
@@ -21,29 +21,19 @@ endpoint_url = os.environ.get('BOTO_ENDPOINT_URL', None)
 s3_client = boto3.client("s3", endpoint_url=endpoint_url, config=Config(max_pool_connections=50))
 
 
-def get_cache(key: str) -> Union[Dict, List, None]:
+def get_cache(key: str, format: str = 'json') -> Union[Dict, List, None]:
     """
-    Get the cached file for a given key if exists, None otherwise.
+    Get the cached json file or manifest file for a given key if exists, None otherwise.
 
     :param key: key to the cache to get
+    :param format: Format of the file to obtain
     :return: file content for the key if exists, None otherwise
     """
     try:
-        return json.loads(s3_client.get_object(Bucket=bucket, Key=os.path.join(bucket_path, key))['Body'].read())
-    except ClientError:
-        print(f"Not cached: {key}")
-        return None
-
-
-def get_cache_manifest(key: str) -> Union[Dict, List, None]:
-    """
-    Get the cached manifest file for a given key if exists, None otherwise.
-
-    :param key: key to the cache to get
-    :return: file content for the key if exists, None otherwise
-    """
-    try:
-        return yaml.safe_load(s3_client.get_object(Bucket=bucket, Key=os.path.join(bucket_path, key))['Body'])
+        if format == 'json':
+            return json.loads(s3_client.get_object(Bucket=bucket, Key=os.path.join(bucket_path, key))['Body'].read())
+        elif format == 'yaml':
+            return yaml.safe_load(s3_client.get_object(Bucket=bucket, Key=os.path.join(bucket_path, key))['Body'])
     except ClientError:
         print(f"Not cached: {key}")
         return None

--- a/backend/api/templates/swagger.yml
+++ b/backend/api/templates/swagger.yml
@@ -277,4 +277,5 @@ components:
     Manifest:
       type: object
       properties:
-        process_count: integer
+        process_count:
+          type: integer

--- a/backend/api/templates/swagger.yml
+++ b/backend/api/templates/swagger.yml
@@ -132,7 +132,7 @@ paths:
                 $ref: '#/components/schemas/Shield'
   /manifest/{name}:
     get:
-      summary: Get the manifest file for plugin
+      summary: Get the manifest file for plugin. Schema here https://napari.org/plugins/manifest.html
       tags:
         - manifest
       parameters:
@@ -145,7 +145,7 @@ paths:
         example: napari-demo
       responses:
         200:
-          description: The return yaml object is the plugin's manifest, and is empty if the plugin name is invalid or disabled
+          description: The return yaml object is the plugin's manifest.
           content:
             application/x-yaml:
               schema:
@@ -277,5 +277,18 @@ components:
     Manifest:
       type: object
       properties:
+        name:
+          type: string
+        display_name:
+          type: string
         process_count:
           type: integer
+        schema_version:
+          type: integer
+        on_activate:
+          type: string
+        on_deactivate:
+          type: string
+        contributions:
+          type: array
+

--- a/backend/api/templates/swagger.yml
+++ b/backend/api/templates/swagger.yml
@@ -26,6 +26,8 @@ tags:
     externalDocs:
       description: Find out more
       url: https://shields.io/
+  - name: manifest
+    description: The manifest file corresponding to npe2 for plugin
 paths:
   /plugins:
     get:
@@ -128,6 +130,26 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Shield'
+  /manifest/{name}:
+    get:
+      summary: Get the manifest file for plugin
+      tags:
+        - manifest
+      parameters:
+      - name: name
+        in: path
+        description: name of plugin to query
+        required: true
+        schema:
+          type: string
+        example: napari-demo
+      responses:
+        200:
+          description: The return yaml object is the plugin's manifest, and is empty if the plugin name is invalid or disabled
+          content:
+            application/x-yaml:
+              schema:
+                $ref: '#/components/schemas/Manifest'
 components:
   schemas:
     Categories:
@@ -252,3 +274,7 @@ components:
           type: integer
         style:
           type: string
+    Manifest:
+      type: object
+      properties:
+        process_count: integer

--- a/backend/api/templates/swagger.yml
+++ b/backend/api/templates/swagger.yml
@@ -150,6 +150,10 @@ paths:
             application/x-yaml:
               schema:
                 $ref: '#/components/schemas/Manifest'
+        404:
+          description: Either the plugin name is incorrect or the manifest was not found. The latter could happen if the installation failed or if the plugin does not implement npe2 yet.
+        503:
+          description: The manifest is temporarily unavailable. Check back in 5 minutes.
 components:
   schemas:
     Categories:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,4 +14,4 @@ wheel
 pkginfo
 datadog-lambda
 build
-cryptography==36.0.2
+pyOpenSSL

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,4 @@ wheel
 pkginfo
 datadog-lambda
 build
+cryptography==36.0.2


### PR DESCRIPTION
Changes in model.py : Mimics the behaviour of get_plugin which makes version.json available
Changes in app.py: After receiving the manifest dictionary from get_manifest function, it checks for the value of process_count to throw the appropriate error. I have set 503 as the code for temporarily unavailable as opposed to some 3xx code based on [this](https://airbrake.io/blog/http-errors/503-service-unavailable#:~:text=A%20503%20Service%20Unavailable%20Error,server%20that's%20down%20for%20maintenance.).