### PR TITLE
Plugin metadata links + authors filter

### DIFF
--- a/frontend/eslint/typescript.js
+++ b/frontend/eslint/typescript.js
@@ -32,7 +32,7 @@ module.exports = {
     },
   },
 
-  plugins: ['simple-import-sort'],
+  plugins: ['simple-import-sort', 'unused-imports'],
 
   rules: {
     // It's helpful to split functionality into multiple functions within a class.
@@ -54,5 +54,16 @@ module.exports = {
     'no-restricted-syntax': config.rules['no-restricted-syntax'].filter(
       (rule) => rule.selector !== 'ForOfStatement',
     ),
+
+    'unused-imports/no-unused-imports': 'error',
+    'unused-imports/no-unused-vars': [
+      'error',
+      {
+        vars: 'all',
+        varsIgnorePattern: '^_',
+        args: 'after-used',
+        argsIgnorePattern: '^_',
+      },
+    ],
   },
 };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -144,6 +144,7 @@
     "eslint-plugin-react": "^7.26.1",
     "eslint-plugin-react-hooks": "^4.3.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
+    "eslint-plugin-unused-imports": "^2.0.0",
     "expect-playwright": "^0.8.0",
     "express": "^4.17.1",
     "husky": "^7.0.4",

--- a/frontend/src/components/MetadataList/MetadataListMetadataItem.tsx
+++ b/frontend/src/components/MetadataList/MetadataListMetadataItem.tsx
@@ -1,0 +1,158 @@
+import clsx from 'clsx';
+import { isString } from 'lodash';
+import { useTranslation } from 'next-i18next';
+import { ReactNode } from 'react';
+import { useQuery } from 'react-query';
+
+import { spdxLicenseDataAPI } from '@/axios';
+import { MetadataKeys } from '@/context/plugin';
+import {
+  FILTER_OS_PATTERN,
+  SUPPORTED_PYTHON_VERSIONS,
+} from '@/store/search/filter.store';
+import { PARAM_KEY_MAP, PARAM_VALUE_MAP } from '@/store/search/queryParameters';
+import { SpdxLicenseResponse } from '@/store/search/types';
+import { PluginType, PluginWriterSaveLayer } from '@/types';
+
+import { Link } from '../common/Link';
+import styles from './MetadataList.module.scss';
+import { MetadataListTextItem } from './MetadataListTextItem';
+
+type MetadataLinkKeys = MetadataKeys | 'supportedData';
+
+interface Props {
+  children: ReactNode;
+  className?: string;
+  metadataKey: MetadataLinkKeys;
+}
+
+function useMetadataValueLabel(
+  key?: MetadataLinkKeys,
+  value?: ReactNode,
+): ReactNode {
+  const { t } = useTranslation(['pluginData']);
+
+  if (!key) {
+    return value;
+  }
+
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  switch (key) {
+    case 'pluginType':
+      switch (value) {
+        case PluginType.Reader:
+          return t('pluginData:labels.pluginType.reader');
+
+        case PluginType.Writer:
+          return t('pluginData:labels.pluginType.writer');
+
+        default:
+          return value;
+      }
+
+    case 'writerSaveLayers':
+      switch (value) {
+        case PluginWriterSaveLayer.Image:
+          return t('pluginData:labels.writerSaveLayers.image');
+
+        case PluginWriterSaveLayer.Points:
+          return t('pluginData:labels.writerSaveLayers.points');
+
+        case PluginWriterSaveLayer.Shapes:
+          return t('pluginData:labels.writerSaveLayers.shapes');
+
+        default:
+          return value;
+      }
+
+    case 'operatingSystems':
+      return value.split(' :: ').at(-1);
+
+    default:
+      return value;
+  }
+}
+
+const METADATA_FILTER_LINKS = new Set<MetadataLinkKeys>([
+  'license',
+  'operatingSystems',
+  'pluginType',
+  'pythonVersion',
+  'readerFileExtensions',
+  'supportedData',
+  'writerFileExtensions',
+  'writerSaveLayers',
+]);
+
+/**
+ * Component for rendering text items in metadata lists.
+ */
+export function MetadataListMetadataItem({
+  children: value,
+  className,
+  metadataKey,
+}: Props) {
+  const valueLabel = useMetadataValueLabel(metadataKey, value);
+
+  // Fetch SDPX license data to check if current license is OSI Approved.
+  const { data: licenses } = useQuery(
+    ['spdx'],
+    async () => {
+      const { data } = await spdxLicenseDataAPI.get<SpdxLicenseResponse>('');
+      return data.licenses;
+    },
+    { enabled: metadataKey === 'license' },
+  );
+
+  const isOsiApproved =
+    metadataKey === 'license' &&
+    isString(value) &&
+    licenses?.some(
+      (license) => license.licenseId === value && license.isOsiApproved,
+    );
+
+  let filterValue: string | undefined;
+
+  if (isString(value)) {
+    if (isOsiApproved) {
+      filterValue = PARAM_VALUE_MAP.openSource;
+    } else if (metadataKey === 'pythonVersion') {
+      for (const version of SUPPORTED_PYTHON_VERSIONS) {
+        if (value.includes(version)) {
+          filterValue = version;
+          break;
+        }
+      }
+    } else if (metadataKey === 'operatingSystems') {
+      if (FILTER_OS_PATTERN.windows.exec(value)) {
+        filterValue = 'windows';
+      } else if (FILTER_OS_PATTERN.mac.exec(value)) {
+        filterValue = 'macos';
+      } else if (FILTER_OS_PATTERN.linux.exec(value)) {
+        filterValue = 'linux';
+      }
+    } else if (metadataKey !== 'license') {
+      filterValue = PARAM_VALUE_MAP[value] ?? value;
+    }
+  }
+  const paramKey = PARAM_KEY_MAP[metadataKey] ?? metadataKey;
+  const url = filterValue && `/?${paramKey}=${encodeURIComponent(filterValue)}`;
+
+  return (
+    <MetadataListTextItem>
+      {url && METADATA_FILTER_LINKS.has(metadataKey) ? (
+        <Link
+          className={clsx(styles.textItem, className, 'underline')}
+          href={url}
+        >
+          {valueLabel}
+        </Link>
+      ) : (
+        valueLabel
+      )}
+    </MetadataListTextItem>
+  );
+}

--- a/frontend/src/components/MetadataList/MetadataListMetadataItem.tsx
+++ b/frontend/src/components/MetadataList/MetadataListMetadataItem.tsx
@@ -26,17 +26,17 @@ interface Props {
   metadataKey: MetadataLinkKeys;
 }
 
+/**
+ * Gets the the label to use when rendering a metadata value. If the metadata
+ * has no associated value label, then the value is used directly.
+ */
 function useMetadataValueLabel(
   key?: MetadataLinkKeys,
   value?: ReactNode,
 ): ReactNode {
   const { t } = useTranslation(['pluginData']);
 
-  if (!key) {
-    return value;
-  }
-
-  if (typeof value !== 'string') {
+  if (!key || typeof value !== 'string') {
     return value;
   }
 
@@ -76,6 +76,9 @@ function useMetadataValueLabel(
   }
 }
 
+/**
+ * Allowlist of metadata that has an associated filter on the search page.
+ */
 const METADATA_FILTER_LINKS = new Set<MetadataLinkKeys>([
   'authors',
   'license',
@@ -89,7 +92,7 @@ const METADATA_FILTER_LINKS = new Set<MetadataLinkKeys>([
 ]);
 
 /**
- * Component for rendering text items in metadata lists.
+ * Component for rendering a metadata value.
  */
 export function MetadataListMetadataItem({
   children: value,
@@ -121,27 +124,29 @@ export function MetadataListMetadataItem({
   const filterValue = useMemo(() => {
     let result: string | undefined;
 
-    if (isString(value)) {
-      if (isOsiApproved) {
-        result = PARAM_VALUE_MAP.openSource;
-      } else if (metadataKey === 'pythonVersion') {
-        for (const version of SUPPORTED_PYTHON_VERSIONS) {
-          if (value.includes(version)) {
-            result = version;
-            break;
-          }
+    if (!isString(value)) {
+      return result;
+    }
+
+    if (isOsiApproved) {
+      result = PARAM_VALUE_MAP.openSource;
+    } else if (metadataKey === 'pythonVersion') {
+      for (const version of SUPPORTED_PYTHON_VERSIONS) {
+        if (value.includes(version)) {
+          result = version;
+          break;
         }
-      } else if (metadataKey === 'operatingSystems') {
-        if (FILTER_OS_PATTERN.windows.exec(value)) {
-          result = 'windows';
-        } else if (FILTER_OS_PATTERN.mac.exec(value)) {
-          result = 'macos';
-        } else if (FILTER_OS_PATTERN.linux.exec(value)) {
-          result = 'linux';
-        }
-      } else if (metadataKey !== 'license') {
-        result = PARAM_VALUE_MAP[value] ?? value;
       }
+    } else if (metadataKey === 'operatingSystems') {
+      if (FILTER_OS_PATTERN.windows.exec(value)) {
+        result = 'windows';
+      } else if (FILTER_OS_PATTERN.mac.exec(value)) {
+        result = 'macos';
+      } else if (FILTER_OS_PATTERN.linux.exec(value)) {
+        result = 'linux';
+      }
+    } else if (metadataKey !== 'license') {
+      result = PARAM_VALUE_MAP[value] ?? value;
     }
 
     return result;

--- a/frontend/src/components/MetadataList/MetadataListMetadataItem.tsx
+++ b/frontend/src/components/MetadataList/MetadataListMetadataItem.tsx
@@ -6,14 +6,10 @@ import { useQuery } from 'react-query';
 
 import { spdxLicenseDataAPI } from '@/axios';
 import { MetadataKeys } from '@/context/plugin';
-import {
-  FILTER_OS_PATTERN,
-  SUPPORTED_PYTHON_VERSIONS,
-} from '@/store/search/filter.store';
+import { SUPPORTED_PYTHON_VERSIONS } from '@/store/search/filter.store';
 import { PARAM_KEY_MAP, PARAM_VALUE_MAP } from '@/store/search/queryParameters';
 import { SpdxLicenseResponse } from '@/store/search/types';
 import { PluginType, PluginWriterSaveLayer } from '@/types';
-import { formatOperatingSystem } from '@/utils';
 
 import { Link } from '../common/Link';
 import styles from './MetadataList.module.scss';
@@ -70,7 +66,19 @@ function useMetadataValueLabel(
       }
 
     case 'operatingSystems':
-      return formatOperatingSystem(value);
+      switch (value) {
+        case 'linux':
+          return 'Linux';
+
+        case 'windows':
+          return 'Windows';
+
+        case 'mac':
+          return 'MacOS';
+
+        default:
+          return value;
+      }
 
     default:
       return value;
@@ -137,14 +145,6 @@ export function MetadataListMetadataItem({
           result = version;
           break;
         }
-      }
-    } else if (metadataKey === 'operatingSystems') {
-      if (FILTER_OS_PATTERN.windows.exec(value)) {
-        result = 'windows';
-      } else if (FILTER_OS_PATTERN.mac.exec(value)) {
-        result = 'macos';
-      } else if (FILTER_OS_PATTERN.linux.exec(value)) {
-        result = 'linux';
       }
     } else if (metadataKey !== 'license') {
       result = PARAM_VALUE_MAP[value] ?? value;

--- a/frontend/src/components/MetadataList/MetadataListMetadataItem.tsx
+++ b/frontend/src/components/MetadataList/MetadataListMetadataItem.tsx
@@ -13,6 +13,7 @@ import {
 import { PARAM_KEY_MAP, PARAM_VALUE_MAP } from '@/store/search/queryParameters';
 import { SpdxLicenseResponse } from '@/store/search/types';
 import { PluginType, PluginWriterSaveLayer } from '@/types';
+import { formatOperatingSystem } from '@/utils';
 
 import { Link } from '../common/Link';
 import styles from './MetadataList.module.scss';
@@ -69,7 +70,7 @@ function useMetadataValueLabel(
       }
 
     case 'operatingSystems':
-      return value.split(' :: ').at(-1);
+      return formatOperatingSystem(value);
 
     default:
       return value;

--- a/frontend/src/components/MetadataList/MetadataListTextItem.tsx
+++ b/frontend/src/components/MetadataList/MetadataListTextItem.tsx
@@ -1,137 +1,16 @@
 import clsx from 'clsx';
-import { isString } from 'lodash';
-import { useTranslation } from 'next-i18next';
 import { ReactNode } from 'react';
-import { useQuery } from 'react-query';
 
-import { spdxLicenseDataAPI } from '@/axios';
-import { MetadataKeys } from '@/context/plugin';
-import { SUPPORTED_PYTHON_VERSIONS } from '@/store/search/filter.store';
-import { PARAM_KEY_MAP, PARAM_VALUE_MAP } from '@/store/search/queryParameters';
-import { SpdxLicenseResponse } from '@/store/search/types';
-import { PluginType, PluginWriterSaveLayer } from '@/types';
-
-import { Link } from '../common/Link';
 import styles from './MetadataList.module.scss';
-
-type MetadataLinkKeys = MetadataKeys | 'supportedData';
 
 interface Props {
   children: ReactNode;
   className?: string;
-  metadataKey: MetadataLinkKeys;
 }
-
-function useMetadataValueLabel(
-  key?: MetadataLinkKeys,
-  value?: ReactNode,
-): ReactNode {
-  const { t } = useTranslation(['pluginData']);
-
-  if (!key) {
-    return value;
-  }
-
-  if (typeof value !== 'string') {
-    return value;
-  }
-
-  switch (key) {
-    case 'pluginType':
-      switch (value) {
-        case PluginType.Reader:
-          return t('pluginData:labels.pluginType.reader');
-
-        case PluginType.Writer:
-          return t('pluginData:labels.pluginType.writer');
-
-        default:
-          return value;
-      }
-
-    case 'writerSaveLayers':
-      switch (value) {
-        case PluginWriterSaveLayer.Image:
-          return t('pluginData:labels.writerSaveLayers.image');
-
-        case PluginWriterSaveLayer.Points:
-          return t('pluginData:labels.writerSaveLayers.points');
-
-        case PluginWriterSaveLayer.Shapes:
-          return t('pluginData:labels.writerSaveLayers.shapes');
-
-        default:
-          return value;
-      }
-
-    default:
-      return value;
-  }
-}
-
-const METADATA_FILTER_LINKS = new Set<MetadataLinkKeys>([
-  'license',
-  'pythonVersion',
-]);
 
 /**
  * Component for rendering text items in metadata lists.
  */
-export function MetadataListTextItem({
-  children,
-  className,
-  metadataKey,
-}: Props) {
-  const valueLabel = useMetadataValueLabel(metadataKey, children);
-
-  // Fetch SDPX license data to check if current license is OSI Approved.
-  const { data: licenses } = useQuery(
-    ['spdx'],
-    async () => {
-      const { data } = await spdxLicenseDataAPI.get<SpdxLicenseResponse>('');
-      return data.licenses;
-    },
-    { enabled: metadataKey === 'license' },
-  );
-
-  const isOsiApproved =
-    metadataKey === 'license' &&
-    isString(children) &&
-    licenses?.some(
-      (license) => license.licenseId === children && license.isOsiApproved,
-    );
-
-  let filterValue: string | undefined;
-
-  if (isString(children)) {
-    if (isOsiApproved) {
-      filterValue = PARAM_VALUE_MAP.openSource;
-    } else if (metadataKey === 'pythonVersion') {
-      for (const version of SUPPORTED_PYTHON_VERSIONS) {
-        if (children.includes(version)) {
-          filterValue = version;
-          break;
-        }
-      }
-    } else if (metadataKey !== 'license') {
-      filterValue = PARAM_VALUE_MAP[children] ?? children;
-    }
-  }
-  const paramKey = PARAM_KEY_MAP[metadataKey] ?? metadataKey;
-  const url = filterValue && `/?${paramKey}=${encodeURIComponent(filterValue)}`;
-
-  return (
-    <li className={clsx(styles.textItem, className)}>
-      {url && METADATA_FILTER_LINKS.has(metadataKey) ? (
-        <Link
-          className={clsx(styles.textItem, className, 'underline')}
-          href={url}
-        >
-          {valueLabel}
-        </Link>
-      ) : (
-        valueLabel
-      )}
-    </li>
-  );
+export function MetadataListTextItem({ children, className }: Props) {
+  return <li className={clsx(styles.textItem, className)}>{children}</li>;
 }

--- a/frontend/src/components/MetadataList/MetadataListTextItem.tsx
+++ b/frontend/src/components/MetadataList/MetadataListTextItem.tsx
@@ -6,7 +6,7 @@ import { useQuery } from 'react-query';
 
 import { spdxLicenseDataAPI } from '@/axios';
 import { MetadataKeys } from '@/context/plugin';
-import { useSearchStore } from '@/store/search/context';
+import { SUPPORTED_PYTHON_VERSIONS } from '@/store/search/filter.store';
 import { PARAM_KEY_MAP, PARAM_VALUE_MAP } from '@/store/search/queryParameters';
 import { SpdxLicenseResponse } from '@/store/search/types';
 import { PluginType, PluginWriterSaveLayer } from '@/types';
@@ -69,7 +69,10 @@ function useMetadataValueLabel(
   }
 }
 
-const METADATA_FILTER_LINKS = new Set<MetadataLinkKeys>(['license']);
+const METADATA_FILTER_LINKS = new Set<MetadataLinkKeys>([
+  'license',
+  'pythonVersion',
+]);
 
 /**
  * Component for rendering text items in metadata lists.
@@ -103,6 +106,13 @@ export function MetadataListTextItem({
   if (isString(children)) {
     if (isOsiApproved) {
       filterValue = PARAM_VALUE_MAP.openSource;
+    } else if (metadataKey === 'pythonVersion') {
+      for (const version of SUPPORTED_PYTHON_VERSIONS) {
+        if (children.includes(version)) {
+          filterValue = version;
+          break;
+        }
+      }
     } else if (metadataKey !== 'license') {
       filterValue = PARAM_VALUE_MAP[children] ?? children;
     }

--- a/frontend/src/components/PluginDetails/PluginMetadata.tsx
+++ b/frontend/src/components/PluginDetails/PluginMetadata.tsx
@@ -132,10 +132,7 @@ function PluginMetadataBase({
         {...props}
       >
         {values.map((currentValue) => (
-          <MetadataListTextItem
-            key={currentValue}
-            metadataKey={key as MetadataKeys}
-          >
+          <MetadataListTextItem key={currentValue} metadataKey={key}>
             {currentValue}
           </MetadataListTextItem>
         ))}

--- a/frontend/src/components/PluginDetails/PluginMetadata.tsx
+++ b/frontend/src/components/PluginDetails/PluginMetadata.tsx
@@ -21,6 +21,8 @@ import {
 import { PluginType } from '@/types';
 import { useIsFeatureFlagEnabled } from '@/utils/featureFlags';
 
+import { MetadataListMetadataItem } from '../MetadataList/MetadataListMetadataItem';
+
 interface GithubMetadataItem {
   label: string;
   count: number;
@@ -132,9 +134,9 @@ function PluginMetadataBase({
         {...props}
       >
         {values.map((currentValue) => (
-          <MetadataListTextItem key={currentValue} metadataKey={key}>
+          <MetadataListMetadataItem key={currentValue} metadataKey={key}>
             {currentValue}
-          </MetadataListTextItem>
+          </MetadataListMetadataItem>
         ))}
       </MetadataList>
     );

--- a/frontend/src/components/PluginDetails/SupportInfo.tsx
+++ b/frontend/src/components/PluginDetails/SupportInfo.tsx
@@ -13,13 +13,10 @@ import {
   Twitter,
 } from '@/components/common/icons';
 import { Media } from '@/components/common/media';
-import {
-  MetadataList,
-  MetadataListLinkItem,
-  MetadataListTextItem,
-} from '@/components/MetadataList';
+import { MetadataList, MetadataListLinkItem } from '@/components/MetadataList';
 import { MetadataId, MetadataKeys, usePluginMetadata } from '@/context/plugin';
 
+import { MetadataListMetadataItem } from '../MetadataList/MetadataListMetadataItem';
 import { ANCHOR } from './CitationInfo.constants';
 import styles from './SupportInfo.module.scss';
 
@@ -153,7 +150,9 @@ export function SupportInfoBase({ className, inline }: SupportInfoBaseProps) {
         inline={inline}
       >
         {metadata.authors.value.map((author) => (
-          <MetadataListTextItem key={author}>{author}</MetadataListTextItem>
+          <MetadataListMetadataItem key={author} metadataKey="authors">
+            {author}
+          </MetadataListMetadataItem>
         ))}
       </MetadataList>
 

--- a/frontend/src/components/PluginSearch/PluginComplexFilter.tsx
+++ b/frontend/src/components/PluginSearch/PluginComplexFilter.tsx
@@ -32,6 +32,9 @@ import { useFilterLabels } from './useFilterLabels';
 import { useFilterOptionLabels } from './useFilterOptionLabels';
 import { useWorkflowStepGroups } from './useWorkflowStepGroups';
 
+/**
+ * Metadata filters that should have a search bar.
+ */
 const SEARCH_ENABLED_FILTERS = new Set<FilterKey>(['workflowStep', 'authors']);
 
 const CATEGORY_FILTERS = new Set<FilterKey>(['workflowStep', 'imageModality']);
@@ -145,10 +148,9 @@ export function PluginComplexFilter({ filterKey }: Props) {
       })
       .sort((option1, option2) => {
         switch (filterKey) {
+          // Sort authors alphabetically.
           case 'authors': {
-            const firstLetter1 = getFirstLetter(option1.name);
-            const firstLetter2 = getFirstLetter(option2.name);
-            return firstLetter1.localeCompare(firstLetter2);
+            return option1.name.localeCompare(option2.name);
           }
 
           default:
@@ -304,6 +306,7 @@ export function PluginComplexFilter({ filterKey }: Props) {
               return workflowStepGroups[option.stateKey] ?? '';
 
             case 'authors':
+              // Use first letter of name for author grouping.
               return getFirstLetter(option.name);
 
             default:

--- a/frontend/src/components/PluginSearch/PluginSearchControls.tsx
+++ b/frontend/src/components/PluginSearch/PluginSearchControls.tsx
@@ -35,7 +35,12 @@ export function PluginSearchControls() {
     );
   }
 
-  requirementFilters.push('pythonVersions', 'operatingSystems', 'license');
+  requirementFilters.push(
+    'authors',
+    'pythonVersions',
+    'operatingSystems',
+    'license',
+  );
 
   return (
     <aside

--- a/frontend/src/components/PluginSearch/PluginSearchControls.tsx
+++ b/frontend/src/components/PluginSearch/PluginSearchControls.tsx
@@ -37,7 +37,7 @@ export function PluginSearchControls() {
 
   requirementFilters.push(
     'authors',
-    'pythonVersions',
+    'pythonVersion',
     'operatingSystems',
     'license',
   );

--- a/frontend/src/components/PluginSearch/useFilterLabels.ts
+++ b/frontend/src/components/PluginSearch/useFilterLabels.ts
@@ -30,5 +30,6 @@ export function useFilterLabels() {
     pluginType: t('pluginData:labels.pluginType'),
     readerFileExtensions: t('pluginData:labels.readerFileExtensions'),
     writerFileExtensions: t('pluginData:labels.writerFileExtensions'),
+    authors: t('pluginData:labels.authors'),
   });
 }

--- a/frontend/src/components/PluginSearch/useFilterLabels.ts
+++ b/frontend/src/components/PluginSearch/useFilterLabels.ts
@@ -23,7 +23,7 @@ export function useFilterLabels() {
   return getLabels({
     license: t('pluginData:labels.license'),
     operatingSystems: t('pluginData:labels.operatingSystem'),
-    pythonVersions: t('pluginData:labels.pythonVersion'),
+    pythonVersion: t('pluginData:labels.pythonVersion'),
     supportedData: t('pluginData:labels.Supported data'),
     workflowStep: t('pluginData:labels.Workflow step'),
     imageModality: t('pluginData:labels.Image modality'),

--- a/frontend/src/store/search/filter.store.test.ts
+++ b/frontend/src/store/search/filter.store.test.ts
@@ -101,7 +101,7 @@ describe('filterResults()', () => {
 
       testCases.forEach(({ input, output }) => {
         const store = new SearchFilterStore({
-          pythonVersions: { 3.9: true },
+          pythonVersion: { 3.9: true },
         });
         const result = store.filterResults(input);
         expect(result).toEqual(output);

--- a/frontend/src/store/search/filter.store.ts
+++ b/frontend/src/store/search/filter.store.ts
@@ -62,6 +62,8 @@ export class SearchFilterStore implements Resettable {
 
   readerFileExtensions: FilterState<string> = {};
 
+  authors: FilterState<string> = {};
+
   private osiApprovedLicenseSet = new Set<string>();
 
   constructor(
@@ -73,6 +75,7 @@ export class SearchFilterStore implements Resettable {
     this.initOsiApprovedLicenseSet(licenses);
     this.initCategoryFilters(index);
     this.initFileExtensionFilters(index);
+    this.initAuthorFilter(index);
   }
 
   reset() {
@@ -133,6 +136,16 @@ export class SearchFilterStore implements Resettable {
         }
       }
     }
+  }
+
+  private initAuthorFilter(index: PluginIndexData[]) {
+    index.forEach(
+      (plugin) =>
+        isArray(plugin.authors) &&
+        plugin.authors.forEach((author) => {
+          this.authors[author.name] = false;
+        }),
+    );
   }
 
   private initFileExtensionFilters(index: PluginIndexData[]): void {

--- a/frontend/src/store/search/filter.store.ts
+++ b/frontend/src/store/search/filter.store.ts
@@ -33,7 +33,7 @@ const DEFAULT_PLUGIN_TYPE_STATE = Object.values(PluginType).reduce(
   {} as Partial<FilterState<PluginType>>,
 ) as FilterState<PluginType>;
 
-export const SUPPORTED_PYTHON_VERSIONS = ['3.7', '3.8', '3.9'];
+export const SUPPORTED_PYTHON_VERSIONS = ['3.6', '3.7', '3.8', '3.9'];
 
 export class SearchFilterStore implements Resettable {
   license = {

--- a/frontend/src/store/search/filter.store.ts
+++ b/frontend/src/store/search/filter.store.ts
@@ -102,6 +102,7 @@ export class SearchFilterStore implements Resettable {
       this.filterByPluginType,
       this.filterByReaderFileExtensions,
       this.filterByWriterFileExtensions,
+      this.filterByAuthor,
     ].map((fn) => fn.bind(this));
 
     // `flow()` will execute a list of functions and provide successive results to
@@ -345,5 +346,17 @@ export class SearchFilterStore implements Resettable {
           selected.has(value),
         ),
       );
+  }
+
+  private filterByAuthor(results: SearchResult[]): SearchResult[] {
+    const selected = new Set(this.getSelectedKeys(this.authors));
+    if (selected.size === 0) {
+      return results;
+    }
+
+    return results.filter(
+      ({ plugin: { authors } }) =>
+        isArray(authors) && authors.some((author) => selected.has(author.name)),
+    );
   }
 }

--- a/frontend/src/store/search/filter.store.ts
+++ b/frontend/src/store/search/filter.store.ts
@@ -33,6 +33,8 @@ const DEFAULT_PLUGIN_TYPE_STATE = Object.values(PluginType).reduce(
   {} as Partial<FilterState<PluginType>>,
 ) as FilterState<PluginType>;
 
+export const SUPPORTED_PYTHON_VERSIONS = ['3.7', '3.8', '3.9'];
+
 export class SearchFilterStore implements Resettable {
   license = {
     openSource: false,
@@ -44,11 +46,10 @@ export class SearchFilterStore implements Resettable {
     windows: false,
   };
 
-  pythonVersions = {
-    3.7: false,
-    3.8: false,
-    3.9: false,
-  };
+  pythonVersions = SUPPORTED_PYTHON_VERSIONS.reduce(
+    (state, version) => set(state, [version], false),
+    {} as FilterState<string>,
+  );
 
   supportedData: FilterState<string> = {};
 

--- a/frontend/src/store/search/filter.store.ts
+++ b/frontend/src/store/search/filter.store.ts
@@ -20,7 +20,7 @@ import {
   SpdxLicenseData,
 } from './types';
 
-const FILTER_OS_PATTERN = {
+export const FILTER_OS_PATTERN = {
   linux: /Linux/,
   mac: /MacOS/,
   windows: /Windows/,

--- a/frontend/src/store/search/filter.store.ts
+++ b/frontend/src/store/search/filter.store.ts
@@ -57,7 +57,7 @@ export class SearchFilterStore implements Resettable {
 
   imageModality: FilterState<string> = {};
 
-  pluginType: FilterState<PluginType> = DEFAULT_PLUGIN_TYPE_STATE;
+  pluginType: FilterState<PluginType> = { ...DEFAULT_PLUGIN_TYPE_STATE };
 
   writerFileExtensions: FilterState<string> = {};
 

--- a/frontend/src/store/search/filter.store.ts
+++ b/frontend/src/store/search/filter.store.ts
@@ -46,7 +46,7 @@ export class SearchFilterStore implements Resettable {
     windows: false,
   };
 
-  pythonVersions = SUPPORTED_PYTHON_VERSIONS.reduce(
+  pythonVersion = SUPPORTED_PYTHON_VERSIONS.reduce(
     (state, version) => set(state, [version], false),
     {} as FilterState<string>,
   );
@@ -194,7 +194,7 @@ export class SearchFilterStore implements Resettable {
   }
 
   private filterByPythonVersion(results: SearchResult[]): SearchResult[] {
-    const state = this.pythonVersions;
+    const state = this.pythonVersion;
 
     // Collect all versions selected on the filter form
     const selectedVersions = this.getSelectedKeys(state);

--- a/frontend/src/store/search/queryParameters.ts
+++ b/frontend/src/store/search/queryParameters.ts
@@ -12,7 +12,7 @@ import type { PluginSearchStore } from './search.store';
 
 export const PARAM_KEY_MAP: Record<string, string | undefined> = {
   operatingSystems: 'operatingSystem',
-  pythonVersions: 'python',
+  pythonVersion: 'python',
 };
 
 export const PARAM_VALUE_MAP: Record<string, string | undefined> = {

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -23,8 +23,8 @@ export function formatOperatingSystem(operatingSystem: string): string {
   // arbitrary, so you can have a long string like "Operating Systems ::
   // Microsoft :: Windows :: Windows 10", or a short string like "Operating
   // Systems :: OS Independent".
-  const parts = operatingSystem.split(' :: ');
-  const name = parts[parts.length - 1];
-
-  return name.replace('OS Independent', 'All');
+  return (
+    operatingSystem.split(' :: ').at(-1)?.replace('OS Independent', 'All') ??
+    operatingSystem
+  );
 }

--- a/frontend/tests/pages/home/filter.test.ts
+++ b/frontend/tests/pages/home/filter.test.ts
@@ -29,7 +29,7 @@ const FILTER_KEY_METADATA_LABEL_MAP: Partial<Record<FilterKey, MetadataLabel>> =
     // TODO Fix tests since metadata has been removed from search result
     // license: MetadataLabel.License,
     // operatingSystems: MetadataLabel.OperatingSystem,
-    // pythonVersions: MetadataLabel.PythonVersion,
+    // pythonVersion: MetadataLabel.PythonVersion,
   };
 
 const CATEGORY_FILTERS = new Set<FilterKey>(['imageModality', 'workflowStep']);
@@ -176,7 +176,7 @@ describe('Plugin Filters', () => {
   it('should filter by python version', async () => {
     await testPluginFilter({
       options: ['3.7', '3.8'],
-      filterKey: 'pythonVersions',
+      filterKey: 'pythonVersion',
       params: [
         ['python', '3.7'],
         ['python', '3.8'],

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4580,6 +4580,18 @@ eslint-plugin-simple-import-sort@^7.0.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz"
   integrity sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==
 
+eslint-plugin-unused-imports@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz#d8db8c4d0cfa0637a8b51ce3fd7d1b6bc3f08520"
+  integrity sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
+  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
+
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz"


### PR DESCRIPTION
## Description

Closes #476 

Implements metadata links for plugin pages so that users can open the search page from a plugin page's metadata using that metadata for the filter value. This works by implementing a new `MetadataListMetadataItem` component that renders a link to the search page if there's a filter available for that metadata.

Also included a bit of cleanup and added a new eslint plugin to remove unused imports.

## Demo

Prod Data: https://napari-hub-metadata-links.vercel.app
Mock Data: https://napari-hub-metadata-links-mock-data.vercel.app

https://user-images.githubusercontent.com/2176050/166075352-4ca81f6b-28f8-4921-ac21-b38b6c1e83b9.mp4

### Authors Filter

<img width="249" alt="image" src="https://user-images.githubusercontent.com/2176050/166076588-ac5f824b-bd24-4d2a-baa7-35ebacff7e90.png">
