### PR TITLE
Fix Python package requirements filtering

### DIFF
--- a/frontend/src/context/plugin.tsx
+++ b/frontend/src/context/plugin.tsx
@@ -245,7 +245,7 @@ export function usePluginMetadata() {
       value:
         plugin?.requirements && isArray(plugin.requirements)
           ? plugin.requirements.filter(
-              (req): req is string => !req?.includes('; extra == '),
+              (req): req is string => !req?.includes(' extra == '),
             )
           : [],
     },


### PR DESCRIPTION
Fixes https://github.com/chanzuckerberg/napari-hub/issues/482.

The errornous entry is specified as

> `'pytest-xvfb ; (sys_platform == "linux") and extra == \'testing\''`

Removing the semicolon in the filter will correclty remove this entry from https://www.napari-hub.org/plugins/napari-matplotlib.