### PR TITLE
Heading anchor links

### DIFF
--- a/frontend/src/components/AnchorHeading/AnchorHeading.module.scss
+++ b/frontend/src/components/AnchorHeading/AnchorHeading.module.scss
@@ -1,0 +1,5 @@
+.heading2 {
+  &:hover .anchor {
+    @apply opacity-100;
+  }
+}

--- a/frontend/src/components/AnchorHeading/AnchorHeading.module.scss.d.ts
+++ b/frontend/src/components/AnchorHeading/AnchorHeading.module.scss.d.ts
@@ -1,0 +1,10 @@
+export type Styles = {
+  anchor: string;
+  heading2: string;
+};
+
+export type ClassNames = keyof Styles;
+
+declare const styles: Styles;
+
+export default styles;

--- a/frontend/src/components/AnchorHeading/AnchorHeading.tsx
+++ b/frontend/src/components/AnchorHeading/AnchorHeading.tsx
@@ -1,0 +1,35 @@
+import clsx from 'clsx';
+import { ReactNode } from 'react';
+
+import styles from './AnchorHeading.module.scss';
+
+interface Props {
+  id?: string;
+  className?: string;
+  children?: ReactNode;
+}
+
+export function AnchorHeading({ className, children, id, ...props }: Props) {
+  return (
+    <h2
+      id={id}
+      className={clsx(className, styles.heading2, 'flex space-x-2')}
+      {...props}
+    >
+      <span>{children}</span>
+
+      {id && (
+        <a
+          className={clsx(
+            styles.anchor,
+            'opacity-0 !text-napari-dark-gray !no-underline',
+            'hover:!text-napari-primary',
+          )}
+          href={`#${id}`}
+        >
+          ¶
+        </a>
+      )}
+    </h2>
+  );
+}

--- a/frontend/src/components/AnchorHeading/index.ts
+++ b/frontend/src/components/AnchorHeading/index.ts
@@ -1,0 +1,1 @@
+export * from './AnchorHeading';

--- a/frontend/src/components/Markdown/Markdown.tsx
+++ b/frontend/src/components/Markdown/Markdown.tsx
@@ -8,6 +8,7 @@ import externalLinks from 'remark-external-links';
 import gfm from 'remark-gfm';
 import removeComments from 'remark-remove-comments';
 
+import { AnchorHeading } from '../AnchorHeading';
 import styles from './Markdown.module.scss';
 import { MarkdownCode } from './MarkdownCode';
 import { MarkdownParagraph } from './MarkdownParagraph';
@@ -70,6 +71,7 @@ export function Markdown({
   const components: Options['components'] = {
     code: MarkdownCode,
     p: MarkdownParagraph,
+    h2: AnchorHeading,
   };
 
   if (disableHeader) {

--- a/frontend/src/components/PluginPage/CitationInfo.tsx
+++ b/frontend/src/components/PluginPage/CitationInfo.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'next-i18next';
 import { useEffect, useState } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 
+import { AnchorHeading } from '@/components/AnchorHeading';
 import { I18n } from '@/components/I18n';
 import { usePluginState } from '@/context/plugin';
 import { CitationData } from '@/types';
@@ -56,7 +57,9 @@ export function CitationInfo({ className }: Props) {
   return (
     <div className={className}>
       <div className="prose max-w-none mb-6">
-        <h2 id={ANCHOR}>{t('pluginPage:citations.title')}</h2>
+        <AnchorHeading id={ANCHOR}>
+          {t('pluginPage:citations.title')}
+        </AnchorHeading>
         <p>
           <I18n i18nKey="pluginPage:citations.body" />
         </p>


### PR DESCRIPTION
## Description

Closes #478 

Adds anchor links to H2 headings for plugin page descriptions.

## Demo

https://napari-hub-anchor-links.vercel.app/plugins/palmari

<img width="185" alt="image" src="https://user-images.githubusercontent.com/2176050/167226271-fedecbb8-ed76-4785-b77a-438657ff6346.png">

<img width="187" alt="image" src="https://user-images.githubusercontent.com/2176050/167226255-5a5cc0d8-d832-4b00-8fee-f5d973ff3a6e.png">
