### PR TITLE
Include repo owner in source code link

### DIFF
--- a/frontend/src/components/PluginPage/SupportInfo.tsx
+++ b/frontend/src/components/PluginPage/SupportInfo.tsx
@@ -40,8 +40,17 @@ function formatTwitter(url: string): string {
 }
 
 function formatRepoName(repoUrl: string): string {
-  const match = /https:\/\/github\.com\/([^/]+)\/(?<name>[^/]+)/.exec(repoUrl);
-  return match?.groups?.name ?? '';
+  const match = /https:\/\/github\.com\/(?<owner>[^/]+)\/(?<name>[^/]+)/.exec(
+    repoUrl,
+  );
+  const owner = match?.groups?.owner ?? '';
+  const name = match?.groups?.name ?? '';
+
+  if (!owner || !name) {
+    return repoUrl;
+  }
+
+  return `${owner}/${name}`;
 }
 
 interface CommonProps {


### PR DESCRIPTION
Closes #477

## Demo

https://napari-hub-owner-repo-link.vercel.app/plugins/napari-segment-blobs-and-things-with-membranes

<img width="237" alt="image" src="https://user-images.githubusercontent.com/2176050/167227335-e0dc3a2b-9afb-476c-aceb-5f5a1e44fd3f.png">
