### PR TITLE
Add support for conda channel, with default to conda forge checking

### DIFF
--- a/backend/api/model.py
+++ b/backend/api/model.py
@@ -6,6 +6,7 @@ from io import BytesIO
 from collections import defaultdict
 import time
 
+from utils.conda import get_conda_forge_package
 from utils.github import get_github_metadata, get_artifact
 from utils.pypi import query_pypi, get_plugin_pypi_metadata
 from api.s3 import get_cache, cache
@@ -16,7 +17,7 @@ from api.zulip import notify_new_packages
 index_subset = {'name', 'summary', 'description_text', 'description_content_type',
                 'authors', 'license', 'python_version', 'operating_system',
                 'release_date', 'version', 'first_released',
-                'development_status', 'category'}
+                'development_status', 'category', 'conda'}
 
 
 def get_public_plugins() -> Dict[str, str]:
@@ -161,6 +162,10 @@ def build_plugin_metadata(plugin: str, version: str) -> Tuple[str, dict]:
         metadata['category'] = categories
         metadata['category_hierarchy'] = category_hierarchy
         del metadata['labels']
+
+    if 'conda' not in metadata:
+        metadata['conda'] = get_conda_forge_package(plugin)
+
     cache(metadata, f'cache/{plugin}/{version}.json')
     return plugin, metadata
 

--- a/backend/utils/conda.py
+++ b/backend/utils/conda.py
@@ -1,0 +1,35 @@
+import requests
+import re
+from typing import List
+
+CONDA_FORGE = 'https://api.anaconda.org/package/conda-forge'
+
+
+def get_conda_forge_package(package: str) -> List:
+    """Get package metadata from the napari hub.
+    Parameters
+    ----------
+    package : str
+        name of the package
+    Returns
+    -------
+    List of potential conda forge packaging info.
+    """
+
+    normalized_name = normalize_name(package)
+    response = requests.get(f'{CONDA_FORGE}/{normalized_name}')
+    if response.status_code != requests.codes.ok:
+        return []
+    else:
+        return [{
+            "channel": "conda-forge",
+            "package": normalized_name
+        }]
+
+
+def normalize_name(name: str) -> str:
+    """
+    Normalize a plugin name by replacing underscores and dots by dashes and
+    lower casing it.
+    """
+    return re.sub(r"[-_.]+", "-", name).lower()

--- a/backend/utils/github.py
+++ b/backend/utils/github.py
@@ -25,7 +25,7 @@ elif github_client_id and github_client_secret:
 
 visibility_set = {'public', 'disabled', 'hidden'}
 github_pattern = re.compile("https://github\\.com/([^/]+)/([^/]+)")
-hub_config_keys = {'summary', 'authors', 'labels', 'visibility'}
+hub_config_keys = {'summary', 'authors', 'labels', 'visibility', 'conda'}
 default_description = 'The developer has not yet provided a napari-hub specific description.'
 project_url_names = {
     'Project Site': 'project_site',


### PR DESCRIPTION
closes #464 

add support to fetching the conda channel from github metadata, with a default to check on conda forge if not present