### PR TITLE
Fix AppBar + SignupForm styling

### DIFF
--- a/frontend/src/components/AppBar/AppBar.tsx
+++ b/frontend/src/components/AppBar/AppBar.tsx
@@ -3,7 +3,6 @@ import clsx from 'clsx';
 import { useTranslation } from 'next-i18next';
 import { useRef, useState } from 'react';
 
-import { ColumnLayout } from '@/components/ColumnLayout';
 import { Menu } from '@/components/icons';
 import { MenuPopover } from '@/components/MenuPopover';
 import { SearchBar } from '@/components/SearchBar';
@@ -31,8 +30,14 @@ export function AppBar() {
         />
       </div>
 
-      <ColumnLayout
+      <header
         className={clsx(
+          'grid grid-cols-[min-content,1fr]',
+          'screen-875:grid-cols-napari-3',
+          'screen-1150:grid-cols-napari-4',
+          'screen-1425:grid-cols-napari-5',
+          'gap-6 screen-495:gap-12',
+
           // Color and height
           'bg-napari-primary h-napari-app-bar',
 
@@ -41,13 +46,7 @@ export function AppBar() {
 
           // Padding
           'px-6 screen-495:px-12 screen-1150:p-0',
-
-          // Grid layout for smaller screens. This allows the search bar to
-          // extend to its max width to the left. The `zero:` modifier is used
-          // to increase specificity over ColumnLayout.
-          'zero:grid-cols-[min-content,1fr]',
         )}
-        component="header"
       >
         <div className="hidden screen-600:block">
           <AppBarLinks items={links} />
@@ -81,7 +80,7 @@ export function AppBar() {
             </IconButton>
           </div>
         </div>
-      </ColumnLayout>
+      </header>
     </>
   );
 }

--- a/frontend/src/components/AppBar/__snapshots__/AppBar.test.tsx.snap
+++ b/frontend/src/components/AppBar/__snapshots__/AppBar.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<AppBar /> should match snapshot 1`] = `
     class="screen-600:hidden"
   />
   <header
-    class="bg-napari-primary h-napari-app-bar justify-center items-center px-6 screen-495:px-12 screen-1150:p-0 zero:grid-cols-[min-content,1fr] grid justify-center gap-6 screen-495:gap-12 grid-cols-2 screen-875:grid-cols-napari-3 screen-1150:grid-cols-napari-4 screen-1425:grid-cols-napari-5"
+    class="grid grid-cols-[min-content,1fr] screen-875:grid-cols-napari-3 screen-1150:grid-cols-napari-4 screen-1425:grid-cols-napari-5 gap-6 screen-495:gap-12 bg-napari-primary h-napari-app-bar justify-center items-center px-6 screen-495:px-12 screen-1150:p-0"
   >
     <div
       class="hidden screen-600:block"

--- a/frontend/src/components/Layout/__snapshots__/Layout.test.tsx.snap
+++ b/frontend/src/components/Layout/__snapshots__/Layout.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`<Layout /> should match snapshot 1`] = `
       class="screen-600:hidden"
     />
     <header
-      class="bg-napari-primary h-napari-app-bar justify-center items-center px-6 screen-495:px-12 screen-1150:p-0 zero:grid-cols-[min-content,1fr] grid justify-center gap-6 screen-495:gap-12 grid-cols-2 screen-875:grid-cols-napari-3 screen-1150:grid-cols-napari-4 screen-1425:grid-cols-napari-5"
+      class="grid grid-cols-[min-content,1fr] screen-875:grid-cols-napari-3 screen-1150:grid-cols-napari-4 screen-1425:grid-cols-napari-5 gap-6 screen-495:gap-12 bg-napari-primary h-napari-app-bar justify-center items-center px-6 screen-495:px-12 screen-1150:p-0"
     >
       <div
         class="hidden screen-600:block"
@@ -190,7 +190,7 @@ exports[`<Layout /> should match snapshot 1`] = `
             </div>
           </div>
           <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-contained text-sm font-semibold h-[35px] col-span-2 screen-495:col-span-1 MuiButton-containedPrimary MuiButton-disableElevation"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained bg-napari-primary text-sm font-semibold h-[35px] col-span-2 screen-495:col-span-1 MuiButton-containedPrimary MuiButton-disableElevation"
             data-testid="submitButton"
             name="subscribe"
             tabindex="0"

--- a/frontend/src/components/SignupForm/SignupForm.tsx
+++ b/frontend/src/components/SignupForm/SignupForm.tsx
@@ -115,6 +115,7 @@ export function SignupForm({ onSubmit, variant = 'default' }: Props) {
             variant="contained"
             disableElevation
             className={clsx(
+              'bg-napari-primary',
               // font & colors
               'text-sm font-semibold',
               // sizing

--- a/frontend/src/components/SignupForm/__snapshots__/SignupForm.test.tsx.snap
+++ b/frontend/src/components/SignupForm/__snapshots__/SignupForm.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`<SignupForm /> should match snapshot 1`] = `
           </div>
         </div>
         <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained text-sm font-semibold h-[35px] col-span-2 screen-495:col-span-1 MuiButton-containedPrimary MuiButton-disableElevation"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained bg-napari-primary text-sm font-semibold h-[35px] col-span-2 screen-495:col-span-1 MuiButton-containedPrimary MuiButton-disableElevation"
           data-testid="submitButton"
           name="subscribe"
           tabindex="0"


### PR DESCRIPTION
## Before

### App Bar

Caused by #499 

<img width="476" alt="image" src="https://user-images.githubusercontent.com/2176050/171458433-ccfe218a-36d9-4d83-9b67-112f542f626f.png">

### Signup Form

Possibly caused by #486, but not sure

<img width="253" alt="image" src="https://user-images.githubusercontent.com/2176050/171458325-f0ba96d9-12c8-4f0f-9529-956777d8a2e8.png">

## After

### App Bar

<img width="478" alt="image" src="https://user-images.githubusercontent.com/2176050/171458487-6203cd6d-c17a-4cd8-92ce-8c5992b4a19f.png">

### Signup Form

<img width="268" alt="image" src="https://user-images.githubusercontent.com/2176050/171458346-0ce41b8a-5748-43e1-9347-3edad325dea2.png">
