### PR TITLE
Update preview page discovery logic

### DIFF
--- a/backend/get_preview.py
+++ b/backend/get_preview.py
@@ -1,4 +1,5 @@
 import os
+
 from preview import get_plugin_preview
 import argparse
 

--- a/backend/get_preview.py
+++ b/backend/get_preview.py
@@ -1,5 +1,4 @@
 import os
-
 from preview import get_plugin_preview
 import argparse
 

--- a/backend/preview/preview.py
+++ b/backend/preview/preview.py
@@ -1,4 +1,3 @@
-from time import sleep
 from typing import Union
 from git import Repo
 from pkginfo import Wheel
@@ -299,11 +298,6 @@ def get_manifest_attributes(plugin_name, repo_pth):
     or manifest discovery fails, return default empty values.
     """
     try:
-        # command = [sys.executable, "-m", "pip", "install", "-e", f'{repo_pth}']
-        # p = subprocess.Popen(command, stdout=subprocess.PIPE)
-        # while p.poll() is None:
-        #     l = p.stdout.readline()  # This blocks until it receives a newline.
-        #     print(l)
         manifest, is_npe2 = discover_manifest(plugin_name)
     except Exception as e:
         manifest = None

--- a/backend/preview/preview.py
+++ b/backend/preview/preview.py
@@ -285,10 +285,17 @@ def get_manifest_attributes(plugin_name, repo_pth):
     try:
         command = [sys.executable, "-m", "pip", "install", f'{repo_pth}']
         p = subprocess.Popen(command, stdout=subprocess.PIPE)
+        while p.poll() is None:
+            l = p.stdout.readline()  # This blocks until it receives a newline.
+            print(l)
         manifest, is_npe2 = discover_manifest(plugin_name)
-    except Exception:
+    except Exception as e:
         manifest = None
         is_npe2 = False
+        print(e)
     manifest_attributes = parse_manifest(manifest)
     manifest_attributes['npe2'] = is_npe2
     return manifest_attributes
+
+manifest_attributes = get_manifest_attributes('zarpaint', '/Users/klai/Desktop/zarpaint')
+print(manifest_attributes)


### PR DESCRIPTION
This updates the preview script so we don't have to try to install the plugin and discover it in the same active python session, making the discovery more robust.

It also unfortunately duplicates the `discover_manifest` function to avoid import errors since `plugins` and `backend` are two separate modules with no parent package. I think we should restructure the "backend" code into one parent module eventually e.g. "src", but that's for future debate.

For now I think it's ok to duplicate it.