### PR TITLE
Update preview page yaml to not specify revision version

### DIFF
--- a/docs/setting-up-preview.md
+++ b/docs/setting-up-preview.md
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: napari hub Preview Page Builder
-        uses: chanzuckerberg/napari-hub-preview-action@v0.1.5
+        uses: chanzuckerberg/napari-hub-preview-action@v0.1
         with:
           hub-ref: main
 ```


### PR DESCRIPTION
This PR updates the example preview page action in our docs to not specify the revision version. This will allow us to make small changes to the preview action without needing users to update their own GitHub actions.

See [this PR](https://github.com/chanzuckerberg/napari-hub-preview-action/pull/4) in the preview action for an example of such a change.