### PR TITLE
fix link to plugin guide

### DIFF
--- a/frontend/i18n/en/faq.mdx
+++ b/frontend/i18n/en/faq.mdx
@@ -104,9 +104,10 @@ For a full list of everyone involved, check out the [contacts page]({CONTACT}).
 <Accordion title="How do I build a napari plugin?" variant="faq">
 
 You can learn more about building a plugin for napari by reading
-[this tutorial](https://napari.org/plugins/stable/for_plugin_developers.html#plugins-for-plugin-developers),
-which will guide you through hook specifications, implementation,
-and how to share your plugin with the world.
+[this documentation](https://napari.org/plugins/),
+which will guide you through creating a plugin, using your plugin
+to extend napari's functionality, and sharing your plugin with
+the world.
 
 </Accordion>
 


### PR DESCRIPTION
The existing link to the plugin tutorial (`https://napari.org/plugins/stable/for_plugin_developers.html#plugins-for-plugin-developers`) is a 404. (I'm guessing it's a tutorial on the old plugin engine, and was renamed/removed.)

This changes the link to `https://napari.org/plugins/`.

I also made some small language changes, which I'm not attached to (happy to tweak however folks want, or abandon this PR and let someone else fix the link), but here's an explanation:

- changed "tutorial" to "documentation" since npe2 doesn't seem to have a "tutorial" exactly
- removed "hook" since that word doesn't seem to be used in npe2.

Here's a screenshot after my changes:

![Screen Shot 2022-06-15 at 10 27 10 AM](https://user-images.githubusercontent.com/1222726/173854584-5662f6e7-84d1-480b-8841-ccfde39222d4.png)

