### PR TITLE
Write manifest to json, update npe2 field to use new manifest field

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -209,7 +209,7 @@ resource "aws_s3_bucket_notification" "plugins_notification" {
     lambda_function_arn = module.plugins_lambda.function_arn
     events              = ["s3:ObjectCreated:*"]
     filter_prefix       = var.env == "dev" ? local.custom_stack_name : ""
-    filter_suffix       = ".yaml"
+    filter_suffix       = "-manifest.json"
   }
 
   depends_on = [aws_lambda_permission.allow_bucket]

--- a/backend/api/model.py
+++ b/backend/api/model.py
@@ -73,12 +73,11 @@ def get_plugin(plugin: str, version: str = None) -> dict:
 
 
 def get_frontend_manifest_metadata(plugin, version):
-    # load manifest from yaml (triggering build)
+    # load manifest from json (triggering build)
     raw_metadata = get_manifest(plugin, version)
     if 'process_count' in raw_metadata:
         raw_metadata = None
     interpreted_metadata = parse_manifest(raw_metadata)
-    interpreted_metadata['npe2'] = is_npe2_plugin(plugin, version)
     return interpreted_metadata
 
 
@@ -94,11 +93,11 @@ def get_manifest(plugin: str, version: str = None) -> dict:
         return {}
     elif version is None:
         version = plugins[plugin]
-    plugin_metadata = get_cache(f'cache/{plugin}/{version}.yaml', 'yaml')
+    plugin_metadata = get_cache(f'cache/{plugin}/{version}-manifest.json')
     if plugin_metadata:
         return plugin_metadata
     else:
-        cache({"process_count": 0}, f'cache/{plugin}/{version}.yaml', format='yaml')
+        cache({"process_count": 0}, f'cache/{plugin}/{version}-manifest.json')
         return {"process_count": 0}
 
 

--- a/backend/api/s3.py
+++ b/backend/api/s3.py
@@ -20,32 +20,28 @@ endpoint_url = os.environ.get('BOTO_ENDPOINT_URL', None)
 s3_client = boto3.client("s3", endpoint_url=endpoint_url, config=Config(max_pool_connections=50))
 
 
-def get_cache(key: str, format: str = 'json') -> Union[Dict, List, None]:
+def get_cache(key: str) -> Union[Dict, List, None]:
     """
     Get the cached json file or manifest file for a given key if exists, None otherwise.
 
     :param key: key to the cache to get
-    :param format: Format of the file to obtain
     :return: file content for the key if exists, None otherwise
     """
     try:
         if format == 'json':
             return json.loads(s3_client.get_object(Bucket=bucket, Key=os.path.join(bucket_path, key))['Body'].read())
-        elif format == 'yaml':
-            return yaml.safe_load(s3_client.get_object(Bucket=bucket, Key=os.path.join(bucket_path, key))['Body'])
     except ClientError:
         print(f"Not cached: {key}")
         return None
 
 
-def cache(content: Union[dict, list, IO[bytes]], key: str, mime: str = None, format: str = 'json'):
+def cache(content: Union[dict, list, IO[bytes]], key: str, mime: str = None):
     """
     Cache the given content to the key location.
 
     :param content: content to cache
     :param key: key path in s3
     :param mime: type of the file
-    :param format: json file or yaml file
     """
     extra_args = None
     mime = mime or mimetypes.guess_type(key)[0]
@@ -61,26 +57,7 @@ def cache(content: Union[dict, list, IO[bytes]], key: str, mime: str = None, for
         s3_client.upload_fileobj(Fileobj=content, Bucket=bucket,
                                  Key=os.path.join(bucket_path, key), ExtraArgs=extra_args)
     else:
-        with io.BytesIO(json.dumps(content).encode('utf8') if format == 'json' else
-                        yaml.dump(content).encode('utf8')) as stream:
+        with io.BytesIO(json.dumps(content).encode('utf8')) as stream:
             s3_client.upload_fileobj(Fileobj=stream, Bucket=bucket,
                                      Key=os.path.join(bucket_path, key), ExtraArgs=extra_args)
 
-
-def is_npe2_plugin(plugin, version):
-    """
-    Return True if the plugin is npe2, False otherwise.
-
-    :param plugin: name of plugin
-    :param version: version of plugin
-    :return: True if npe2, False otherwise
-    """
-    key = f'cache/{plugin}/{version}.yaml'
-    try:
-        manifest_body = s3_client.get_object(Bucket=bucket, Key=os.path.join(bucket_path, key))['Body']
-        manifest_body_str = manifest_body.read().decode('utf-8')
-        if manifest_body_str.startswith('#npe2'):
-            return True
-    except ClientError:
-        print(f"Not cached: {key}")
-    return False

--- a/backend/utils/utils.py
+++ b/backend/utils/utils.py
@@ -140,6 +140,7 @@ def parse_manifest(manifest: Optional[dict] = None):
     if manifest is None:
         return manifest_attributes
     manifest_attributes['display_name'] = manifest.get('display_name', '')
+    manifest_attributes['npe2'] = not manifest.get('npe1_shim', False)
     if 'contributions' in manifest:
         manifest_contributions = manifest.get('contributions', dict())
         if 'readers' in manifest_contributions:


### PR DESCRIPTION
This PR closes #573 by updating the manifest discovery and parsing logic to rely on `json` rather than `yaml`.

Additionally, [npe2 #182](https://github.com/napari/npe2/pull/182) will write a schema field for shimmed plugins, so I've updated our code for deciding whether a plugin is native `npe2` or not to use this field. Since that field won't be available until `npe2` release, I'm still doing some work to ensure we have correct metadata before release. We can further clean up some of the code once `npe2` is released.

I've had to update the path to the manifest file as now that we are writing `json`, we don't want to conflict with the original plugin json. This means raw manifests are being written to `{plugin}/{version}-manifest.json`.