### PR TITLE
add explicit dependency between lambda functions when there is a reference

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -212,7 +212,7 @@ resource "aws_s3_bucket_notification" "plugins_notification" {
     filter_suffix       = ".yaml"
   }
 
-  depends_on = [aws_lambda_permission.allow_bucket]
+  depends_on = [aws_lambda_permission.allow_bucket, module.plugins_lambda]
 }
 
 resource "aws_cloudwatch_event_target" "update_target" {


### PR DESCRIPTION
fixed an race condition where 2 invoke resources tries to update the Lambda function at the same time, which raise resource conflict exception