### PR TITLE
Remove empty filter options

### DIFF
--- a/frontend/src/components/SearchPage/PluginComplexFilter.tsx
+++ b/frontend/src/components/SearchPage/PluginComplexFilter.tsx
@@ -351,7 +351,9 @@ export function PluginComplexFilter({ filterKey }: Props) {
           </div>
         ),
       }}
-      options={optionsRef.current}
+      options={optionsRef.current.filter(
+        (option) => option.name && option.stateKey,
+      )}
       value={pendingState}
       PopperComponent={StyledPopper}
     />


### PR DESCRIPTION
Issue is that the plugin https://www.napari-hub.org/plugins/napari-bioimageio has no author, but returns an author object with empty strings:

https://api.napari-hub.org/plugins/napari-bioimageio

```json
{
  "authors": [
    {
      "email": "", 
      "name": ""
    }
  ],
}
```

This throws an error on the frontend because its expecting the author string to be non-empty:

https://github.com/chanzuckerberg/napari-hub/blob/23fcddde78453a4c0b894c1d6447a7265336f2da/frontend/src/components/SearchPage/PluginComplexFilter.tsx#L93

This PR fixes the issue by removing filter options that include an empty string.

