### PR TITLE
fix links that point to pages with non-working CSS

### DIFF
--- a/backend/api/templates/swagger.yml
+++ b/backend/api/templates/swagger.yml
@@ -132,7 +132,7 @@ paths:
                 $ref: '#/components/schemas/Shield'
   /manifest/{name}:
     get:
-      summary: Get the manifest file for plugin. Schema here https://napari.org/plugins/manifest.html
+      summary: Get the manifest file for plugin. Schema here https://napari.org/stable/plugins/manifest.html
       tags:
         - manifest
       parameters:

--- a/frontend/i18n/en/faq.mdx
+++ b/frontend/i18n/en/faq.mdx
@@ -104,7 +104,7 @@ For a full list of everyone involved, check out the [contacts page]({CONTACT}).
 <Accordion title="How do I build a napari plugin?" variant="faq">
 
 You can learn more about building a plugin for napari by reading
-[this documentation](https://napari.org/plugins/),
+[this documentation](https://napari.org/stable/plugins/index.html),
 which will guide you through creating a plugin, using your plugin
 to extend napari's functionality, and sharing your plugin with
 the world.


### PR DESCRIPTION
In https://github.com/chanzuckerberg/napari-hub/pull/558 I fixed a link that was a 404.

That PR updated the link to go to https://napari.org/plugins/ instead. I think that URL worked fine at the time, but now the CSS there isn't working (sorry).

The working version of that content is https://napari.org/stable/plugins/index.html, so this PR updates the link to go there.

I noticed the same issue with a reference to `https://napari.org/plugins/manifest.html`, so this fixes that too.

(If the pages without "stable" in the URL are intended to work fine, then feel free to fix that instead and ignore this PR.)