### PR TITLE
Check plugin version before indexing

### DIFF
--- a/backend/api/model.py
+++ b/backend/api/model.py
@@ -148,7 +148,7 @@ def build_plugin_metadata(plugin: str, version: str) -> Tuple[str, dict]:
     cached_plugin = get_cache(f'cache/{plugin}/{version}.json')
     if cached_plugin:
         return plugin, cached_plugin
-    metadata = get_plugin_pypi_metadata(plugin, version=None)
+    metadata = get_plugin_pypi_metadata(plugin, version=version)
     github_repo_url = metadata.get('code_repository')
     if github_repo_url:
         metadata = {**metadata, **get_github_metadata(github_repo_url)}

--- a/backend/api/model.py
+++ b/backend/api/model.py
@@ -149,6 +149,8 @@ def build_plugin_metadata(plugin: str, version: str) -> Tuple[str, dict]:
     if cached_plugin:
         return plugin, cached_plugin
     metadata = get_plugin_pypi_metadata(plugin, version=version)
+    if not metadata:
+        return plugin, metadata
     github_repo_url = metadata.get('code_repository')
     if github_repo_url:
         metadata = {**metadata, **get_github_metadata(github_repo_url)}

--- a/backend/utils/pypi.py
+++ b/backend/utils/pypi.py
@@ -48,16 +48,18 @@ def get_plugin_pypi_metadata(plugin: str, version: str) -> dict:
     :param version: version of the plugin
     :return: metadata dict for the plugin, empty if not found
     """
-    if version:
-        url = f"https://pypi.org/pypi/{plugin}/{version}/json"
-    else:
-        url = f"https://pypi.org/pypi/{plugin}/json"
-        
+    # versioned url https://pypi.org/pypi/{plugin}/{version}/json does not track history anymore.
+    # see https://github.com/chanzuckerberg/napari-hub/issues/598
+    url = f"https://pypi.org/pypi/{plugin}/json"
+
     try:
         response = requests.get(url)
         if response.status_code != requests.codes.ok:
             response.raise_for_status()
         info = format_plugin(json.loads(response.text.strip()))
+        if version and info['version'] != version:
+            print(f"Index Error: Skipping {plugin}:{version}, mismatching PyPI version {info['version']}")
+            return {}
         return info
     except HTTPError:
         return {}


### PR DESCRIPTION
this address some problems identified in #611 

perform a version check when indexing plugin metadata to prevent pypi api race condition, where the listing reports a newer version but history API is not up to date to use that version.

