### PR TITLE
Remove configuration for failure lambda

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -142,11 +142,16 @@ module plugins_lambda {
   }
 
   log_retention_in_days = 14
-  timeout               = 900
+  timeout               = 300
   memory_size           = 10240
   ephemeral_storage_size = 10240
-  maximum_retry_attempts = 0
+
   create_async_event_config = true
+  attach_async_event_policy = true
+
+  maximum_event_age_in_seconds = 300
+  maximum_retry_attempts       = 0
+
 }
 
 module api_gateway_proxy_stage {
@@ -225,7 +230,7 @@ data aws_iam_policy_document plugins_policy {
 
     resources = ["${local.data_bucket_arn}/*"]
   }
-  
+
 }
 
 resource aws_iam_role_policy policy {

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -225,14 +225,7 @@ data aws_iam_policy_document plugins_policy {
 
     resources = ["${local.data_bucket_arn}/*"]
   }
-
-  statement {
-    actions = [
-      "lambda:InvokeFunction",
-      "lambda:InvokeAsync",
-    ]
-
-  }
+  
 }
 
 resource aws_iam_role_policy policy {

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -17,7 +17,6 @@ locals {
   frontend_cmd = []
   backend_cmd  = []
   plugins_cmd  = []
-  failure_cmd  = ["get_plugin_manifest.failure_handler"]
 
   security_groups     = local.secret["security_groups"]
   zone                = local.secret["zone_id"]
@@ -52,7 +51,6 @@ locals {
   frontend_url = var.frontend_url != "" ? var.frontend_url: try(join("", ["https://", module.frontend_dns.dns_prefix, ".", local.external_dns]), var.frontend_url)
   backend_function_name = "${local.custom_stack_name}-backend"
   plugins_function_name = "${local.custom_stack_name}-plugins"
-  failure_function_name = "${local.custom_stack_name}-failure"
 }
 
 module frontend_dns {
@@ -149,30 +147,6 @@ module plugins_lambda {
   ephemeral_storage_size = 10240
   maximum_retry_attempts = 0
   create_async_event_config = true
-  destination_on_failure = module.failure_lambda.function_arn
-}
-
-module failure_lambda {
-  source             = "../lambda-container"
-  function_name      = local.failure_function_name
-  image_repo         = local.plugins_image_repo
-  image_tag          = local.image_tag
-  cmd                = local.failure_cmd
-  tags               = var.tags
-
-  vpc_config = {
-    subnet_ids         = local.cloud_env.private_subnets
-    security_group_ids = local.security_groups
-  }
-
-  environment = {
-    "BUCKET" = local.data_bucket_name
-    "BUCKET_PATH" = var.env == "dev" ? local.custom_stack_name : ""
-  }
-
-  log_retention_in_days = 14
-  timeout               = 900
-  maximum_retry_attempts = 0
 }
 
 module api_gateway_proxy_stage {
@@ -258,19 +232,6 @@ data aws_iam_policy_document plugins_policy {
       "lambda:InvokeAsync",
     ]
 
-    resources = [module.failure_lambda.function_arn]
-  }
-}
-
-data aws_iam_policy_document failure_policy {
-  statement {
-    actions = [
-      "s3:PutObject",
-      "s3:GetObject",
-      "s3:DeleteObject",
-    ]
-
-    resources = ["${local.data_bucket_arn}/*"]
   }
 }
 
@@ -284,12 +245,6 @@ resource aws_iam_role_policy plugins_lambda_policy {
   name     = "${local.custom_stack_name}-${var.env}-plugins-lambda-policy"
   role     = module.plugins_lambda.role_name
   policy   = data.aws_iam_policy_document.plugins_policy.json
-}
-
-resource aws_iam_role_policy failure_lambda_policy {
-  name     = "${local.custom_stack_name}-${var.env}-failure-lambda-policy"
-  role     = module.failure_lambda.role_name
-  policy   = data.aws_iam_policy_document.failure_policy.json
 }
 
 resource aws_acm_certificate cert {

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -146,12 +146,6 @@ module plugins_lambda {
   memory_size           = 10240
   ephemeral_storage_size = 10240
 
-  create_async_event_config = true
-  attach_async_event_policy = true
-
-  maximum_event_age_in_seconds = 300
-  maximum_retry_attempts       = 0
-
 }
 
 module api_gateway_proxy_stage {
@@ -280,4 +274,10 @@ resource aws_lb_listener_certificate cert {
   depends_on      = [aws_acm_certificate_validation.cert]
   listener_arn    = local.frontend_listener_arn
   certificate_arn = aws_acm_certificate.cert.arn
+}
+
+resource "aws_lambda_function_event_invoke_config" "async-config" {
+  function_name                = module.plugins_lambda.function_name
+  maximum_event_age_in_seconds = 500
+  maximum_retry_attempts       = 0
 }

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -142,7 +142,7 @@ module plugins_lambda {
   }
 
   log_retention_in_days = 14
-  timeout               = 300
+  timeout               = 150
   memory_size           = 10240
   ephemeral_storage_size = 10240
 

--- a/.happy/terraform/modules/lambda-container/main.tf
+++ b/.happy/terraform/modules/lambda-container/main.tf
@@ -43,11 +43,3 @@ data "aws_ecr_image" "image" {
   repository_name = split("/", var.image_repo)[1]
   image_tag       = var.image_tag
 }
-
-# worked around unfixed issue https://github.com/terraform-aws-modules/terraform-aws-lambda/issues/263
-resource "aws_lambda_function_event_invoke_config" "this" {
-  count = var.create_async_event_config ? 1 : 0
-
-  function_name = var.function_name
-
-}

--- a/.happy/terraform/modules/lambda-container/main.tf
+++ b/.happy/terraform/modules/lambda-container/main.tf
@@ -43,3 +43,11 @@ data "aws_ecr_image" "image" {
   repository_name = split("/", var.image_repo)[1]
   image_tag       = var.image_tag
 }
+
+# worked around unfixed issue https://github.com/terraform-aws-modules/terraform-aws-lambda/issues/263
+resource "aws_lambda_function_event_invoke_config" "this" {
+  function_name = var.function_name
+  maximum_event_age_in_seconds = 60
+  maximum_retry_attempts       = 0
+
+}

--- a/.happy/terraform/modules/lambda-container/main.tf
+++ b/.happy/terraform/modules/lambda-container/main.tf
@@ -50,9 +50,4 @@ resource "aws_lambda_function_event_invoke_config" "this" {
 
   function_name = var.function_name
 
-  destination_config {
-    on_failure {
-      destination = var.destination_on_failure
-    }
-  }
 }

--- a/.happy/terraform/modules/lambda-container/main.tf
+++ b/.happy/terraform/modules/lambda-container/main.tf
@@ -43,11 +43,3 @@ data "aws_ecr_image" "image" {
   repository_name = split("/", var.image_repo)[1]
   image_tag       = var.image_tag
 }
-
-# worked around unfixed issue https://github.com/terraform-aws-modules/terraform-aws-lambda/issues/263
-resource "aws_lambda_function_event_invoke_config" "this" {
-  function_name = var.function_name
-  maximum_event_age_in_seconds = 60
-  maximum_retry_attempts       = 0
-
-}

--- a/.happy/terraform/modules/lambda-container/variables.tf
+++ b/.happy/terraform/modules/lambda-container/variables.tf
@@ -116,9 +116,3 @@ variable create_async_event_config {
   description = "Controls whether async event configuration for Lambda Function/Alias should be created"
   default     = false
 }
-
-variable destination_on_failure {
-  type        = string
-  description = "Amazon Resource Name (ARN) of the destination resource for failed asynchronous invocations"
-  default     = null
-}

--- a/.happy/terraform/modules/lambda-container/variables.tf
+++ b/.happy/terraform/modules/lambda-container/variables.tf
@@ -111,8 +111,3 @@ variable description {
   default = ""
 }
 
-variable create_async_event_config {
-  type        = bool
-  description = "Controls whether async event configuration for Lambda Function/Alias should be created"
-  default     = false
-}

--- a/plugins/get_plugin_manifest.py
+++ b/plugins/get_plugin_manifest.py
@@ -73,23 +73,3 @@ def generate_manifest(event, context):
             Key=key
         )
         s3_client.put_object(Body=s3_body, Bucket=bucket, Key=key)
-
-
-def failure_handler(event, context):
-    """
-    Inspects the manifest json file of the plugin, and if process_count is in the json file, then the method
-    increments the value of process_count in the json file, then write to designated location on s3.
-    """
-    manifest_path = event['requestPayload']['Records'][0]['s3']['object']['key']
-    bucket = event['requestPayload']['Records'][0]['s3']['bucket']['name']
-    response = s3.get_object(Bucket=bucket, Key=manifest_path)
-    myBody = response["Body"]
-    body_dict = json.loads(myBody.read().decode("utf-8"))
-    s3_client = boto3.client('s3')
-    if 'process_count' in body_dict:
-        response = s3_client.delete_object(
-            Bucket=bucket,
-            Key=manifest_path
-        )
-        body_dict['process_count'] += 1
-        s3_client.put_object(Body=json.dumps(body_dict), Bucket=bucket, Key=manifest_path)


### PR DESCRIPTION
This PR closes #637 by removing all configuration for the `failure` lambda. I've also configured the `plugins` lambda timeout and fixed the maximum retry configuration for the `plugins` lambda in the process.

The deployed functions are [here](https://us-west-2.console.aws.amazon.com/lambda/home?region=us-west-2#/functions) and we can see:
- no `dev-remove-failure-lambda-failure` function
- [no destination configured](https://us-west-2.console.aws.amazon.com/lambda/home?region=us-west-2#/functions/dev-remove-failure-lambda-plugins?tab=configure) on `dev-remove-failure-lambda-plugins` function
- [timeout configured](https://us-west-2.console.aws.amazon.com/lambda/home?region=us-west-2#/functions/dev-remove-failure-lambda-plugins?tab=configure) to 300 seconds (5 minutes) on the `dev-remove-failure-lambda-plugins` function
- [asynchronous invocation maximum retries](https://us-west-2.console.aws.amazon.com/lambda/home?region=us-west-2#/functions/dev-remove-failure-lambda-plugins?tab=configure) configured to 0 on the `dev-remove-failure-lambda-plugins` function

This does *not* bring back the triggers for the `plugins` lambda.