### PR TITLE
Backend Error Fix

### DIFF
--- a/backend/utils/github.py
+++ b/backend/utils/github.py
@@ -148,7 +148,6 @@ def get_github_metadata(repo_url: str, branch: str = 'HEAD') -> dict:
         # if the yaml.safe_load method returns None, then assign {} to config
         if config is None:
             config = {}
-            print(yaml_file)
         hub_config = {key: config[key] for key in hub_config_keys if key in config}
         github_metadata.update(hub_config)
 

--- a/backend/utils/github.py
+++ b/backend/utils/github.py
@@ -145,6 +145,9 @@ def get_github_metadata(repo_url: str, branch: str = 'HEAD') -> dict:
         yaml_file = get_file(repo_url, ".napari/config.yml", branch=branch)
     if yaml_file:
         config = yaml.safe_load(yaml_file)
+        # if the yaml.safe_load method returns None, then assign {} to config
+        if config is None:
+            config = {}
         hub_config = {key: config[key] for key in hub_config_keys if key in config}
         github_metadata.update(hub_config)
 

--- a/backend/utils/github.py
+++ b/backend/utils/github.py
@@ -148,6 +148,7 @@ def get_github_metadata(repo_url: str, branch: str = 'HEAD') -> dict:
         # if the yaml.safe_load method returns None, then assign {} to config
         if config is None:
             config = {}
+            print(yaml_file)
         hub_config = {key: config[key] for key in hub_config_keys if key in config}
         github_metadata.update(hub_config)
 


### PR DESCRIPTION
Per the incident https://app.datadoghq.com/apm/error-tracking?query=&issueId=931045fc-2551-11ed-acc9-da7ad0900002&start=1661530894372&end=1661534494372&paused=false, this pull request addresses the case in which `config` is `None`, which impacts the staging and prod environments as a result. The solution is therefore to set the default value in the case in which `config is None` to `config = {}`