### PR TITLE
Update plugins lambda handler to use `npe2.fetch_manifest` for discovery

### DIFF
--- a/.github/workflows/plugins-tests.yml
+++ b/.github/workflows/plugins-tests.yml
@@ -1,0 +1,52 @@
+# Workflow for running plugins lambda tests for PRs and main branch
+
+name: Plugins Tests
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'plugins/**'
+  pull_request:
+    branches:
+      - '**'
+    paths:
+      - 'plugins/**'
+
+defaults:
+  run:
+    working-directory: plugins/
+
+jobs:
+  # Runs pytest for backend code
+  tests:
+    name: pytest
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.9"
+
+      - name: Cache Python environment
+        uses: actions/cache@v3
+        id: pip-cache
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+
+      - name: Run tests
+        working-directory: plugins/
+        run : |
+          python -m pytest .

--- a/plugins/_tests/test_discovery.py
+++ b/plugins/_tests/test_discovery.py
@@ -1,0 +1,68 @@
+import json
+import os
+import requests
+from unittest import mock
+from plugins.get_plugin_manifest import generate_manifest
+
+TEST_PLUGIN = 'test-plugin'
+TEST_VERSION = '0.0.1'
+TEST_BUCKET = 'test-bucket'
+TEST_CACHE_PATH = f'cache/{TEST_PLUGIN}/{TEST_PLUGIN}.{TEST_VERSION}-manifest.json'
+TEST_WHEEL_URL = 'https://github.com/DragaDoncila/napari-demo/releases/download/v0.1.3/napari_demo-0.1.3-py3-none-any.whl'
+
+def _mock_get_object(Bucket, Key):
+    if os.path.exists(Key):
+        with open(Key) as fp:
+            return json.load(fp)
+    else:
+        # find proper exception class
+        raise FileNotFoundError
+
+def _mock_put_object(Body, Bucket, Key):
+    if os.path.exists(Key):
+        raise FileExistsError
+    else:
+        with open(Key, 'w') as fp:
+            fp.write(Body)
+
+
+def test_discovery_manifest_exists(tmp_path):
+    """Test we return without writing anything when manifest already exists.
+    """
+    manifest_pth = tmp_path / TEST_CACHE_PATH
+    manifest_pth.parent.mkdir(parents=True)
+    manifest_pth.write_text(json.dumps({'error': 'Could not build manifest.'}))
+    with mock.patch('plugins.get_plugin_manifest.bucket_path', tmp_path),\
+        mock.patch('plugins.get_plugin_manifest.s3') as mock_s3:
+        mock_s3.get_object = _mock_get_object
+        generate_manifest({'plugin': TEST_PLUGIN, 'version': TEST_VERSION}, None)
+    mock_s3.put_object.assert_not_called()
+
+def test_discovery_failure(tmp_path):
+    """Test discovery failure results in error written to manifest file.
+    """
+    manifest_pth = tmp_path / TEST_CACHE_PATH
+    manifest_pth.parent.mkdir(parents=True)
+    with mock.patch('plugins.get_plugin_manifest.bucket_path', tmp_path),\
+        mock.patch('plugins.get_plugin_manifest.s3') as mock_s3:
+        mock_s3.get_object = _mock_get_object
+        mock_s3.put_object = _mock_put_object
+        generate_manifest({'plugin': TEST_PLUGIN, 'version': TEST_VERSION}, None)
+    written = json.loads(manifest_pth.read_text())
+    assert written['error'] == 'HTTP Error 404: Not Found'
+
+def test_discovery_success(tmp_path):
+    """Test that valid manifest is correctly written to file."""
+    plugin_name = 'napari-demo'
+    plugin_version = 'v0.1.0'
+
+    manifest_pth = tmp_path / f'cache/{plugin_name}/{plugin_name}.{plugin_version}-manifest.json'
+    manifest_pth.parent.mkdir(parents=True)
+    with mock.patch('plugins.get_plugin_manifest.bucket_path', tmp_path),\
+        mock.patch('plugins.get_plugin_manifest.s3') as mock_s3:
+        mock_s3.get_object = _mock_get_object
+        mock_s3.put_object = _mock_put_object
+        generate_manifest({'plugin': plugin_name, 'version': plugin_version}, None)
+    written = json.loads(manifest_pth.read_text())
+    assert written['name'] == 'napari-demo'    
+    assert len(written['contributions']['widgets']) == 1

--- a/plugins/get_plugin_manifest.py
+++ b/plugins/get_plugin_manifest.py
@@ -1,19 +1,21 @@
 import json
 import os
 import boto3
-from botocore.exceptions import ClientError
 from npe2 import fetch_manifest
 
-s3 = boto3.resource('s3')
 # Environment variable set through ecs stack terraform module
-bucket_name = os.environ.get('BUCKET')
+bucket_name = os.environ.get('BUCKET')    
 bucket_path = os.environ.get('BUCKET_PATH', '')
+s3 = boto3.resource('s3')
 
 def generate_manifest(event, context):
     """
     When manifest does not already exist, discover using `npe2_fetch` and write
     valid manifest or resulting error message back to manifest file.
     """
+    if not bucket_name:
+        raise RuntimeError('Bucket name not specified.')
+
     plugin = event['plugin']
     version = event['version']
     key = os.path.join(bucket_path, f'cache/{plugin}/{plugin}.{version}-manifest.json')

--- a/plugins/get_plugin_manifest.py
+++ b/plugins/get_plugin_manifest.py
@@ -1,75 +1,29 @@
-import contextlib
 import json
-import urllib.parse
+import os
 import boto3
-import subprocess
-import sys
-from npe2 import PluginManager
+from npe2 import fetch_manifest
 
 s3 = boto3.client('s3')
-
-
-def discover_manifest(plugin_name):
-    """
-    Discovers manifest via npe2 library and fetches metadata related to plugin's manifest file.
-    """
-    pm = PluginManager()
-    pm.discover(include_npe1=False)
-    is_npe2 = True
-    try:
-        manifest = pm.get_manifest(plugin_name)
-    except KeyError:
-        pm.discover(include_npe1=True)
-        is_npe2 = False
-        # forcing lazy discovery to run
-        with contextlib.suppress(OSError):
-            pm.index_npe1_adapters()
-        manifest = pm.get_manifest(plugin_name)
-        if not manifest.contributions:
-            raise RuntimeError(f"Manifest {plugin_name} exists but has no contributions.")
-    return manifest, is_npe2
-
+# Environment variable set through ecs stack terraform module
+bucket = os.environ.get('BUCKET')
+bucket_path = os.environ.get('BUCKET_PATH', '')
 
 def generate_manifest(event, context):
     """
-    Inspects the manifest file of the plugin to retrieve the value of process_count. If the value of process_count
-    is in the json file and it is less than max_failure_tries, then the method attempts to pip install the plugin
-    with its version, calls discover_manifest to return manifest and is_npe2, then write to designated location on s3.
+    When manifest does not already exist, discover using `npe2_fetch` and write
+    valid manifest or resulting error message back to manifest file.
     """
-    max_failure_tries = 2
-    bucket = event['Records'][0]['s3']['bucket']['name']
-    key = urllib.parse.unquote_plus(event['Records'][0]['s3']['object']['key'], encoding='utf-8')
-    response = s3.get_object(Bucket=bucket, Key=key)
-    myBody = response["Body"]
-    body_dict = json.loads(myBody.read().decode("utf-8"))
-    s3_client = boto3.client('s3')
-    s3_body = ''
-    if 'process_count' not in body_dict or body_dict['process_count'] >= max_failure_tries:
-        return
+    plugin = event['plugin']
+    version = event['version']
+    key = os.path.join(bucket_path, f'cache/{plugin}/{plugin}.{version}-manifest.json')
     try:
-        splitPath = str(key).split("/")
-        plugin = splitPath[-2]
-        version = splitPath[-1].strip('-manifest.json')
-        command = [sys.executable, "-m", "pip", "install", f'{plugin}=={version}', "--target=/tmp/" + plugin]
-        p = subprocess.Popen(command, stdout=subprocess.PIPE)
-        while p.poll() is None:
-            l = p.stdout.readline()  # This blocks until it receives a newline.
-        sys.path.insert(0, "/tmp/" + plugin)
-        manifest, is_npe2 = discover_manifest(plugin)
-        # shimmed plugins will have `npe1_shim` field set to True, but only after npe2 release
-        manifest_dict = json.loads(manifest.json())
-        # write field manually for now
-        manifest_dict['npe1_shim'] = manifest_dict.get('npe1_shim', not is_npe2)
-        s3_body = json.dumps(manifest_dict)
+        existing_manifest = s3.get_object(Bucket=bucket, Key=key)
+        return 
+    # will fail on nonexistent, need to find proper exception class
     except Exception as e:
-        str_e = str(e).replace('"', "")
-        str_e = str_e.replace("'", "")
-        body_dict['error_message'] = str_e
-        s3_body = json.dumps(body_dict)
-        raise e
-    finally:
-        response = s3_client.delete_object(
-            Bucket=bucket,
-            Key=key
-        )
-        s3_client.put_object(Body=s3_body, Bucket=bucket, Key=key)
+        try:
+            manifest = fetch_manifest(plugin, version)
+            s3_body = manifest.json()
+        except Exception as e:
+            s3_body = str(e)
+        s3.put_object(Body=s3_body, Bucket=bucket, Key=key)

--- a/plugins/get_plugin_manifest.py
+++ b/plugins/get_plugin_manifest.py
@@ -16,14 +16,15 @@ def generate_manifest(event, context):
     plugin = event['plugin']
     version = event['version']
     key = os.path.join(bucket_path, f'cache/{plugin}/{plugin}.{version}-manifest.json')
+    # print(key)
     try:
         existing_manifest = s3.get_object(Bucket=bucket, Key=key)
-        return 
+        return
     # will fail on nonexistent, need to find proper exception class
     except Exception as e:
         try:
             manifest = fetch_manifest(plugin, version)
             s3_body = manifest.json()
         except Exception as e:
-            s3_body = str(e)
+            s3_body =  json.dumps({'error': str(e)})
         s3.put_object(Body=s3_body, Bucket=bucket, Key=key)

--- a/plugins/requirements.txt
+++ b/plugins/requirements.txt
@@ -1,4 +1,3 @@
 boto3
-requests
 npe2
 numpy

--- a/plugins/requirements.txt
+++ b/plugins/requirements.txt
@@ -1,6 +1,4 @@
 boto3
 requests
-napari
 npe2
 numpy
-pyqt5


### PR DESCRIPTION
As per #621 , this PR removes the manual manifest discovery code in the `plugins` lambda and replaces it with `npe2.fetch_manifest`.

To ensure idempotency and limit the likelihood of repeated processing of the same plugin, we also add a check for whether the manifest file already exists.

I've also added tests that can be run locally and on PRs touching the `plugins/` directory. These are not end to end tests i.e. they mock the s3 client and do not interact with AWS. They're pretty comprehensive otherwise though.