### PR TITLE
Fix area chart client-side API requests

### DIFF
--- a/frontend/mock-server.js
+++ b/frontend/mock-server.js
@@ -80,17 +80,17 @@ app.get('/activity/:plugin/stats', (req, res) => {
   if (stats) {
     res.json(stats);
   } else {
-    res.status(404);
+    res.status(404).send('not found');
   }
 });
 
 app.get('/activity/:plugin', async (req, res) => {
-  const stats = get(activity, [req.params.plugin, 'points'], null);
+  const points = get(activity, [req.params.plugin, 'points'], null);
 
-  if (stats) {
-    res.json(stats);
+  if (points) {
+    res.json(points);
   } else {
-    res.status(404);
+    res.status(404).send('not found');
   }
 });
 

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -67,8 +67,6 @@ module.exports = {
 
     config.plugins.push(
       new EnvironmentPlugin({
-        API_URL: '',
-
         BASE_PATH: '',
 
         // Path to JSON file that has the same structure as the backend's plugin

--- a/frontend/src/constants/env.ts
+++ b/frontend/src/constants/env.ts
@@ -3,3 +3,5 @@ export const PROD = process.env.ENV === 'prod';
 export const STAGING = process.env.ENV === 'staging';
 
 export const PREVIEW = !!process.env.PREVIEW;
+
+export const BROWSER = typeof window !== 'undefined';

--- a/frontend/src/pages/api/activity/[name]/index.ts
+++ b/frontend/src/pages/api/activity/[name]/index.ts
@@ -1,0 +1,14 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import { apiErrorWrapper } from '@/utils/error';
+import { hubAPI } from '@/utils/HubAPIClient';
+
+export default async function getPluginActivity(
+  req: NextApiRequest,
+  res: NextApiResponse,
+): Promise<void> {
+  await apiErrorWrapper(res, async () => {
+    const plugins = await hubAPI.getPluginActivity(req.query.name as string);
+    res.json(plugins);
+  });
+}

--- a/frontend/src/pages/api/activity/[name]/stats.ts
+++ b/frontend/src/pages/api/activity/[name]/stats.ts
@@ -1,0 +1,16 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import { apiErrorWrapper } from '@/utils/error';
+import { hubAPI } from '@/utils/HubAPIClient';
+
+export default async function getPluginInstallStats(
+  req: NextApiRequest,
+  res: NextApiResponse,
+): Promise<void> {
+  await apiErrorWrapper(res, async () => {
+    const plugins = await hubAPI.getPluginInstallStats(
+      req.query.name as string,
+    );
+    res.json(plugins);
+  });
+}

--- a/frontend/src/pages/api/activity/plugins.ts
+++ b/frontend/src/pages/api/activity/plugins.ts
@@ -1,0 +1,14 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import { apiErrorWrapper } from '@/utils/error';
+import { hubAPI } from '@/utils/HubAPIClient';
+
+export default async function getActivityPlugins(
+  _: NextApiRequest,
+  res: NextApiResponse,
+): Promise<void> {
+  await apiErrorWrapper(res, async () => {
+    const plugins = await hubAPI.getPluginsWithActivities();
+    res.json(plugins);
+  });
+}

--- a/frontend/src/utils/HubAPIClient.ts
+++ b/frontend/src/utils/HubAPIClient.ts
@@ -2,6 +2,7 @@
 
 import axios from 'axios';
 
+import { BROWSER } from '@/constants/env';
 import { PluginData, PluginIndexData } from '@/types';
 import { CollectionData, CollectionIndexData } from '@/types/collections';
 import { DataPoint, PluginInstallStats } from '@/types/stats';
@@ -55,10 +56,12 @@ function isHubAPIErrorResponse(
  */
 class HubAPIClient {
   private api = axios.create({
-    baseURL: API_URL,
-    headers: {
-      Host: API_URL_HOST,
-    },
+    baseURL: BROWSER ? '/api' : API_URL,
+    headers: BROWSER
+      ? undefined
+      : {
+          Host: API_URL_HOST,
+        },
   });
 
   async getPluginIndex(): Promise<PluginIndexData[]> {

--- a/frontend/src/utils/error.ts
+++ b/frontend/src/utils/error.ts
@@ -1,0 +1,26 @@
+import axios from 'axios';
+import { NextApiResponse } from 'next';
+
+export function getErrorMessage(error: unknown): string {
+  if (axios.isAxiosError(error)) {
+    return error.message;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+export async function apiErrorWrapper(
+  res: NextApiResponse,
+  callback: () => Promise<void>,
+) {
+  try {
+    await callback();
+  } catch (err) {
+    const status = axios.isAxiosError(err) ? err.response?.status : null;
+    res.status(status ?? 500).send(getErrorMessage(err));
+  }
+}


### PR DESCRIPTION
Closes #652 

This works by proxying client-side API requests through the Next.js server since the `API_URL` is available at runtime instead of build time.