### PR TITLE
Only call activity APIs when flag is off

### DIFF
--- a/frontend/src/hooks/usePluginActivity.ts
+++ b/frontend/src/hooks/usePluginActivity.ts
@@ -1,11 +1,16 @@
 import { useQuery } from 'react-query';
 
+import { useIsFeatureFlagEnabled } from '@/utils/featureFlags';
 import { hubAPI } from '@/utils/HubAPIClient';
 
 export function usePluginActivity(plugin?: string) {
+  const isActivityDashboardEnabled =
+    useIsFeatureFlagEnabled('activityDashboard');
+
   const { data: dataPoints = [], ...result } = useQuery(
     ['plugin-activity', plugin],
     () => (plugin ? hubAPI.getPluginActivity(plugin) : []),
+    { enabled: isActivityDashboardEnabled },
   );
 
   return { dataPoints, ...result };

--- a/frontend/src/hooks/usePluginInstallStats.ts
+++ b/frontend/src/hooks/usePluginInstallStats.ts
@@ -1,11 +1,16 @@
 import { useQuery } from 'react-query';
 
+import { useIsFeatureFlagEnabled } from '@/utils/featureFlags';
 import { hubAPI } from '@/utils/HubAPIClient';
 
 export function usePluginInstallStats(plugin?: string) {
+  const isActivityDashboardEnabled =
+    useIsFeatureFlagEnabled('activityDashboard');
+
   const { data: pluginStats, ...result } = useQuery(
     ['plugin-stats', plugin],
     () => (plugin ? hubAPI.getPluginInstallStats(plugin) : null),
+    { enabled: isActivityDashboardEnabled },
   );
 
   return {


### PR DESCRIPTION
Closes #693

This works by [disabling the query in react-query](https://tanstack.com/query/v4/docs/guides/disabling-queries) if the flag is off