### PR TITLE
Update preview page logic for npe2 fetch and fix tests

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -41,10 +41,11 @@ jobs:
           key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
 
       - name: Install dependencies
+        # need npe2 here to test preview page
         run: |
           pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest
+          pip install pytest npe2
 
       - name: Run tests
         working-directory: backend

--- a/frontend/src/utils/featureFlags.ts
+++ b/frontend/src/utils/featureFlags.ts
@@ -24,7 +24,7 @@ export const FEATURE_FLAGS = createFeatureFlags({
   },
 
   npe2: {
-    environments: ['dev', 'staging', 'prod'],
+    environments: ['dev', 'staging', 'prod', 'preview'],
   },
 
   collections: {


### PR DESCRIPTION
This PR updates the metadata parsing logic for the preview page to use `npe2 fetch` for manifest metadata and package info parsing, consistent with the process in the backend.

Link to example preview generated with this PR and [napari-hub-preview-action#5](https://github.com/chanzuckerberg/napari-hub-preview-action/pull/5):
https://preview.napari-hub.org/chanzuckerberg/napari-demo/19