### PR TITLE
Adding snowflake parameters to lambda env

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -119,8 +119,8 @@ module backend_lambda {
     "DD_ENV" = var.env
     "DD_SERVICE" = local.custom_stack_name
     "API_URL" = var.env == "dev" ? module.api_gateway_proxy_stage.invoke_url : ""
-    "PLUGINS_LAMBDA_NAME" = local.plugins_function_name,
-    "SNOWFLAKE_USER" = local.snowflake_user,
+    "PLUGINS_LAMBDA_NAME" = local.plugins_function_name
+    "SNOWFLAKE_USER" = local.snowflake_user
     "SNOWFLAKE_PASSWORD" = local.snowflake_password
   }
 

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -47,6 +47,8 @@ locals {
   github_app_key = try(local.secret["github"]["app_key"], "")
   github_app_secret = try(local.secret["github"]["app_secret"], "")
   datadog_api_key = try(local.secret["datadog"]["api_key"], "")
+  snowflake_user = try(local.secret["snowflake"]["user"], "")
+  snowflake_password = try(local.secret["snowflake"]["password"], "")
 
   frontend_url = var.frontend_url != "" ? var.frontend_url: try(join("", ["https://", module.frontend_dns.dns_prefix, ".", local.external_dns]), var.frontend_url)
   backend_function_name = "${local.custom_stack_name}-backend"
@@ -117,7 +119,9 @@ module backend_lambda {
     "DD_ENV" = var.env
     "DD_SERVICE" = local.custom_stack_name
     "API_URL" = var.env == "dev" ? module.api_gateway_proxy_stage.invoke_url : ""
-    "PLUGINS_LAMBDA_NAME" = local.plugins_function_name
+    "PLUGINS_LAMBDA_NAME" = local.plugins_function_name,
+    "SNOWFLAKE_USER" = local.snowflake_user,
+    "SNOWFLAKE_PASSWORD" = local.snowflake_password
   }
 
   log_retention_in_days = 14


### PR DESCRIPTION
Relates to: https://github.com/chanzuckerberg/napari-hub/issues/695
Depends on: https://github.com/chanzuckerberg/sci-imaging-infra/pull/69


### Solution
Adds the required snowflake environment variable to the lambda from secrets. Defaults to `""` when values don't exist in the secrets.  