### PR TITLE
Update plugin metadata copy to render in sentence case

### DIFF
--- a/frontend/i18n/en/pluginData.json
+++ b/frontend/i18n/en/pluginData.json
@@ -3,29 +3,28 @@
     "authors": "Authors",
     "citations": "Citation information",
     "description": "Description",
+    "displayName": "Display name",
     "documentation": "Documentation",
     "firstReleased": "First released",
+    "Image modality": "Image modality",
+    "license": "License",
+    "operatingSystem": "Operating system",
     "projectSite": "Project site",
+    "readerFileExtensions": "Open extension",
+    "releaseDate": "Release date",
     "reportIssues": "Report issues",
     "requirements": "Requirements",
     "sourceCode": "Source code",
-
-    "Image modality": "Image modality",
     "Supported data": "Supported data",
+    "twitter": "Twitter",
+    "version": "Version",
     "Workflow step": "Workflow step",
+    "writerFileExtensions": "Save extension",
 
     "pluginType": {
       "label": "Plugin type",
       "reader": "File reader",
       "writer": "File writer"
-    },
-
-    "readerFileExtensions": {
-      "label": "Open extension"
-    },
-
-    "writerFileExtensions": {
-      "label": "Save extension"
     },
 
     "writerSaveLayers": {
@@ -35,34 +34,14 @@
       "shapes": "Shapes"
     },
 
-    "license": {
-      "label": "License",
-      "lower": "license"
-    },
-
-    "operatingSystem": {
-      "label": "Operating system",
-      "lower": "operating system"
-    },
-
     "pluginName": {
       "label": "Plugin name",
       "preview": "Name"
     },
 
-    "displayName": {
-      "label": "Display name"
-    },
-
     "pythonVersion": {
       "label": "Python versions supported",
-      "short": "Python versions",
-      "lower": "Python version"
-    },
-
-    "releaseDate": {
-      "label": "Release date",
-      "lower": "release date"
+      "short": "Python versions"
     },
 
     "summary": {
@@ -73,15 +52,6 @@
     "supportSite": {
       "label": "Support site",
       "preview": "Support"
-    },
-
-    "twitter": {
-      "label": "Twitter"
-    },
-
-    "version": {
-      "label": "Version",
-      "lower": "version"
     }
   },
 

--- a/frontend/src/components/SearchPage/PluginSearchResult.tsx
+++ b/frontend/src/components/SearchPage/PluginSearchResult.tsx
@@ -131,8 +131,8 @@ export function PluginSearchResult({
     return url.pathname + url.search;
   }, [plugin.name, snap]);
 
-  const getLower = (label: I18nPluginDataLabel) =>
-    isString(label) ? label : label.lower ?? label.label;
+  const getLabel = (label: I18nPluginDataLabel) =>
+    isString(label) ? label : label.label;
 
   function getItems(
     ...items: Array<{
@@ -141,7 +141,7 @@ export function PluginSearchResult({
     }>
   ): SearchResultItem[] {
     return items.map((item) => ({
-      label: getLower(item.label),
+      label: getLabel(item.label),
       value: item.value,
     }));
   }
@@ -313,9 +313,7 @@ export function PluginSearchResult({
                   key={`${item.label}-${item.value}`}
                   className="grid grid-cols-[auto,1fr]"
                 >
-                  <h5 className="inline whitespace-nowrap lowercase">
-                    {item.label}
-                  </h5>
+                  <h5 className="inline whitespace-nowrap">{item.label}</h5>
                   <span
                     className={clsx(
                       'ml-sds-xxs',


### PR DESCRIPTION
## Description

Closes #705

Refactors how we render the metadata on the plugin search result card so that we show the metadata labels in sentence case rather than lowercase 

## Demos

<img width="263" alt="image" src="https://user-images.githubusercontent.com/2176050/202041817-16d9944a-9cf6-4dad-9582-f9a5a0ba4254.png">
