### PR TITLE
Add plausible analytics for plugin tabbed navigation

### DIFF
--- a/frontend/src/components/PluginPage/PluginTabs.tsx
+++ b/frontend/src/components/PluginPage/PluginTabs.tsx
@@ -11,7 +11,7 @@ import { MetadataHighlighter } from '@/components/MetadataHighlighter';
 import { SkeletonLoader } from '@/components/SkeletonLoader';
 import { useLoadingState } from '@/context/loading';
 import { usePluginState } from '@/context/plugin';
-import { useMediaQuery } from '@/hooks';
+import { useMediaQuery, usePlausible } from '@/hooks';
 import { pluginTabsStore, resetPluginTabs } from '@/store/pluginTabs';
 import { PluginTabType } from '@/types/plugin';
 
@@ -63,6 +63,7 @@ export function PluginTabs() {
   const { activeTab } = useSnapshot(pluginTabsStore);
   const isLoading = useLoadingState();
   const hasPluginMetadataScroll = useMediaQuery({ maxWidth: 'screen-1425' });
+  const plausible = usePlausible();
 
   // Reset plugin tab state when navigating away from page.
   useEffect(resetPluginTabs, []);
@@ -128,7 +129,13 @@ export function PluginTabs() {
           }}
           value={activeTab}
           onChange={(_, nextTab) => {
-            pluginTabsStore.activeTab = nextTab as PluginTabType;
+            const tab = nextTab as PluginTabType;
+            pluginTabsStore.activeTab = tab;
+
+            plausible('Plugin Tab Nav', {
+              tab,
+              plugin: plugin?.name ?? '',
+            });
           }}
         >
           {tabs.map(({ label, tab }) => (

--- a/frontend/src/hooks/usePlausible.ts
+++ b/frontend/src/hooks/usePlausible.ts
@@ -1,5 +1,6 @@
 import { usePlausible as usePlausibleNext } from 'next-plausible';
 
+import { PluginTabType } from '@/types/plugin';
 import { Logger } from '@/utils';
 
 const logger = new Logger('usePlausible.ts');
@@ -56,6 +57,11 @@ export type Events = {
   };
 
   'CTA: New Collection': unknown;
+
+  'Plugin Tab Nav': {
+    plugin: string;
+    tab: PluginTabType;
+  };
 };
 
 export type PlausibleEventKey = keyof Events;


### PR DESCRIPTION
## Description

Closes #748

Adds a new plausible event `Plugin Tab Nav` for tracking when the user switches between tabs on a plugin. This includes metadata that shows which plugin and which tab the user switched to 

## Demo

<img width="464" alt="image" src="https://user-images.githubusercontent.com/2176050/202043563-95d3afc8-12be-4107-8897-b850e8461d59.png">
