### PR TITLE
Fix total installs release date

### DIFF
--- a/frontend/src/components/ActivityDashboard/TotalInstalls.tsx
+++ b/frontend/src/components/ActivityDashboard/TotalInstalls.tsx
@@ -38,8 +38,8 @@ export function TotalInstalls() {
   );
 
   const date = useMemo(
-    () => dayjs(plugin?.release_date),
-    [plugin?.release_date],
+    () => dayjs(plugin?.first_released),
+    [plugin?.first_released],
   );
 
   const dateBucketType = useDateBucketType(date);


### PR DESCRIPTION
## Description

Closes #755

@klai95 and @manasaV3 found a bug where we showed the wrong date on the total installs section caused by a typo

## Demo

### Before

<img width="259" alt="image" src="https://user-images.githubusercontent.com/2176050/202046232-d3273b89-5d3f-4999-b350-e5651d7f658c.png">


### After

<img width="249" alt="image" src="https://user-images.githubusercontent.com/2176050/202046200-c5bf9319-ca19-400d-866b-f225cd1d8e2d.png">

