### PR TITLE
Fix preview i18n for category chips

### DIFF
--- a/frontend/i18n/en/common.json
+++ b/frontend/i18n/en/common.json
@@ -1,6 +1,7 @@
 {
   "about": "About",
   "close": "Close",
+  "collapse": "Collapse",
   "collections": "Collections",
   "contact": "Contact",
   "cziOss": "Chan Zuckerberg Initiative EOSS Program",
@@ -20,6 +21,7 @@
   "plausiblePrivacy": "Plausible.io Privacy Policy",
   "plugins": "Plugins",
   "privacy": "Privacy",
+  "showMore": "Show {{count}} more",
 
   "ariaLabels": {
     "clearSearchBar": "Clear search bar text",

--- a/frontend/i18n/en/homePage.json
+++ b/frontend/i18n/en/homePage.json
@@ -2,8 +2,6 @@
   "browsePlugins": "Browse plugins: <count />",
   "fetchError": "Unable to fetch plugin index",
   "searchBar": "Search for a plugin by keyword or author",
-  "showMore": "Show {{count}} more",
-  "collapse": "Collapse",
 
   "ariaLabels": {
     "sortPlugins": "Sort plugins by"

--- a/frontend/src/components/CategoryChip/CategoryChipContainer.tsx
+++ b/frontend/src/components/CategoryChip/CategoryChipContainer.tsx
@@ -40,7 +40,7 @@ export function CategoryChipContainer({
   const categoryChipsRef = useRef<HTMLDivElement[]>([]);
   const [overflowIndex, setOverflowIndex] = useState(Infinity);
   const [overrideOverflow, setOverrideOverflow] = useState(false);
-  const { t } = useTranslation(['homePage']);
+  const { t } = useTranslation(['common']);
   const plausible = usePlausible();
 
   useEffect(() => {
@@ -155,8 +155,8 @@ export function CategoryChipContainer({
           type="button"
         >
           {overrideOverflow
-            ? t('homePage:collapse')
-            : t('homePage:showMore', {
+            ? t('common:collapse')
+            : t('common:showMore', {
                 count: (categories || hierarchies).length - overflowIndex,
               })}
         </button>

--- a/frontend/src/pages/preview.tsx
+++ b/frontend/src/pages/preview.tsx
@@ -33,7 +33,6 @@ export async function getStaticProps({
     'pageTitles',
     'pluginPage',
     'pluginData',
-    'preview',
   ] as I18nNamespace[]);
 
   // Return default data to prevent Next.js error if the plugin path is not defined.


### PR DESCRIPTION
## Description

Fixes issue with i18n not rendering correctly on preview page. Instead, it shows the i18n keys `showMore` and `collapse` instead of the rendered text 

## Demo

### Before

<img width="464" alt="image" src="https://user-images.githubusercontent.com/2176050/202057670-b7a26496-81b5-4351-9b0c-a28c5bdfdabc.png">

<img width="725" alt="image" src="https://user-images.githubusercontent.com/2176050/202057687-fecb3c09-01f4-4eb6-a4f6-7f96b477dfd8.png">


### After

<img width="487" alt="image" src="https://user-images.githubusercontent.com/2176050/202057633-b3d2335f-66b6-4c14-a13c-1a1bd60cc8bb.png">

<img width="727" alt="image" src="https://user-images.githubusercontent.com/2176050/202057645-65f3d5ee-1649-4e02-94d9-27ea03a7d2a9.png">
