### PR TITLE
Use correct published date for monthly installs

### DIFF
--- a/frontend/src/components/ActivityDashboard/MonthlyInstalls/MonthlyInstalls.tsx
+++ b/frontend/src/components/ActivityDashboard/MonthlyInstalls/MonthlyInstalls.tsx
@@ -33,7 +33,7 @@ export function MonthlyInstalls() {
   );
   const chartData = useChartData(
     dataPoints,
-    dayjs(plugin?.release_date),
+    dayjs(plugin?.first_released),
     visibleMonths,
   );
 

--- a/frontend/src/components/ActivityDashboard/MonthlyInstalls/PublishedLine.tsx
+++ b/frontend/src/components/ActivityDashboard/MonthlyInstalls/PublishedLine.tsx
@@ -12,7 +12,7 @@ export function PublishedLine(props: VictoryLabelProps) {
   const { plugin } = usePluginState();
   const { x = 0, datum } = props;
   const point = datum as DataPoint;
-  const release = dayjs(plugin?.release_date);
+  const release = dayjs(plugin?.first_released);
 
   if (
     point.y === null ||


### PR DESCRIPTION
## Description

Closes #767

Fixes a typo that uses the incorrect date for monthly installs.

## Demo

## Before

<img width="290" alt="image" src="https://user-images.githubusercontent.com/2176050/203662530-2f5de75e-8c2a-401a-82ef-e175b6ccb004.png">

## After

<img width="286" alt="image" src="https://user-images.githubusercontent.com/2176050/203662813-afc1da0e-5546-40ca-b209-9e18d802d0ea.png">
