### PR TITLE
Handle uppercase in branch name

### DIFF
--- a/.github/workflows/push-rdev.yml
+++ b/.github/workflows/push-rdev.yml
@@ -41,9 +41,6 @@ jobs:
           else             
             echo $GITHUB_REF_NAME | tr '[:upper:]' '[:lower:]' | xargs -I {} -n 1 echo STACK_NAME={} >> $GITHUB_ENV
           fi
-      - name: Set deleted branch name
-        if: ${{ github.event.name == 'delete' && startsWith(github.event.ref, 'dev-') }}
-        run: echo ${{ github.event.ref }} | tr '[:upper:]' '[:lower:]' | xargs -I {} -n 1 echo DELETE_STACK_NAME={} >> $GITHUB_ENV
       - name: Create update dev
         if: ${{ github.event_name == 'push' }}
         uses: chanzuckerberg/github-actions/.github/actions/deploy-happy-stack@v1.7.4
@@ -56,6 +53,9 @@ jobs:
           tfe-token: ${{ secrets.TFE_TOKEN }}
           env: "dev"
           operation: "create-or-update"
+      - name: Delete dev set up stack name
+        if: ${{ github.event_name == 'delete' && startsWith(github.event.ref, 'dev-') }}
+        run: echo ${{ github.event.ref }} | tr '[:upper:]' '[:lower:]' | xargs -I {} -n 1 echo DELETE_STACK_NAME={} >> $GITHUB_ENV
       - name: Delete dev
         if: ${{ github.event_name == 'delete' && startsWith(github.event.ref, 'dev-') }}
         uses: chanzuckerberg/github-actions/.github/actions/deploy-happy-stack@v1.4.0

--- a/.github/workflows/push-rdev.yml
+++ b/.github/workflows/push-rdev.yml
@@ -38,9 +38,12 @@ jobs:
           if [[ ${#GITHUB_REF_NAME} -gt 32 ]]; then
             echo "branch name: ${GITHUB_REF_NAME}, length ${#GITHUB_REF_NAME}, is $((${#GITHUB_REF_NAME} - 32)) characters too long, please use a branch name that's 32 characters or shorter"
             exit 1
-          else 
-            echo STACK_NAME=${GITHUB_REF_NAME} >> $GITHUB_ENV
+          else             
+            echo $GITHUB_REF_NAME | tr '[:upper:]' '[:lower:]' | xargs -I {} -n 1 echo STACK_NAME={} >> $GITHUB_ENV
           fi
+      - name: Set deleted branch name
+        if: ${{ github.event.name == 'delete' && startsWith(github.event.ref, 'dev-') }}
+        run: echo ${{ github.event.ref }} | tr '[:upper:]' '[:lower:]' | xargs -I {} -n 1 echo DELETE_STACK_NAME={} >> $GITHUB_ENV
       - name: Create update dev
         if: ${{ github.event_name == 'push' }}
         uses: chanzuckerberg/github-actions/.github/actions/deploy-happy-stack@v1.7.4
@@ -59,7 +62,7 @@ jobs:
         env:
           ENV: dev
         with:
-          stack-name: ${{ github.event.ref }}
+          stack-name: ${{ env.DELETE_STACK_NAME }}
           operation: "delete"
           tfe-token: ${{ secrets.TFE_TOKEN }}
           env: "dev"

--- a/.github/workflows/push-rdev.yml
+++ b/.github/workflows/push-rdev.yml
@@ -38,7 +38,7 @@ jobs:
           if [[ ${#GITHUB_REF_NAME} -gt 32 ]]; then
             echo "branch name: ${GITHUB_REF_NAME}, length ${#GITHUB_REF_NAME}, is $((${#GITHUB_REF_NAME} - 32)) characters too long, please use a branch name that's 32 characters or shorter"
             exit 1
-          else             
+          else 
             echo $GITHUB_REF_NAME | tr '[:upper:]' '[:lower:]' | xargs -I {} -n 1 echo STACK_NAME={} >> $GITHUB_ENV
           fi
       - name: Create update dev


### PR DESCRIPTION
Relates to https://github.com/chanzuckerberg/napari-hub/issues/764

Changes Introduced:
To prevent stack names from containing upper-case characters, we transform the text received in GITHUB_REF_NAME to lowercase characters before assigning it to STACK_NAME in the GitHub env.

We use the tr command to transform all uppercase chars to lowercase chars.
Ref: https://linuxcommand.org/lc3_man_pages/tr1.html

### Detailed Summary:

> The short ref name of the branch or tag that triggered the workflow run. This value matches the branch or tag name shown on GitHub.

In our cases, the `$GITHUB_REF_NAME` stores the name of the `dev-` branch we are trying to deploy.

In the past, we directly pushed `STACK_NAME=GITHUB_REF_NAME` to GitHub env variables for workflow execution. This would set the stack name to be the same as the branch name. 

But, we are running into edge-case issues with branch names containing uppercase characters. So, we are transforming any uppercase char to lowercase here before pushing it to the GitHub env. To break this down:

1. We start with `echo $GITHUB_REF_NAME` to have the branch name available for processing in the pipeline. 
2. The `tr` command is configured to transform any uppercase chars to lowercase chars. ref: [man](https://man7.org/linux/man-pages/man1/tr.1p.html)
3. As we build a statement where we assign the output of the prior statement into the echo statement, we use xargs. ref [man](https://man7.org/linux/man-pages/man1/xargs.1.html)