### PR TITLE
Add learn more link

### DIFF
--- a/frontend/i18n/en/activity.json
+++ b/frontend/i18n/en/activity.json
@@ -2,9 +2,10 @@
   "installs": "installs",
   "installsTitle": "Installs",
   "usage": "Usage",
+  "learnMoreLink": "https://github.com/chanzuckerberg/napari-hub/wiki/Guide-to-Activity-Tab",
+  "learnMore": "<externalLink href='$t(learnMoreLink)'>Learn more about where we get this data.</externalLink>",
   "noData": {
-    "learnMoreLink": "https://github.com/chanzuckerberg/napari-hub",
-    "allData": "No data could be fetched for this plugin. <externalLink href='$t(noData.learnMoreLink)'>Learn more.</externalLink>",
+    "allData": "No data could be fetched for this plugin. <externalLink href='$t(learnMoreLink)'>Learn more.</externalLink>",
     "monthlyInstalls": "There is not yet enough data to display for this plugin"
   },
   "monthlyInstalls": {

--- a/frontend/src/components/ActivityDashboard/ActivityDashboard.tsx
+++ b/frontend/src/components/ActivityDashboard/ActivityDashboard.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
 import { I18n } from '@/components/I18n';
+import { Text } from '@/components/Text';
 import { usePluginState } from '@/context/plugin';
 import { usePluginMetrics } from '@/hooks';
 
@@ -35,7 +36,13 @@ export function ActivityDashboard() {
           <I18n i18nKey="activity:noData.allData" />
         </EmptyState>
       ) : (
-        <ActivityUsageSection />
+        <>
+          <ActivityUsageSection />
+
+          <Text variant="bodyS">
+            <I18n i18nKey="activity:learnMore" />
+          </Text>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Description

Closes #752

Adds the learn more link to the bottom of the activity dashboard page. It also updates the wiki link to the correct link:
https://github.com/chanzuckerberg/napari-hub/wiki/Guide-to-Activity-Tab

## Demo

<img width="818" alt="image" src="https://user-images.githubusercontent.com/2176050/204628956-5bead470-2abd-492f-be4e-4e63de8bb6ee.png">
