### PR TITLE
 unused old components

### DIFF
--- a/backend/api/_tests/test_activity_dashboard.py
+++ b/backend/api/_tests/test_activity_dashboard.py
@@ -15,56 +15,6 @@ mock_plugin_recent_installs = {'string-1': 25, 'foo': 10, 'bar': 30}
 
 class TestActivityDashboard(unittest.TestCase):
 
-    @patch.object(
-        model, 'get_install_timeline_data', return_value=mock_df.copy()
-    )
-    def test_get_installs_nonempty(self, mock_get_activity_dashboard_data):
-        from api.model import get_installs
-        result = get_installs('string-1', '3')
-        assert result == self._generate_expected_timeline(-3, 'x', 'y')
-
-    @patch.object(
-        model, 'get_install_timeline_data', return_value=mock_df.copy()
-    )
-    def test_get_installs_zero_limit(self, mock_get_activity_dashboard_data):
-        from api.model import get_installs
-        result = get_installs('string-1', '0')
-        assert result == []
-
-    @patch.object(
-        model, 'get_install_timeline_data', return_value=empty_df.copy()
-    )
-    def test_get_installs_no_data(self, mock_get_activity_dashboard_data):
-        from api.model import get_installs
-        result = get_installs('string-1', '1')
-        assert result == self._generate_expected_timeline(-1, 'x', 'y')
-
-    @patch.object(
-        model, 'get_install_timeline_data', return_value=mock_df.copy()
-    )
-    def test_get_installs_stats_nonempty(self, mock_get_activity_dashboard_data):
-        from api.model import get_installs_stats
-        result = get_installs_stats('string-1')
-        expected = {'totalInstalls': sum(mock_installs), 'totalMonths': 10}
-        assert result == expected
-
-    @patch.object(
-        model, 'get_install_timeline_data', return_value=empty_df.copy()
-    )
-    def test_get_installs_stats_empty(self, mock_get_activity_dashboard_data):
-        from api.model import get_installs_stats
-        result = get_installs_stats('string-1')
-        assert result == {}
-
-    @patch.object(model, 'get_recent_activity_data', return_value={})
-    def test_get_recent_installs_stats_empty(self, _):
-        from api.model import get_recent_installs_stats
-        self.assertEqual({'installsInLast30days': 0}, get_recent_installs_stats('string-1'))
-
-    @patch.object(model, 'get_recent_activity_data', return_value=mock_plugin_recent_installs)
-    def test_get_recent_installs_stats_nonempty(self, _):
-        from api.model import get_recent_installs_stats
-        self.assertEqual({'installsInLast30days': 25}, get_recent_installs_stats('string-1'))
 
     @patch.object(model, 'get_recent_activity_data', return_value={})
     @patch.object(model, 'get_install_timeline_data', return_value=empty_df.copy())

--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -116,21 +116,6 @@ def update_activity() -> Response:
     return app.make_response(("Complete", 204))
 
 
-@app.route('/activity/<plugin>')
-def get_plugin_installs(plugin: str) -> Response:
-    return jsonify(get_installs(plugin, request.args.get('limit', '12')))
-
-
-@app.route('/activity/<plugin>/stats')
-def get_plugin_installs_stats(plugin: str) -> Response:
-    return jsonify(get_installs_stats(plugin))
-
-
-@app.route('/activity/<plugin>/recent_stats')
-def get_plugin_recent_installs_stats(plugin: str) -> Response:
-    return jsonify(get_recent_installs_stats(plugin))
-
-
 @app.route('/metrics/<plugin>')
 def get_plugin_metrics(plugin: str) -> Response:
     return jsonify(get_metrics_for_plugin(plugin, request.args.get('limit', '12')))

--- a/backend/api/model.py
+++ b/backend/api/model.py
@@ -420,21 +420,7 @@ def _is_not_valid_limit(limit):
     return not limit.isdigit() or limit == '0'
 
 
-def get_installs(plugin: str, limit: str) -> List[Any]:
-    """
-    This should return a list of objects, in which attribute x is the numerical value in milliseconds
-    and attribute y is the number of installs
-    :param plugin: plugin name
-    :param limit: number of objects to return
-    :return: list of objects
-    """
-    if _is_not_valid_limit(limit):
-        return []
-    plugin_df = get_install_timeline_data(plugin)
-    return _process_for_timeline(plugin_df, int(limit), 'x', 'y')
-
-
-def _process_for_timeline(plugin_df, limit, timestamp_key, installs_key):
+def _process_for_timeline(plugin_df, limit):
     date_format = '%Y-%m-%d'
     end_date = date.today().replace(day=1) + relativedelta(months=-1)
     start_date = end_date + relativedelta(months=-limit + 1)
@@ -448,7 +434,7 @@ def _process_for_timeline(plugin_df, limit, timestamp_key, installs_key):
             installs = int(str(row.NUM_DOWNLOADS_BY_MONTH).split()[1])
         else:
             installs = 0
-        result.append({timestamp_key: int(cur_date.timestamp()) * 1000, installs_key: installs})
+        result.append({'timestamp': int(cur_date.timestamp()) * 1000, 'installs': installs})
     return result
 
 
@@ -461,17 +447,6 @@ def _process_for_stats(plugin_df):
         'totalInstalls': int(plugin_df['NUM_DOWNLOADS_BY_MONTH'].sum()),
         'totalMonths': month_offset.n
     }
-
-
-def get_installs_stats(plugin: str) -> Any:
-    """
-    This should return an object, with numerical attributes totalInstallCount and totalMonths
-
-    :param plugin: plugin name
-    :return: object
-    """
-    plugin_df = get_install_timeline_data(plugin)
-    return _process_for_stats(plugin_df)
 
 
 def _update_recent_activity_data(number_of_time_periods=30, time_granularity='DAY'):
@@ -499,22 +474,14 @@ def _update_recent_activity_data(number_of_time_periods=30, time_granularity='DA
     write_data(json.dumps(data), "activity_dashboard_data/recent_installs.json")
 
 
-def _get_recent_activity_data(plugin) -> int:
-    return get_recent_activity_data().get(plugin, 0)
-
-
-def get_recent_installs_stats(plugin: str) -> Dict:
-    return {'installsInLast30days': _get_recent_activity_data(plugin)}
-
-
 def get_metrics_for_plugin(plugin: str, limit: str) -> Dict:
     data = get_install_timeline_data(plugin)
     install_stats = _process_for_stats(data)
-    timeline = [] if _is_not_valid_limit(limit) else _process_for_timeline(data, int(limit), 'timestamp', 'installs')
+    timeline = [] if _is_not_valid_limit(limit) else _process_for_timeline(data, int(limit))
     complete_stats = {
         'totalInstalls': install_stats.get('totalInstalls', 0),
         'totalMonths': install_stats.get('totalMonths', 0),
-        'installsInLast30Days': _get_recent_activity_data(plugin)
+        'installsInLast30Days': get_recent_activity_data().get(plugin, 0)
     }
     activity_data = {
         'timeline': timeline,


### PR DESCRIPTION
Relates to: https://github.com/chanzuckerberg/napari-hub/issues/720

#### Summary
Removes the code for individual activity APIs as the frontend uses the consolidated`/metric` endpoint as of https://github.com/chanzuckerberg/napari-hub/pull/749

