### PR TITLE
Adding begins with checks to git url match

### DIFF
--- a/backend/preview/preview.py
+++ b/backend/preview/preview.py
@@ -1,6 +1,5 @@
 from typing import Union
 from git import Repo
-from pkginfo import Wheel
 from collections import defaultdict
 import datetime
 import subprocess
@@ -9,7 +8,6 @@ import glob
 import os
 import json
 import requests
-import yaml
 from utils.utils import get_category_mapping, parse_manifest
 from utils.github import github_pattern, get_github_metadata, get_github_repo_url
 from utils.pypi import get_plugin_pypi_metadata

--- a/backend/utils/github.py
+++ b/backend/utils/github.py
@@ -25,7 +25,7 @@ elif github_client_id and github_client_secret:
     auth = HTTPBasicAuth(github_client_id, github_client_secret)
 
 visibility_set = {'public', 'disabled', 'hidden'}
-github_pattern = re.compile("https://github\\.com/([^/]+)/([^/]+)")
+github_pattern = re.compile("^https://github\\.com/([^/]+)/([^/]+)")
 hub_config_keys = {'summary', 'authors', 'labels', 'visibility'}
 default_description = 'The developer has not yet provided a napari-hub specific description.'
 project_url_names = {


### PR DESCRIPTION
Relates to: https://github.com/gitpython-developers/GitPython/issues/1515

According to https://security.snyk.io/vuln/SNYK-PYTHON-GITPYTHON-3113858:
This is only relevant when enabling the `ext` transport protocol.

We already validate the URLs that we pass on the `git.clone` to be `https` protocol with a regex match
https://github.com/chanzuckerberg/napari-hub/blob/main/backend/utils/github.py#L28
https://github.com/chanzuckerberg/napari-hub/blob/main/backend/preview/preview.py#L90

### Changes:
Making the regex match more explicit to validate that the url begins with `https://github.com`