### PR TITLE
Adjusting plugin_update_schedule expression for staging

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -55,7 +55,7 @@ locals {
   backend_function_name = "${local.custom_stack_name}-backend"
   plugins_function_name = "${local.custom_stack_name}-plugins"
 
-  plugin_update_schedule = var.env == "prod" ? "rate(5 minutes)" : var.env == "staging" ? "rate(1 hours)" : "rate(1 days)"
+  plugin_update_schedule = var.env == "prod" ? "rate(5 minutes)" : var.env == "staging" ? "rate(1 hour)" : "rate(1 day)"
 }
 
 module frontend_dns {


### PR DESCRIPTION
Relates to: https://github.com/chanzuckerberg/napari-hub/pull/797

**Bug:** 
This is causing `Parameter ScheduleExpression is not valid` in staging. 

From [Schedule Expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#RateExpressions):

> Restrictions
If the value is equal to 1, then the unit must be singular. Similarly, for values greater than 1, the unit must be plural. For example, rate(1 hours) and rate(5 hour) are not valid, but rate(1 hour) and rate(5 hours) are valid.

**Summary:**
Making the time unit singular for staging and devo.
