### PR TITLE
Staging front end ECS task count to default to 1

### DIFF
--- a/.happy/terraform/envs/staging/main.tf
+++ b/.happy/terraform/envs/staging/main.tf
@@ -28,4 +28,5 @@ module stack {
   stack_prefix          = "/${var.stack_name}"
   tags                  = local.tags
   wait_for_steady_state = var.wait_for_steady_state
+  frontend_instance_count = 1
 }


### PR DESCRIPTION
Relates to https://github.com/chanzuckerberg/napari-hub/issues/746

Sets minimum frontend tasks to 1 in the staging environment. 