### PR TITLE
Handling prefix mount in dev environment

### DIFF
--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -7,6 +7,7 @@ from flask import Flask, Response, jsonify, render_template, request
 from flask_githubapp.core import GitHubApp
 
 from api.collections import get_collections, get_collection
+from api.custom_wsgi import script_path_middleware
 from api.model import get_public_plugins, get_index, get_plugin, get_excluded_plugins, update_cache, \
     move_artifact_to_s3, get_category_mapping, get_categories_mapping, get_manifest, update_activity_data, \
     get_metrics_for_plugin
@@ -21,6 +22,10 @@ app = Flask(__name__)
 app.config['JSONIFY_PRETTYPRINT_REGULAR'] = True
 app.url_map.redirect_defaults = False
 preview_app = Flask("Preview")
+
+if os.getenv('DD_ENV') == 'dev':
+    app.wsgi_app = script_path_middleware(f'/{os.getenv("DD_SERVICE")}')(app.wsgi_app)
+
 
 if GITHUB_APP_ID and GITHUB_APP_KEY and GITHUB_APP_SECRET:
     preview_app.config['GITHUBAPP_ID'] = int(GITHUB_APP_ID)

--- a/backend/api/custom_wsgi.py
+++ b/backend/api/custom_wsgi.py
@@ -1,0 +1,11 @@
+
+def script_path_middleware(script_path):
+    def wrapper(wsgi_app):
+        def new_app(environ, start_response):
+            if environ['PATH_INFO'].startswith(script_path):
+                environ['PATH_INFO'] = environ['PATH_INFO'][len(script_path):]
+                environ['SCRIPT_NAME'] += script_path
+            return wsgi_app(environ, start_response)
+
+        return new_app
+    return wrapper

--- a/backend/api/custom_wsgi.py
+++ b/backend/api/custom_wsgi.py
@@ -1,6 +1,7 @@
-
 def script_path_middleware(script_path):
     def wrapper(wsgi_app):
+
+        # Allows route mapping to ignore the specific prefix if present
         def new_app(environ, start_response):
             if environ['PATH_INFO'].startswith(script_path):
                 environ['PATH_INFO'] = environ['PATH_INFO'][len(script_path):]


### PR DESCRIPTION
Closes: https://github.com/chanzuckerberg/napari-hub/issues/872

With the custom domain of the API gateway's dev environment, we get the prefix of the stack as a part of the URL. This PR adds wsgi middleware to allow the route mapping to ignore the prefix if present. 

We can now access the dev api as follows: 
- https://6vwmwypt38.execute-api.us-west-2.amazonaws.com/dev-manasa-test/
- https://api.dev.napari-hub.org/dev-manasa-test/


Relates to: https://github.com/chanzuckerberg/sci-imaging-infra/pull/77
Blocks: https://github.com/chanzuckerberg/napari-hub/pull/816
