### PR TITLE
Ingest all data for commit_activity.json & compute total_commits based on it

### DIFF
--- a/backend/api/_tests/test_activity_dashboard.py
+++ b/backend/api/_tests/test_activity_dashboard.py
@@ -21,22 +21,20 @@ MOCK_PLUGIN_COMMIT_ACTIVITY = [(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (
 class TestActivityDashboard(unittest.TestCase):
 
     @patch.object(model, 'get_latest_commit', return_value=None)
-    @patch.object(model, 'get_total_commit', return_value=None)
     @patch.object(model, 'get_commit_activity', return_value=None)
     @patch.object(model, 'get_recent_activity_data', return_value={})
     @patch.object(model, 'get_install_timeline_data', return_value=EMPTY_DF.copy())
-    def test_get_metrics_empty(self, mock_get_install_timeline_data, mock_get_recent_activity_data,  mock_get_commit_activity, mock_get_total_commit, mock_get_latest_commit):
+    def test_get_metrics_empty(self, mock_get_install_timeline_data, mock_get_recent_activity_data,  mock_get_commit_activity, mock_get_latest_commit):
         expected = self._generate_expected_metrics(
             timeline=self._generate_expected_timeline(-3, to_installs=lambda i: 0)
         )
-        self._verify_results('3', expected, mock_get_install_timeline_data, mock_get_recent_activity_data, mock_get_commit_activity, mock_get_total_commit, mock_get_latest_commit)
+        self._verify_results('3', expected, mock_get_install_timeline_data, mock_get_recent_activity_data, mock_get_commit_activity, mock_get_latest_commit)
 
     @patch.object(model, 'get_latest_commit', return_value=MOCK_PLUGIN_LATEST_COMMIT)
-    @patch.object(model, 'get_total_commit', return_value=MOCK_PLUGIN_TOTAL_COMMIT)
     @patch.object(model, 'get_commit_activity', return_value=MOCK_PLUGIN_COMMIT_ACTIVITY)
     @patch.object(model, 'get_recent_activity_data', return_value=MOCK_PLUGIN_RECENT_INSTALLS)
     @patch.object(model, 'get_install_timeline_data', return_value=MOCK_DF.copy())
-    def test_get_metrics_nonempty(self, mock_get_install_timeline_data, mock_get_recent_activity_data, mock_get_commit_activity, mock_get_total_commit, mock_get_latest_commit):
+    def test_get_metrics_nonempty(self, mock_get_install_timeline_data, mock_get_recent_activity_data, mock_get_commit_activity, mock_get_latest_commit):
         expected = self._generate_expected_metrics(
             timeline=self._generate_expected_timeline(-3),
             total_installs=sum(MOCK_INSTALLS),
@@ -45,14 +43,13 @@ class TestActivityDashboard(unittest.TestCase):
             total_commit=MOCK_PLUGIN_TOTAL_COMMIT,
             commit_activity=MOCK_PLUGIN_COMMIT_ACTIVITY
         )
-        self._verify_results('3', expected, mock_get_install_timeline_data, mock_get_recent_activity_data, mock_get_commit_activity, mock_get_total_commit, mock_get_latest_commit)
+        self._verify_results('3', expected, mock_get_install_timeline_data, mock_get_recent_activity_data, mock_get_commit_activity, mock_get_latest_commit)
 
     @patch.object(model, 'get_latest_commit', return_value=MOCK_PLUGIN_LATEST_COMMIT)
-    @patch.object(model, 'get_total_commit', return_value=MOCK_PLUGIN_TOTAL_COMMIT)
     @patch.object(model, 'get_commit_activity', return_value=MOCK_PLUGIN_COMMIT_ACTIVITY)
     @patch.object(model, 'get_recent_activity_data', return_value=MOCK_PLUGIN_RECENT_INSTALLS)
     @patch.object(model, 'get_install_timeline_data', return_value=MOCK_DF.copy())
-    def test_get_metrics_nonempty_zero_limit(self, mock_get_install_timeline_data, mock_get_recent_activity_data, mock_get_commit_activity, mock_get_total_commit, mock_get_latest_commit):
+    def test_get_metrics_nonempty_zero_limit(self, mock_get_install_timeline_data, mock_get_recent_activity_data, mock_get_commit_activity, mock_get_latest_commit):
         expected = self._generate_expected_metrics(
             total_installs=sum(MOCK_INSTALLS),
             installs_in_last_30_days=25,
@@ -60,14 +57,13 @@ class TestActivityDashboard(unittest.TestCase):
             total_commit=MOCK_PLUGIN_TOTAL_COMMIT,
             commit_activity=MOCK_PLUGIN_COMMIT_ACTIVITY
         )
-        self._verify_results('0', expected, mock_get_install_timeline_data, mock_get_recent_activity_data,  mock_get_commit_activity, mock_get_total_commit, mock_get_latest_commit)
+        self._verify_results('0', expected, mock_get_install_timeline_data, mock_get_recent_activity_data,  mock_get_commit_activity, mock_get_latest_commit)
 
     @patch.object(model, 'get_latest_commit', return_value=MOCK_PLUGIN_LATEST_COMMIT)
-    @patch.object(model, 'get_total_commit', return_value=MOCK_PLUGIN_TOTAL_COMMIT)
     @patch.object(model, 'get_commit_activity', return_value=MOCK_PLUGIN_COMMIT_ACTIVITY)
     @patch.object(model, 'get_recent_activity_data', return_value=MOCK_PLUGIN_RECENT_INSTALLS)
     @patch.object(model, 'get_install_timeline_data', return_value=MOCK_DF.copy())
-    def test_get_metrics_nonempty_invalid_limit(self, mock_get_install_timeline_data, mock_get_recent_activity_data,  mock_get_commit_activity, mock_get_total_commit, mock_get_latest_commit):
+    def test_get_metrics_nonempty_invalid_limit(self, mock_get_install_timeline_data, mock_get_recent_activity_data,  mock_get_commit_activity, mock_get_latest_commit):
         expected = self._generate_expected_metrics(
             total_installs=sum(MOCK_INSTALLS),
             installs_in_last_30_days=25,
@@ -75,16 +71,15 @@ class TestActivityDashboard(unittest.TestCase):
             total_commit=MOCK_PLUGIN_TOTAL_COMMIT,
             commit_activity=MOCK_PLUGIN_COMMIT_ACTIVITY
         )
-        self._verify_results('foo', expected, mock_get_install_timeline_data, mock_get_recent_activity_data,  mock_get_commit_activity, mock_get_total_commit, mock_get_latest_commit)
+        self._verify_results('foo', expected, mock_get_install_timeline_data, mock_get_recent_activity_data,  mock_get_commit_activity, mock_get_latest_commit)
 
-    def _verify_results(self, limit, expected, mock_get_install_timeline_data, mock_get_recent_activity_data,  mock_get_commit_activity, mock_get_total_commit, mock_get_latest_commit):
+    def _verify_results(self, limit, expected, mock_get_install_timeline_data, mock_get_recent_activity_data,  mock_get_commit_activity, mock_get_latest_commit):
         from api.model import get_metrics_for_plugin
         result = get_metrics_for_plugin(PLUGIN_NAME, limit)
         self.assertEqual(expected, result)
         mock_get_install_timeline_data.assert_called_with(PLUGIN_NAME_CLEAN)
         mock_get_recent_activity_data.assert_called_with()
         mock_get_latest_commit.assert_called_with(PLUGIN_NAME_CLEAN)
-        mock_get_total_commit.assert_called_with(PLUGIN_NAME_CLEAN)
         mock_get_commit_activity.assert_called_with(PLUGIN_NAME_CLEAN)
 
 

--- a/backend/api/_tests/test_activity_dashboard.py
+++ b/backend/api/_tests/test_activity_dashboard.py
@@ -15,18 +15,21 @@ PLUGIN_NAME_CLEAN = 'string-1'
 MOCK_PLUGIN_RECENT_INSTALLS = {PLUGIN_NAME_CLEAN: 25, 'foo': 10, 'bar': 30}
 MOCK_PLUGIN_LATEST_COMMIT = 1672531200000
 MOCK_PLUGIN_TOTAL_COMMIT = 200
-MOCK_PLUGIN_COMMIT_ACTIVITY = [(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10), (11, 11), (12, 12)]
+MOCK_PLUGIN_TOTAL_COMMIT_EMPTY = 0
+MOCK_PLUGIN_COMMIT_ACTIVITY = [{'timestamp': 1643673600000, 'commits': 200}]
+MOCK_PLUGIN_COMMIT_ACTIVITY_EMPTY = []
 
 
 class TestActivityDashboard(unittest.TestCase):
 
     @patch.object(model, 'get_latest_commit', return_value=None)
-    @patch.object(model, 'get_commit_activity', return_value=None)
+    @patch.object(model, 'get_commit_activity', return_value=MOCK_PLUGIN_COMMIT_ACTIVITY_EMPTY)
     @patch.object(model, 'get_recent_activity_data', return_value={})
     @patch.object(model, 'get_install_timeline_data', return_value=EMPTY_DF.copy())
     def test_get_metrics_empty(self, mock_get_install_timeline_data, mock_get_recent_activity_data,  mock_get_commit_activity, mock_get_latest_commit):
         expected = self._generate_expected_metrics(
-            timeline=self._generate_expected_timeline(-3, to_installs=lambda i: 0)
+            timeline=self._generate_expected_timeline(-3, to_installs=lambda i: 0),
+            total_commit=MOCK_PLUGIN_TOTAL_COMMIT_EMPTY,
         )
         self._verify_results('3', expected, mock_get_install_timeline_data, mock_get_recent_activity_data, mock_get_commit_activity, mock_get_latest_commit)
 
@@ -55,7 +58,7 @@ class TestActivityDashboard(unittest.TestCase):
             installs_in_last_30_days=25,
             latest_commit=MOCK_PLUGIN_LATEST_COMMIT,
             total_commit=MOCK_PLUGIN_TOTAL_COMMIT,
-            commit_activity=MOCK_PLUGIN_COMMIT_ACTIVITY
+            commit_activity=MOCK_PLUGIN_COMMIT_ACTIVITY_EMPTY
         )
         self._verify_results('0', expected, mock_get_install_timeline_data, mock_get_recent_activity_data,  mock_get_commit_activity, mock_get_latest_commit)
 
@@ -69,7 +72,7 @@ class TestActivityDashboard(unittest.TestCase):
             installs_in_last_30_days=25,
             latest_commit=MOCK_PLUGIN_LATEST_COMMIT,
             total_commit=MOCK_PLUGIN_TOTAL_COMMIT,
-            commit_activity=MOCK_PLUGIN_COMMIT_ACTIVITY
+            commit_activity=MOCK_PLUGIN_COMMIT_ACTIVITY_EMPTY
         )
         self._verify_results('foo', expected, mock_get_install_timeline_data, mock_get_recent_activity_data,  mock_get_commit_activity, mock_get_latest_commit)
 
@@ -92,7 +95,7 @@ class TestActivityDashboard(unittest.TestCase):
         return [{timestamp_key: to_timestamp(i), installs_key: to_installs(i)} for i in range(start_range, 0)]
 
     @staticmethod
-    def _generate_expected_metrics(timeline=None, total_installs=0, installs_in_last_30_days=0, latest_commit=None, total_commit=None, commit_activity=None):
+    def _generate_expected_metrics(timeline=None, total_installs=0, installs_in_last_30_days=0, latest_commit=None, total_commit=None, commit_activity=[]):
         return {
             'usage': {
                 'timeline': timeline if timeline else [],

--- a/backend/api/_tests/test_activity_dashboard.py
+++ b/backend/api/_tests/test_activity_dashboard.py
@@ -95,7 +95,7 @@ class TestActivityDashboard(unittest.TestCase):
         return [{timestamp_key: to_timestamp(i), installs_key: to_installs(i)} for i in range(start_range, 0)]
 
     @staticmethod
-    def _generate_expected_metrics(timeline=None, total_installs=0, installs_in_last_30_days=0, latest_commit=None, total_commit=None, commit_activity=[]):
+    def _generate_expected_metrics(timeline=None, total_installs=0, installs_in_last_30_days=0, latest_commit=None, total_commit=None, commit_activity=MOCK_PLUGIN_COMMIT_ACTIVITY_EMPTY):
         return {
             'usage': {
                 'timeline': timeline if timeline else [],

--- a/backend/api/model.py
+++ b/backend/api/model.py
@@ -525,14 +525,17 @@ def _update_commit_activity(repo_to_plugin_dict):
     """
     cursor_list = _execute_query(query, "GITHUB")
     data = {}
+    fields = ['repo', 'month', 'num_commits']
     for cursor in cursor_list:
         for row in cursor:
-            repo = row[0]
+            dict_row = dict(zip(fields, row))
+            repo = dict_row.get('repo')
             if repo in repo_to_plugin_dict:
                 plugin = repo_to_plugin_dict[repo]
-                timestamp_raw = row[1]
+                timestamp_raw = dict_row.get('month')
                 timestamp = int(pd.to_datetime(timestamp_raw).strftime("%s")) * 1000
-                commits = int(row[2])
+                commits_raw = dict_row.get('num_commits')
+                commits = int(commits_raw)
                 obj = {'timestamp': timestamp, 'commits': commits}
                 data.setdefault(plugin, []).append(obj)
     for plugin in data:

--- a/backend/api/model.py
+++ b/backend/api/model.py
@@ -9,7 +9,8 @@ from collections import defaultdict
 import pandas as pd
 from utils.github import get_github_metadata, get_artifact
 from utils.pypi import query_pypi, get_plugin_pypi_metadata
-from api.s3 import get_cache, cache, write_data, get_install_timeline_data, get_latest_commit, get_total_commit, get_commit_activity, get_recent_activity_data
+from api.s3 import get_cache, cache, write_data, get_install_timeline_data, get_latest_commit, get_total_commit, \
+    get_commit_activity, get_recent_activity_data
 from utils.utils import render_description, send_alert, get_attribute, get_category_mapping, parse_manifest
 from utils.datadog import report_metrics
 from api.zulip import notify_new_packages
@@ -94,6 +95,7 @@ def get_frontend_manifest_metadata(plugin, version):
     interpreted_metadata = parse_manifest(raw_metadata)
     return interpreted_metadata
 
+
 def discover_manifest(plugin: str, version: str = None):
     """
     Invoke plugins lambda to generate manifest & write to cache.
@@ -110,6 +112,7 @@ def discover_manifest(plugin: str, version: str = None):
         Payload=json.dumps(lambda_event),
     )
 
+
 def get_manifest(plugin: str, version: str = None) -> dict:
     """
     Get plugin manifest file for a particular plugin, get latest if version is None.
@@ -123,7 +126,7 @@ def get_manifest(plugin: str, version: str = None) -> dict:
     elif version is None:
         version = plugins[plugin]
     plugin_metadata = get_cache(f'cache/{plugin}/{version}-manifest.json')
-    
+
     # plugin_metadata being None indicates manifest is not cached and needs processing 
     if plugin_metadata is None:
         return {'error': 'Manifest not yet processed.'}
@@ -393,7 +396,6 @@ def update_activity_data():
     _update_recent_activity_data()
     repo_to_plugin_dict = _get_repo_to_plugin_dict()
     _update_latest_commits(repo_to_plugin_dict)
-    _update_total_commits(repo_to_plugin_dict)
     _update_commit_activity(repo_to_plugin_dict)
 
 
@@ -430,7 +432,7 @@ def _process_for_timeline(plugin_df, limit):
     start_date = end_date + relativedelta(months=-limit + 1)
     dates = pd.date_range(start=start_date, periods=limit, freq='MS')
     plugin_df = plugin_df[(plugin_df['MONTH'] >= start_date.strftime(date_format)) & (
-                plugin_df['MONTH'] <= end_date.strftime(date_format))]
+            plugin_df['MONTH'] <= end_date.strftime(date_format))]
     result = []
     for cur_date in dates:
         if cur_date in plugin_df['MONTH'].values:
@@ -508,31 +510,6 @@ def _update_latest_commits(repo_to_plugin_dict):
     write_data(json.dumps(data), "activity_dashboard_data/latest_commits.json")
 
 
-def _update_total_commits(repo_to_plugin_dict):
-    """
-    Get the total commit occurred for the plugin
-    """
-    query = f"""
-        SELECT 
-            repo, sum(1) as total_commits
-        FROM 
-            imaging.github.commits
-        WHERE 
-            repo_type = 'plugin'
-        GROUP BY 1
-        ORDER BY total_commits desc   
-    """
-    cursor_list = _execute_query(query, "GITHUB")
-    data = {}
-    for cursor in cursor_list:
-        for row in cursor:
-            repo = row[0]
-            if repo in repo_to_plugin_dict:
-                plugin = repo_to_plugin_dict[repo]
-                data[plugin] = int(row[1])
-    write_data(json.dumps(data), "activity_dashboard_data/total_commits.json")
-
-
 def _update_commit_activity(repo_to_plugin_dict):
     """
     Get the commit activity occurred for the plugin in the past year
@@ -544,11 +521,8 @@ def _update_commit_activity(repo_to_plugin_dict):
             imaging.github.commits
         WHERE 
             repo_type = 'plugin'
-            AND month >= dateadd(month, -12, DATE_TRUNC(month, CURRENT_DATE())) 
-            AND month < DATE_TRUNC(month, CURRENT_DATE())
         GROUP BY 1,2
     """
-    repo_to_plugin_dict = _get_repo_to_plugin_dict()
     cursor_list = _execute_query(query, "GITHUB")
     data = {}
     for cursor in cursor_list:
@@ -556,7 +530,8 @@ def _update_commit_activity(repo_to_plugin_dict):
             repo = row[0]
             if repo in repo_to_plugin_dict:
                 plugin = repo_to_plugin_dict[repo]
-                data.setdefault(plugin, []).append({'timestamp': int(pd.to_datetime(row[1]).strftime("%s")) * 1000, 'commits': int(row[2])})
+                data.setdefault(plugin, []).append(
+                    {'timestamp': int(pd.to_datetime(row[1]).strftime("%s")) * 1000, 'commits': int(row[2])})
     for plugin in data:
         data[plugin] = sorted(data[plugin], key=lambda x: (x['timestamp']))
     write_data(json.dumps(data), "activity_dashboard_data/commit_activity.json")
@@ -567,7 +542,14 @@ def get_metrics_for_plugin(plugin: str, limit: str) -> Dict:
     data = get_install_timeline_data(plugin)
     install_stats = _process_for_stats(data)
     timeline = [] if _is_not_valid_limit(limit) else _process_for_timeline(data, int(limit))
-    maintenance_timeline = get_commit_activity(plugin)
+    commit_activity = get_commit_activity(plugin)
+    if _is_not_valid_limit(limit):
+        maintenance_timeline = []
+    else:
+        maintenance_timeline = commit_activity.copy()
+        if len(maintenance_timeline) > int(limit):
+            maintenance_timeline = maintenance_timeline[
+                                   len(maintenance_timeline) - int(limit):len(maintenance_timeline)]
 
     usage_stats = {
         'total_installs': install_stats.get('totalInstalls', 0),
@@ -575,7 +557,7 @@ def get_metrics_for_plugin(plugin: str, limit: str) -> Dict:
     }
     maintenance_stats = {
         'latest_commit_timestamp': get_latest_commit(plugin),
-        'total_commits': get_total_commit(plugin),
+        'total_commits': sum([item['commits'] for item in commit_activity]),
     }
     usage_data = {
         'timeline': timeline,

--- a/backend/api/model.py
+++ b/backend/api/model.py
@@ -543,7 +543,7 @@ def get_metrics_for_plugin(plugin: str, limit: str) -> Dict:
     install_stats = _process_for_stats(data)
     timeline = [] if _is_not_valid_limit(limit) else _process_for_timeline(data, int(limit))
     commit_activity = get_commit_activity(plugin)
-    if _is_not_valid_limit(limit):
+    if _is_not_valid_limit(limit) or len(commit_activity) == 0:
         maintenance_timeline = []
     else:
         maintenance_timeline = commit_activity.copy()

--- a/backend/api/model.py
+++ b/backend/api/model.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 import pandas as pd
 from utils.github import get_github_metadata, get_artifact
 from utils.pypi import query_pypi, get_plugin_pypi_metadata
-from api.s3 import get_cache, cache, write_data, get_install_timeline_data, get_latest_commit, get_total_commit, \
+from api.s3 import get_cache, cache, write_data, get_install_timeline_data, get_latest_commit, \
     get_commit_activity, get_recent_activity_data
 from utils.utils import render_description, send_alert, get_attribute, get_category_mapping, parse_manifest
 from utils.datadog import report_metrics

--- a/backend/api/model.py
+++ b/backend/api/model.py
@@ -421,10 +421,6 @@ def _update_activity_timeline_data():
     write_data(csv_string, "activity_dashboard_data/plugin_installs.csv")
 
 
-def _is_valid_limit(limit):
-    return limit.isdigit() and limit != '0'
-
-
 def _process_for_timeline(plugin_df, limit):
     date_format = '%Y-%m-%d'
     end_date = date.today().replace(day=1) + relativedelta(months=-1)
@@ -542,10 +538,11 @@ def get_metrics_for_plugin(plugin: str, limit: str) -> Dict:
     data = get_install_timeline_data(plugin)
     install_stats = _process_for_stats(data)
     commit_activity = get_commit_activity(plugin)
+    is_valid_limit = limit.isdigit() and limit != '0'
 
     timeline = []
     maintenance_timeline = []
-    if _is_valid_limit(limit):
+    if is_valid_limit:
         limit = int(limit)
         timeline = _process_for_timeline(data, limit)
         maintenance_timeline = commit_activity[-limit:]

--- a/backend/api/model.py
+++ b/backend/api/model.py
@@ -432,7 +432,7 @@ def _process_for_timeline(plugin_df, limit):
     start_date = end_date + relativedelta(months=-limit + 1)
     dates = pd.date_range(start=start_date, periods=limit, freq='MS')
     plugin_df = plugin_df[(plugin_df['MONTH'] >= start_date.strftime(date_format)) & (
-            plugin_df['MONTH'] <= end_date.strftime(date_format))]
+                plugin_df['MONTH'] <= end_date.strftime(date_format))]
     result = []
     for cur_date in dates:
         if cur_date in plugin_df['MONTH'].values:

--- a/backend/api/model.py
+++ b/backend/api/model.py
@@ -422,8 +422,8 @@ def _update_activity_timeline_data():
     write_data(csv_string, "activity_dashboard_data/plugin_installs.csv")
 
 
-def _is_not_valid_limit(limit):
-    return not limit.isdigit() or limit == '0'
+def _is_valid_limit(limit):
+    return limit.isdigit() and limit != '0'
 
 
 def _process_for_timeline(plugin_df, limit):
@@ -541,15 +541,14 @@ def get_metrics_for_plugin(plugin: str, limit: str) -> Dict:
     plugin = plugin.lower()
     data = get_install_timeline_data(plugin)
     install_stats = _process_for_stats(data)
-    timeline = [] if _is_not_valid_limit(limit) else _process_for_timeline(data, int(limit))
     commit_activity = get_commit_activity(plugin)
-    if _is_not_valid_limit(limit) or len(commit_activity) == 0:
-        maintenance_timeline = []
-    else:
-        maintenance_timeline = commit_activity.copy()
-        if len(maintenance_timeline) > int(limit):
-            maintenance_timeline = maintenance_timeline[
-                                   len(maintenance_timeline) - int(limit):len(maintenance_timeline)]
+
+    timeline = []
+    maintenance_timeline = []
+    if _is_valid_limit(limit):
+        limit = int(limit)
+        timeline = _process_for_timeline(data, limit)
+        maintenance_timeline = commit_activity[-limit:]
 
     usage_stats = {
         'total_installs': install_stats.get('totalInstalls', 0),

--- a/backend/api/model.py
+++ b/backend/api/model.py
@@ -530,8 +530,11 @@ def _update_commit_activity(repo_to_plugin_dict):
             repo = row[0]
             if repo in repo_to_plugin_dict:
                 plugin = repo_to_plugin_dict[repo]
-                data.setdefault(plugin, []).append(
-                    {'timestamp': int(pd.to_datetime(row[1]).strftime("%s")) * 1000, 'commits': int(row[2])})
+                timestamp_raw = row[1]
+                timestamp = int(pd.to_datetime(timestamp_raw).strftime("%s")) * 1000
+                commits = int(row[2])
+                obj = {'timestamp': timestamp, 'commits': commits}
+                data.setdefault(plugin, []).append(obj)
     for plugin in data:
         data[plugin] = sorted(data[plugin], key=lambda x: (x['timestamp']))
     write_data(json.dumps(data), "activity_dashboard_data/commit_activity.json")

--- a/backend/api/s3.py
+++ b/backend/api/s3.py
@@ -111,9 +111,5 @@ def get_latest_commit(plugin: str) -> Any:
     return _load_json_from_s3("activity_dashboard_data/latest_commits.json").get(plugin)
 
 
-def get_total_commit(plugin: str) -> Any:
-    return _load_json_from_s3("activity_dashboard_data/total_commits.json").get(plugin)
-
-
 def get_commit_activity(plugin: str) -> List:
     return _load_json_from_s3("activity_dashboard_data/commit_activity.json").get(plugin, [])


### PR DESCRIPTION
`Related Issue`
https://github.com/chanzuckerberg/napari-hub/issues/820

`Description`
Based on the feedback from Manasa and Richa in https://github.com/chanzuckerberg/napari-hub/pull/848#discussion_r1092356074 and https://github.com/chanzuckerberg/napari-hub/pull/848#discussion_r1096389113, this follow-up PR re-structures how the backend logic handles querying and returning plugin commit activity in order to reduce the amount of rework in design and engineering for the future

`S3`
To view updates made to `commit_activity.json` and `latest_commits.json`, click on https://s3.console.aws.amazon.com/s3/buckets/napari-hub-staging?region=us-west-2&prefix=activity_dashboard_data/. Note that `total_commits.json` was not updated due to the changes introduced in this PR. See `(2)` in the `Changes` section for more context.

`Changes`
Before the changes introduced in this PR, `commit_activity.json` on `s3` only has the 12 month's of data for all plugins. With this current PR , the changes introduced include:
(1) `commit_activity.json` contains all-time commit activity for all plugins instead of only for 12 months
(2) `total_commits` is calculated by summing up all commits for each plugin directly using `commit_activity.json` to maintain parity with the implementation of usage metrics, and thus there is no longer a need for the existence and usage of `total_commits.json`