### PR TITLE
Fix click on plugin links

### DIFF
--- a/frontend/src/components/PluginPage/SupportInfo.tsx
+++ b/frontend/src/components/PluginPage/SupportInfo.tsx
@@ -243,13 +243,17 @@ function Links({ children, links }: LinksProps) {
       onOpen={openTooltip}
       onClose={closeTooltip}
       title={
-        <ul>
+        <div className="flex flex-col">
           {links.map((link) => (
-            <li className="hover:bg-hub-gray-100 py-sds-s px-sds-l">
-              <Link href={link.value}>{link.label}</Link>
-            </li>
+            <Link
+              className="py-sds-s px-sds-l hover:bg-hub-gray-100"
+              href={link.value}
+              key={link.value}
+            >
+              {link.label}
+            </Link>
           ))}
-        </ul>
+        </div>
       }
     >
       <ButtonIcon onClick={openTooltip} disabled={hasEmptyLinks}>


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
4. Include screenshots / videos for PRs if there are visual changes.

A good example is https://github.com/chanzuckerberg/napari-hub/pull/77.
-->

## Description
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Set the status for the issue to “Pending QA & Release” upon merging
		- Provide a checklist of any relevant pre-deployment notes, e.g. whether a config or database change is needed
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

#909

Issue was that padding was specified on link container rather than link, so a portion of the container was not clickable. The only way to open the link would be by clicking on the text directly, this fixes it so that clicking on the entire menu item will open the link.

## Demos
<!-- Optional but recommended. Remove if not in use -->

https://user-images.githubusercontent.com/2176050/219170365-6cdee57f-feb0-4133-ba77-e6505ae83356.mp4
