### PR TITLE
Use canonical links

### DIFF
--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -95,15 +95,14 @@ function App({ Component, pageProps }: AppProps) {
       }
 
       <Head>
+        <link rel="canonical" href={canonicalLink} />
+
         {/*
           Disable indexing for non-production deployments.
           https://developers.google.com/search/docs/advanced/crawling/block-indexing
         */}
         {(!PROD || process.env.PREVIEW) && (
-          <>
-            <meta name="robots" content="noindex" />
-            <link rel="canonical" href={canonicalLink} />
-          </>
+          <meta name="robots" content="noindex" />
         )}
       </Head>
 

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -97,7 +97,10 @@ function App({ Component, pageProps }: AppProps) {
           https://developers.google.com/search/docs/advanced/crawling/block-indexing
         */}
         {(!PROD || process.env.PREVIEW) && (
-          <link rel="canonical" href={router.pathname} />
+          <>
+            <meta name="robots" content="noindex" />
+            <link rel="canonical" href={router.pathname} />
+          </>
         )}
       </Head>
 

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -79,8 +79,8 @@ function App({ Component, pageProps }: AppProps) {
   let loader: ReactNode;
   const isLoading = loading && (loader = getLoaderComponent());
   const page = isLoading ? loader : withLayout(<Component {...pageProps} />);
-  const pathName = router.pathname;
-  const canonicalLink = pathName.split('?')[0];
+  const pathName = router.asPath;
+  const canonicalLink = 'https://www.napari-hub.org' + pathName.split('?')[0];
 
   return (
     <>

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -79,8 +79,9 @@ function App({ Component, pageProps }: AppProps) {
   let loader: ReactNode;
   const isLoading = loading && (loader = getLoaderComponent());
   const page = isLoading ? loader : withLayout(<Component {...pageProps} />);
-  const pathName = router.asPath;
-  const canonicalLink = 'https://www.napari-hub.org' + pathName.split('?')[0];
+  const baseURL = 'https://www.napari-hub.org';
+  const path = router.asPath.split('?')[0];
+  const canonicalLink = baseURL + path;
 
   return (
     <>

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -79,6 +79,8 @@ function App({ Component, pageProps }: AppProps) {
   let loader: ReactNode;
   const isLoading = loading && (loader = getLoaderComponent());
   const page = isLoading ? loader : withLayout(<Component {...pageProps} />);
+  const pathName = router.pathname;
+  const canonicalLink = pathName.split('?')[0];
 
   return (
     <>
@@ -99,7 +101,7 @@ function App({ Component, pageProps }: AppProps) {
         {(!PROD || process.env.PREVIEW) && (
           <>
             <meta name="robots" content="noindex" />
-            <link rel="canonical" href={router.pathname} />
+            <link rel="canonical" href={canonicalLink} />
           </>
         )}
       </Head>

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -97,7 +97,7 @@ function App({ Component, pageProps }: AppProps) {
           https://developers.google.com/search/docs/advanced/crawling/block-indexing
         */}
         {(!PROD || process.env.PREVIEW) && (
-          <meta name="robots" content="noindex" />
+          <link rel="canonical" href={router.pathname} />
         )}
       </Head>
 


### PR DESCRIPTION
`Ticket`
- https://github.com/chanzuckerberg/napari-hub/issues/896

`Description`
- This PR adds canonical link to the frontend codebase so that we can specify the primary URL for all pages that can be derived from a single authoritative URL

`Screenshots`

<img width="1632" alt="Screen Shot 2023-03-02 at 6 47 01 PM" src="https://user-images.githubusercontent.com/70177777/222603561-07aeb241-b80b-40e5-ad3a-c574d67d38a5.png">

<img width="1634" alt="Screen Shot 2023-03-02 at 6 47 15 PM" src="https://user-images.githubusercontent.com/70177777/222603588-e08482f9-3a41-4cd6-83fb-80a77dde9a8d.png">