### PR TITLE
Fixing working dir for integration test github workflow

### DIFF
--- a/.github/workflows/backend-bdd-tests.yml
+++ b/.github/workflows/backend-bdd-tests.yml
@@ -18,11 +18,6 @@ jobs:
         with:
           python-version: '3.9'
 
-      - name: Install dependencies
-        run: |
-          pip install --upgrade pip
-          pip install -r test-requirements.txt
-
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:
@@ -35,4 +30,7 @@ jobs:
       - name: Run tests
         if: ${{ env.PREFIX != 'invalid' }}
         working-directory: backend
-        run: cd bdd_test && python -m pytest
+        run: |
+          pip install --upgrade pip
+          pip install -r test-requirements.txt
+          cd bdd_test && python -m pytest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,16 +71,16 @@ jobs:
           tfe-token: ${{ secrets.TFE_TOKEN }}
           env: "staging"
           operation: "create-or-update"
-    update-artifacts:
-      name: Setup artifacts on environment deployed to
-      runs-on: ubuntu-latest
-      steps:
-        - name: Set workflow artifact file
-          run: |
-            mkdir -p ./workflow_artifact
-            echo $STACK_NAME > ./workflow_artifact/stack_name
-        - name: Upload stack name artifact
-          uses: actions/upload-artifact@v3
-          with:
-            name: napari_hub_dev_deployment
-            path: workflow_artifact/
+  update-artifacts:
+    name: Setup artifacts on environment deployed to
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set workflow artifact file
+        run: |
+          mkdir -p workflow_artifact
+          echo $STACK_NAME > workflow_artifact/stack_name
+      - name: Upload stack name artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: napari_hub_dev_deployment
+          path: workflow_artifact/stack_name

--- a/.github/workflows/push-rdev.yml
+++ b/.github/workflows/push-rdev.yml
@@ -39,9 +39,7 @@ jobs:
             echo "branch name: ${GITHUB_REF_NAME}, length ${#GITHUB_REF_NAME}, is $((${#GITHUB_REF_NAME} - 32)) characters too long, please use a branch name that's 32 characters or shorter"
             exit 1
           else 
-            echo $GITHUB_REF_NAME | tr '[:upper:]' '[:lower:]' | xargs -I {} -n 1 echo STACK_NAME={} >> $GITHUB_ENV
-            mkdir -p ./workflow_artifact
-            echo $STACK_NAME > ./workflow_artifact/stack_name
+            echo $GITHUB_REF_NAME | tr '[:upper:]' '[:lower:]' | xargs -I {} -n 1 echo STACK_NAME={} >> $GITHUB_ENV            
           fi
 
       - name: Create update dev
@@ -61,7 +59,6 @@ jobs:
         if: ${{ github.event_name == 'delete' && startsWith(github.event.ref, 'dev-') }}
         run: |
           echo ${{ github.event.ref }} | tr '[:upper:]' '[:lower:]' | xargs -I {} -n 1 echo DELETE_STACK_NAME={} >> $GITHUB_ENV
-          echo 'invalid' > ./workflow_artifact/stack_name
 
       - name: Delete dev
         if: ${{ github.event_name == 'delete' && startsWith(github.event.ref, 'dev-') }}
@@ -74,8 +71,13 @@ jobs:
           tfe-token: ${{ secrets.TFE_TOKEN }}
           env: "dev"
 
+      - name: Create workflow artifact
+        run: | 
+          mkdir -p workflow_artifact
+          if [ ${{ github.event_name == 'delete' }} ]; then echo 'invalid'; else echo $STACK_NAME; fi > workflow_artifact/stack_name
+
       - name: Upload stack name artifact
         uses: actions/upload-artifact@v3
         with:
           name: napari_hub_dev_deployment
-          path: workflow_artifact/
+          path: workflow_artifact/stack_name


### PR DESCRIPTION
Relates to: https://github.com/chanzuckerberg/napari-hub/pull/816

This fixes the bdd failure caused because the workflow tries to install from the requirements file when not in the correct working directory. 