### PR TITLE
Run E2E tests only for frontend directory

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -3,7 +3,17 @@
 
 name: E2E Tests
 
-on: push
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'frontend/**'
+  pull_request:
+    branches:
+      - '**'
+    paths:
+      - 'frontend/**'
 
 defaults:
   run:
@@ -142,7 +152,7 @@ jobs:
       - name: Upload artifacts
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3.1.1
-        with: 
+        with:
           name: e2e-artifacts
           path: frontend/e2e/report
           retention-days: 1


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
4. Include screenshots / videos for PRs if there are visual changes.

A good example is https://github.com/chanzuckerberg/napari-hub/pull/77.
-->

## Description
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Set the status for the issue to “Pending QA & Release” upon merging
		- Provide a checklist of any relevant pre-deployment notes, e.g. whether a config or database change is needed
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

#806 introduced a change where the frontend tests are run on every push. However, it makes more sense to run the E2E tests only when frontend changes are made, so this PR adds an event filter that checks if it's a push to `main` or to a pull request in the `frontend/*` directory