### PR TITLE
Do not add `blocked` plugins to `public-plugins.json` 

### DIFF
--- a/backend/api/model.py
+++ b/backend/api/model.py
@@ -240,7 +240,10 @@ def update_cache():
     excluded_plugins = get_updated_plugin_exclusion(plugins_metadata)
     visibility_plugins = {"public": {}, "hidden": {}}
     for plugin, version in plugins.items():
-        visibility = plugins_metadata[plugin].get('visibility', 'public')
+        if plugin in excluded_plugins:
+            visibility = excluded_plugins[plugin]
+        else:
+            visibility = plugins_metadata[plugin].get('visibility', 'public')
         if visibility in visibility_plugins:
             visibility_plugins[visibility][plugin] = version
 
@@ -271,6 +274,7 @@ def get_updated_plugin_exclusion(plugins_metadata):
     public: fully visible (default)
     hidden: plugin page exists, but doesn't show up in search listings
     disabled: no plugin page created, does not show up in search listings
+    blocked: no plugin page created, does not show up in search listings
 
     :param plugins_metadata: plugin metadata containing visibility information
     :return: updated exclusion list


### PR DESCRIPTION
**Current behavior**: Currently, if a plugin is `blocked`, it does not appear in hub search results, but the hub plugin page still renders, similar to how `hidden` plugins work.  

**Expected behavior**: Since `blocked` is a manual override, it would make more sense to prevent the plugin page from rendering, and have it behave the same as `disabled` plugins.

**Changes introduced**: With this change, we fetch the correct plugin visibility from `excluded_plugins.json`, which ensures that `blocked` plugins are not added to the `public-plugins.json` file. As a result, `blocked` plugins will not meet the logic required in `get_plugin` (which calls `get_valid_plugins`, which in turn calls `get_hidden_plugins` and `get_public_plugins`).


Note: Depending on the outcome of https://github.com/chanzuckerberg/napari-hub/issues/942, we may choose to deprecate the `blocked` setting entirely. However, given this is a quick fix, I think it's okay to move forward with this change in the meantime.