### PR TITLE
Rename version_label to version_hash

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -144,14 +144,14 @@ module category_dynamodb_table {
   source              = "../dynamo"
   table_name          = "${local.custom_stack_name}-category"
   hash_key            = "name"
-  range_key           = "version_label"
+  range_key           = "version_hash"
   attributes          = [
                           {
                             name = "name"
                             type = "S"
                           },
                           {
-                            name = "version_label"
+                            name = "version_hash"
                             type = "S"
                           }
                         ]


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
4. Include screenshots / videos for PRs if there are visual changes.

A good example is https://github.com/chanzuckerberg/napari-hub/pull/77.
-->

## Description
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Set the status for the issue to “Pending QA & Release” upon merging
		- Provide a checklist of any relevant pre-deployment notes, e.g. whether a config or database change is needed
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Based on [discussions](https://github.com/chanzuckerberg/napari-hub/pull/954) for using a hash instead of the label in the range key, it would make sense to rename the range key to `version_hash` to reflect that it's a hash
