### PR TITLE
Collection path template visible in sitemap

### DIFF
--- a/frontend/src/pages/sitemap.xml.ts
+++ b/frontend/src/pages/sitemap.xml.ts
@@ -31,7 +31,7 @@ const HUB_URL_IGNORE_PATTERNS = [
   // sitemap.xml and robots.txt files
   /\/sitemap\.xml|robots\.txt/,
 
-  // Plugin pages
+  // Collections pages
   /\/collections\/\[symbol\]/,
 
   // Plugin pages

--- a/frontend/src/pages/sitemap.xml.ts
+++ b/frontend/src/pages/sitemap.xml.ts
@@ -32,6 +32,9 @@ const HUB_URL_IGNORE_PATTERNS = [
   /\/sitemap\.xml|robots\.txt/,
 
   // Plugin pages
+  /\/collections\/\[symbol\]/,
+
+  // Plugin pages
   /\/plugins\/\[name\]/,
 
   // Plugin preview page


### PR DESCRIPTION
Issue: https://github.com/chanzuckerberg/napari-hub/issues/937
Description: This PR removes https://napari-hub.org/collections/[symbol] from the sitemap.