### PR TITLE
Setting up local dynamo

### DIFF
--- a/backend/api/models/metrics.py
+++ b/backend/api/models/metrics.py
@@ -14,8 +14,9 @@ LOGGER = logging.getLogger()
 
 class InstallActivity(Model):
     class Meta:
-        table_name = f'{os.getenv("STACK_NAME")}-install-activity'
+        host = os.getenv('LOCAL_DYNAMO_HOST')
         region = os.getenv('AWS_REGION')
+        table_name = f'{os.getenv("STACK_NAME")}-install-activity'
 
     plugin_name = UnicodeAttribute(hash_key=True)
     type_timestamp = UnicodeAttribute(range_key=True)

--- a/data-workflows/activity/install_activity_model.py
+++ b/data-workflows/activity/install_activity_model.py
@@ -43,9 +43,8 @@ class InstallActivityType(Enum):
 class InstallActivity(Model):
     class Meta:
         host = os.getenv('LOCAL_DYNAMO_HOST')
-        prefix = os.getenv('STACK_NAME')
         region = os.getenv('AWS_REGION')
-        table_name = f'{prefix}-install-activity'
+        table_name = f'{os.getenv("STACK_NAME")}-install-activity'
 
     plugin_name = UnicodeAttribute(hash_key=True)
     type_timestamp = UnicodeAttribute(range_key=True)

--- a/data-workflows/activity/install_activity_model.py
+++ b/data-workflows/activity/install_activity_model.py
@@ -42,6 +42,7 @@ class InstallActivityType(Enum):
 
 class InstallActivity(Model):
     class Meta:
+        host = os.getenv('LOCAL_DYNAMO_HOST')
         prefix = os.getenv('STACK_NAME')
         region = os.getenv('AWS_REGION')
         table_name = f'{prefix}-install-activity'

--- a/data-workflows/local-dynamo-setup.sh
+++ b/data-workflows/local-dynamo-setup.sh
@@ -1,0 +1,108 @@
+#!/bin/sh
+
+if ! command -v aws &> /dev/null; then
+    echo "aws cli could not be found. Please install aws cli and rerun the script." \
+    "Please find documentation here: " \
+    "https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html"
+    exit
+fi
+
+if ! command -v jq &> /dev/null; then
+    echo "jq could not be found. Trying to install jq."
+
+    if command -v brew &> /dev/null; then
+      echo "Installing with brew"
+      brew install jq
+    elif command -v port &> /dev/null; then
+      echo "Installing with port"
+      port install jq
+    else
+      echo "Unable to install jq, please install jq and rerun the script." \
+      "Please find documentation here: https://stedolan.github.io/jq/download/"
+    fi
+    exit
+fi
+
+create_if_not_exists() {
+  TABLE_NAME="$PREFIX-$1"
+  if $(jq --arg table_name $TABLE_NAME '.TableNames | any(. == $table_name)' <<< "$TABLES_LIST_RESPONSE"); then
+    echo "$TABLE_NAME exists"
+  else
+    echo "$TABLE_NAME table not found. Getting source table description with prefix $SOURCE_PREFIX-"
+
+    SOURCE_TABLE=$(aws dynamodb describe-table --table-name "$SOURCE_PREFIX-$1" --profile $AWS_PROFILE 2>&1)
+
+    if ! $(jq 'has("Table")' <<< "$SOURCE_TABLE"); then
+      echo "Unable to fetch source table $SOURCE_TABLE"
+      return 1
+    fi
+
+    ATTRIBUTE_DEFINITION=$(jq '.Table.AttributeDefinitions' <<< "$SOURCE_TABLE")
+    KEY_SCHEMA=$(jq '.Table.KeySchema' <<< "$SOURCE_TABLE")
+
+    echo "Creating $TABLE_NAME.."
+
+    # TODO: Add GSI to table creation
+    TABLE_CREATION=$(aws dynamodb create-table \
+    --table-name "$TABLE_NAME" \
+    --attribute-definitions "$ATTRIBUTE_DEFINITION" \
+    --key-schema "$KEY_SCHEMA" \
+    --provisioned-throughput ReadCapacityUnits=1,WriteCapacityUnits=1 \
+    --table-class STANDARD \
+    --endpoint-url "$ENDPOINT_URL" 2>&1)
+
+    if $(jq -e 'has("TableDescription") and .TableDescription.TableStatus == "ACTIVE"' <<< "$TABLE_CREATION"); then
+      echo "$TABLE_NAME table created successfully. ARN: $(jq '.TableDescription.TableArn' <<< "$TABLE_CREATION")"
+    else
+      echo "Unable to create table: $TABLE_NAME"
+    fi
+  fi
+}
+
+
+CURRENT_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
+CURRENT_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+CURRENT_AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION
+
+export AWS_ACCESS_KEY_ID=fakeMyKeyId
+export AWS_SECRET_ACCESS_KEY=fakeSecretAccessKey
+export AWS_DEFAULT_REGION=us-west-2
+
+SOURCE_PREFIX="staging"
+PREFIX="local"
+if [ "$2" != "" ]; then
+  PREFIX=$2
+fi
+
+LOCAL_DYNAMO_PORT=8000
+if [ "$1" != "" ]; then
+  LOCAL_DYNAMO_PORT=$1
+fi
+ENDPOINT_URL="http://localhost:$LOCAL_DYNAMO_PORT"
+
+# Get list of local tables
+TABLES_LIST_RESPONSE=$(aws dynamodb list-tables --endpoint-url $ENDPOINT_URL 2>&1)
+
+# Check for connection errors
+if [[ $TABLES_LIST_RESPONSE == *"Could not connect to the endpoint URL"* ]]; then
+  echo "Please confirm your local dynamo is running on port: $LOCAL_DYNAMO_PORT."
+fi
+
+if $(jq -e 'has("TableNames")' <<< "$TABLES_LIST_RESPONSE") &> /dev/null; then
+  echo "Successfully connected to dynamo on $ENDPOINT_URL"
+else
+  echo "Unable to connect to dynamo on $ENDPOINT_URL"
+  exit
+fi
+
+# Create tables from source
+tables=("install-activity" "github-activity" "category" "plugins")
+for table in ${tables[@]}; do
+  create_if_not_exists $table
+done
+
+# Reset environment variables
+export AWS_ACCESS_KEY_ID=$CURRENT_AWS_ACCESS_KEY_ID
+export AWS_SECRET_ACCESS_KEY=$CURRENT_AWS_SECRET_ACCESS_KEY
+export AWS_DEFAULT_REGION=$CURRENT_AWS_DEFAULT_REGION
+

--- a/data-workflows/local-dynamo-setup.sh
+++ b/data-workflows/local-dynamo-setup.sh
@@ -1,19 +1,19 @@
 #!/bin/sh
 
-if ! command -v aws &> /dev/null; then
+if ! command -v aws 2>&1 /dev/null; then
     echo "aws cli could not be found. Please install aws cli and rerun the script." \
     "Please find documentation here: " \
     "https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html"
     exit
 fi
 
-if ! command -v jq &> /dev/null; then
+if ! command -v jq 2>&1 /dev/null; then
     echo "jq could not be found. Trying to install jq."
 
-    if command -v brew &> /dev/null; then
+    if command -v brew 2>&1 /dev/null; then
       echo "Installing with brew"
       brew install jq
-    elif command -v port &> /dev/null; then
+    elif command -v port 2>&1 /dev/null; then
       echo "Installing with port"
       port install jq
     else
@@ -25,95 +25,103 @@ fi
 
 reset_updated_env_variables() {
   # Resets environment variables
-  export AWS_ACCESS_KEY_ID=$CURRENT_AWS_ACCESS_KEY_ID
-  export AWS_SECRET_ACCESS_KEY=$CURRENT_AWS_SECRET_ACCESS_KEY
-  export AWS_DEFAULT_REGION=$CURRENT_AWS_DEFAULT_REGION
+  export AWS_ACCESS_KEY_ID=$current_aws_access_key
+  export AWS_SECRET_ACCESS_KEY=$current_aws_secret_key
+  export AWS_DEFAULT_REGION=$current_aws_default_region
 }
 
 create_if_not_exists() {
-  TABLE_NAME="$PREFIX-$1"
-  if $(jq --arg table_name $TABLE_NAME '.TableNames | any(. == $table_name)' <<< "$TABLES_LIST_RESPONSE"); then
-    echo "$TABLE_NAME exists"
+  name="$local_dynamo_prefix-$1"
+  if echo "$list_tables_resp" | jq -e --arg name "$name" '.TableNames | any(. == $name)' > /dev/null; then
+    echo "$name exists"
   else
-    echo "$TABLE_NAME table not found. Getting source table description with prefix $SOURCE_PREFIX-"
+    echo "$name table not found. Getting source table description with prefix $remote_dynamo_prefix-"
 
-    SOURCE_TABLE=$(aws dynamodb describe-table --table-name "$SOURCE_PREFIX-$1" --profile $AWS_PROFILE 2>&1)
+    source_table=$(aws dynamodb describe-table --table-name "$remote_dynamo_prefix-$1" --profile "$AWS_PROFILE" 2>&1)
 
-    if ! $(jq 'has("Table")' <<< "$SOURCE_TABLE" &> /dev/null); then
-      echo "Unable to fetch source table $SOURCE_TABLE"
+    if ! (echo "$source_table" | jq -e '. | has("Table")' > /dev/null); then
+      echo "Unable to fetch source table $source_table"
       return 1
     fi
 
-    ATTRIBUTE_DEFINITION=$(jq '.Table.AttributeDefinitions' <<< "$SOURCE_TABLE")
-    KEY_SCHEMA=$(jq '.Table.KeySchema' <<< "$SOURCE_TABLE")
+    attribute_definitions=$(echo "$source_table" | jq '.Table.AttributeDefinitions')
+    key_schema=$(echo "$source_table" | jq '.Table.KeySchema')
 
-    echo "Creating $TABLE_NAME.."
+    optional_params=()
+    gsi=$(echo "$source_table" | jq --argjson provisioning "$default_provisioning" \
+      '[.Table | .GlobalSecondaryIndexes[]?
+      | {IndexName, KeySchema, Projection, "ProvisionedThroughput": $provisioning}]')
 
-    # TODO: Add support for advanced table creation attributes
-    TABLE_CREATION=$(aws dynamodb create-table \
-    --table-name "$TABLE_NAME" \
-    --attribute-definitions "$ATTRIBUTE_DEFINITION" \
-    --key-schema "$KEY_SCHEMA" \
+    [ "$gsi" != "[]" ] && optional_params+=(--global-secondary-indexes "$gsi")
+
+    echo "Creating $name.."
+
+    create_table_resp=$(aws dynamodb create-table \
+    --table-name "$name" \
+    --attribute-definitions "$attribute_definitions" \
+    --key-schema "$key_schema" \
     --provisioned-throughput ReadCapacityUnits=1,WriteCapacityUnits=1 \
     --table-class STANDARD \
-    --endpoint-url "$ENDPOINT_URL" 2>&1)
+    --endpoint-url "$endpoint_url" \
+    "${optional_params[@]}")
 
-    if $(jq -e 'has("TableDescription") and .TableDescription.TableStatus == "ACTIVE"' <<< "$TABLE_CREATION"); then
-      echo "$TABLE_NAME table created successfully. ARN: $(jq '.TableDescription.TableArn' <<< "$TABLE_CREATION")"
+    if echo "$create_table_resp" | jq -e 'has("TableDescription") and .TableDescription.TableStatus == "ACTIVE"' > /dev/null; then
+      echo "$name table created successfully.
+        table arn: $(jq '.TableDescription.TableArn' <<< "$create_table_resp")"
     else
-      echo "Unable to create table: $TABLE_NAME"
+      echo "Unable to create table: $name"
     fi
   fi
 }
 
 
-CURRENT_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
-CURRENT_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
-CURRENT_AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION
+current_aws_access_key=$AWS_ACCESS_KEY_ID
+current_aws_secret_key=$AWS_SECRET_ACCESS_KEY
+current_aws_default_region=$AWS_DEFAULT_REGION
 
-export AWS_ACCESS_KEY_ID=fakeMyKeyId
-export AWS_SECRET_ACCESS_KEY=fakeSecretAccessKey
-export AWS_DEFAULT_REGION=us-west-2
+export AWS_ACCESS_KEY_ID="fakeMyKeyId"
+export AWS_SECRET_ACCESS_KEY="fakeSecretAccessKey"
+export AWS_DEFAULT_REGION="us-west-2"
 
-SOURCE_PREFIX="staging"
+remote_dynamo_prefix="staging"
 if [ "$REMOTE_DYNAMO_PREFIX" != "" ]; then
-  SOURCE_PREFIX=$REMOTE_DYNAMO_PREFIX
+  remote_dynamo_prefix=$REMOTE_DYNAMO_PREFIX
 fi
-echo "SOURCE_PREFIX=$SOURCE_PREFIX"
+echo "remote_dynamo_prefix=$remote_dynamo_prefix"
 
-PREFIX="local"
+local_dynamo_prefix="local"
 if [ "$LOCAL_DYNAMO_PREFIX" != "" ]; then
-  PREFIX=$LOCAL_DYNAMO_PREFIX
+  local_dynamo_prefix=$LOCAL_DYNAMO_PREFIX
 fi
-echo "PREFIX=$PREFIX"
+echo "local_dynamo_prefix=$local_dynamo_prefix"
 
-LOCAL_PORT=8000
+local_port=8000
 if [ "$LOCAL_DYNAMO_PORT" != "" ]; then
-  LOCAL_PORT=$LOCAL_DYNAMO_PORT
+  local_port=$LOCAL_DYNAMO_PORT
 fi
-echo "LOCAL_PORT=$LOCAL_PORT"
+echo "local_port=$local_port"
 
-ENDPOINT_URL="http://localhost:$LOCAL_PORT"
+endpoint_url="http://localhost:$local_port"
+default_provisioning='{"ReadCapacityUnits": 1, "WriteCapacityUnits": 1}'
 
 # Get list of local tables
-TABLES_LIST_RESPONSE=$(aws dynamodb list-tables --endpoint-url $ENDPOINT_URL 2>&1)
+list_tables_resp=$(aws dynamodb list-tables --endpoint-url "$endpoint_url" 2>&1)
 
 # Check for connection errors
-if [[ $TABLES_LIST_RESPONSE == *"Could not connect to the endpoint URL"* ]]; then
-  echo "Please confirm your local dynamo is running on port: $LOCAL_PORT."
+if [ "$list_tables_resp" = "*Could not connect to the endpoint URL*" ]; then
+  echo "Please confirm your local dynamo is running on port: $local_port."
 fi
 
-if $(jq -e 'has("TableNames")' <<< "$TABLES_LIST_RESPONSE" &> /dev/null); then
-  echo "Successfully connected to dynamo running on $ENDPOINT_URL"
+if echo "$list_tables_resp" | jq -e 'has("TableNames")' > /dev/null; then
+  echo "Successfully connected to dynamo running on $endpoint_url"
 else
-  echo "Unable to connect to dynamo on $ENDPOINT_URL"
+  echo "Unable to connect to dynamo on $endpoint_url"
   reset_updated_env_variables
   exit
 fi
 
 # Create tables that don't exist from source for table names passed as arguments
-tables=("$@")
-for table in "${tables[@]}"; do
+for table in "$@"; do
   create_if_not_exists "$table"
 done
 


### PR DESCRIPTION
Closes https://github.com/chanzuckerberg/napari-hub/issues/953

Note: The description will be copied over to the wiki. 

## Description

This introduces changes to set up the local dynamo with tables in sync with staging. 

## Setting up local dynamo

This setup guide is for running dynamo from zip files.

### Setting up java
Try running, `java -version` on your commandline. If you have java runtime environment set up, you should see something like this below:
```
$ java -version
java version "1.8.0_361"
Java(TM) SE Runtime Environment (build 1.8.0_361-b09)
```
If you don't, please go through the jre setup from [here](https://www.java.com/en/download/help/download_options.html). Once the setup is complete and the path to java is in your `PATH` environment variable, try running the above command. You should now be able to get the java version you are running.

### Downloading files
You can download the files from [here](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.DownloadingAndRunning.html#DynamoDBLocal.DownloadingAndRunning.title) and extract them. 


### Starting up
To start the local DynamoDB, navigate to the directory where you extracted DynamoDBLocal.jar and enter the following command:
```
java -Djava.library.path=./DynamoDBLocal_lib -jar DynamoDBLocal.jar -sharedDb
```
Ensure that the `AWS_ACCESS_KEY_ID` and the `AWS_SECRET_ACCESS_KEY` environment variables are set up with fake values before requesting the local dynamo.

### Alternative setup with Docker

You can alternatively set up dynamo locally using docker with the guide provided [here](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.DownloadingAndRunning.html#docker).

## Requirements

- It requires a local dynamo to be running.  Please take a look at the section above for setting up local dynamo. 
- aws CLI to be available. Please refer [here](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) to find relevant documentation. 
- [jq](https://stedolan.github.io/jq/download/) package to be available. If `jq` is not already available, it will try to install it using `brew` or `macPorts`. 
- env variable `AWS_PROFILE` set up to a profile name with access to the staging tables or other configured source tables.

### Optional Environment Variables for customizations
The following environment variables can be set with values to override default values.
- `REMOTE_DYNAMO_PREFIX` can be configured to the prefix of the remote table to be used as the source when creating new tables. This defaults to `staging`.
- `LOCAL_DYNAMO_PREFIX` can be configured to the prefix of the local dynamo table to be created. This defaults to `local`.
- `LOCAL_DYNAMO_PORT` can be configured to the port where the local dynamo is listening. This defaults to `8000`.


## How to run the script

The script takes the names of tables to be created as arguments. 

The script can be run from the command line as follows, from the folder where the script exists.
```
$ ./local-dynamo-setup.sh "install-activity" 
```
This will create the table `local-install-activity` if it doesn't already exist in the local dynamo.

Multiple table names can also be passed in a single invocation as follows:
```
$ ./local-dynamo-setup.sh "install-activity" "github-activity" "category"
```

### Pointing applications to local dynamo

When running locally, set up the `LOCAL_DYNAMO_HOST` environment variable to `http://localhost:8000` or whereever your local dynamo is running.  Example:
```
$ export LOCAL_DYNAMO_HOST="http://localhost:8000"
```

In the pynamo models, setup the host attribute of the metaclass to get the value assigned to `LOCAL_DYNAMO_HOST` environment variable.  As done [here](https://github.com/chanzuckerberg/napari-hub/blob/6440a4d389a688ab5b96a6759b2a4565f27b042f/data-workflows/activity/install_activity_model.py#L45).