### PR TITLE
Create plugin dynamo tables

### DIFF
--- a/.happy/terraform/modules/dynamo/main.tf
+++ b/.happy/terraform/modules/dynamo/main.tf
@@ -10,6 +10,8 @@ module dynamodb {
 
   table_class = var.table_class
 
+  global_secondary_indexes = var.global_secondary_indexes
+
   point_in_time_recovery_enabled = var.tags.env == "prod" ? true : false
 
   autoscaling_enabled = var.autoscaling_enabled

--- a/.happy/terraform/modules/dynamo/variables.tf
+++ b/.happy/terraform/modules/dynamo/variables.tf
@@ -21,6 +21,12 @@ variable hash_key {
   description = "Please provide the hash key for table"
 }
 
+variable global_secondary_indexes {
+  type        = any
+  description = "Please provide GSI configuration"
+  default     = []
+}
+
 variable range_key {
   type        = string
   description = "Please provide the range key for table"

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -186,16 +186,17 @@ module plugin_dynamodb_table {
 
   global_secondary_indexes = [
                           {
-                            name               = "latest_plugins"
+                            name               = "${local.custom_stack_name}-latest-plugins"
                             hash_key           = "name"
                             range_key          = "is_latest"
                             projection_type    = "ALL"
                           },
                           {
-                            name               = "excluded_plugins"
+                            name               = "${local.custom_stack_name}-excluded-plugins"
                             hash_key           = "name"
                             range_key          = "excluded"
-                            projection_type    = "KEYS_ONLY"
+                            projection_type    = "INCLUDE"
+                            non_key_attributes = ["is_latest", "last_updated_timestamp"]
                           }
                         ]
   autoscaling_enabled = var.env == "dev" ? false : true

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -176,11 +176,11 @@ module plugin_dynamodb_table {
                           },
                           {
                             name = "is_latest"
-                            type = "S"
+                            type = "S" #terraform only supports String, Number or Binary for primary key attribute
                           },
                           {
                             name = "excluded"
-                            type = "S" #primary key attribute must be a String, Number or Binary. So this is set to S.
+                            type = "S"
                           }
                         ]
 
@@ -455,6 +455,8 @@ data aws_iam_policy_document backend_policy {
       module.install_dynamodb_table.table_arn,
       module.github_dynamodb_table.table_arn,
       module.category_dynamodb_table.table_arn,
+      module.plugin_dynamodb_table.table_arn,
+      module.plugin_blocked_dynamodb_table.table_arn
     ]
   }
 
@@ -495,6 +497,8 @@ data aws_iam_policy_document data_workflows_policy {
     resources = [
         module.install_dynamodb_table.table_arn,
         module.github_dynamodb_table.table_arn,
+        module.plugin_dynamodb_table.table_arn,
+        module.plugin_blocked_dynamodb_table.table_arn
     ]
   }
   statement {
@@ -530,6 +534,14 @@ data aws_iam_policy_document plugins_policy {
     ]
 
     resources = ["${local.data_bucket_arn}"]
+  }
+
+  statement {
+    actions = [
+      "dynamodb:Query",
+      "dynamodb:PutItem",
+    ]
+    resources = [module.plugin_dynamodb_table.table_arn]
   }
 }
 

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -160,6 +160,41 @@ module category_dynamodb_table {
   tags                = var.tags
 }
 
+module plugin_dynamodb_table {
+  source              = "../dynamo"
+  table_name          = "${local.custom_stack_name}-plugin"
+  hash_key            = "name"
+  range_key           = "version_type"
+  attributes          = [
+                          {
+                            name = "name"
+                            type = "S"
+                          },
+                          {
+                            name = "version_type"
+                            type = "S"
+                          }
+                        ]
+
+  global_secondary_indexes = [
+                          {
+                            name               = "name_is_latest"
+                            hash_key           = "name"
+                            range_key          = "is_latest"
+                            projection_type    = "ALL"
+                          },
+                          {
+                            name               = "name_excluded"
+                            hash_key           = "name"
+                            range_key          = "excluded"
+                            projection_type    = "KEYS_ONLY"
+                          }
+                        ]
+  autoscaling_enabled = var.env == "dev" ? false : true
+  create_table        = true
+  tags                = var.tags
+}
+
 module backend_lambda {
   source             = "../lambda-container"
   function_name      = local.backend_function_name

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -173,21 +173,44 @@ module plugin_dynamodb_table {
                           {
                             name = "version_type"
                             type = "S"
+                          },
+                          {
+                            name = "is_latest"
+                            type = "S"
+                          },
+                          {
+                            name = "excluded"
+                            type = "S" #primary key attribute must be a String, Number or Binary. So this is set to S.
                           }
                         ]
 
   global_secondary_indexes = [
                           {
-                            name               = "name_is_latest"
+                            name               = "latest_plugins"
                             hash_key           = "name"
                             range_key          = "is_latest"
                             projection_type    = "ALL"
                           },
                           {
-                            name               = "name_excluded"
+                            name               = "excluded_plugins"
                             hash_key           = "name"
                             range_key          = "excluded"
                             projection_type    = "KEYS_ONLY"
+                          }
+                        ]
+  autoscaling_enabled = var.env == "dev" ? false : true
+  create_table        = true
+  tags                = var.tags
+}
+
+module plugin_blocked_dynamodb_table {
+  source              = "../dynamo"
+  table_name          = "${local.custom_stack_name}-plugin-blocked"
+  hash_key            = "name"
+  attributes          = [
+                          {
+                            name = "name"
+                            type = "S"
                           }
                         ]
   autoscaling_enabled = var.env == "dev" ? false : true


### PR DESCRIPTION
Relates to https://github.com/chanzuckerberg/napari-hub/issues/880

## Description
- Creates tables for `plugin`, `plugin-metadata` and `plugin-blocked`.

- The `plugin-blocked` schema follows the spec from the RFC.

- The `plugin-metadata` table will store the data from different sources such as pypi, github and manifest. The table will follow the schema designed for the plugin table but without the secondary indices. As the records will only have the source data, the attributes in this table will also be only those defined for the source data ie name, version-type, version, type, data, last_updated_timestamp

- The `plugin` table will store only the aggregated plugin data. The schema follows the spec from the RFC with the change that the range key is now the version of the plugin. The `type` identifier is no longer needed, as all the records in this table are of `type=AGGREGATE`.  This will also result in the type attribute not being stored in this table.


