### PR TITLE
Making dataworkflows timestamp window utc to be consistent

### DIFF
--- a/data-workflows/activity/snowflake_adapter.py
+++ b/data-workflows/activity/snowflake_adapter.py
@@ -79,7 +79,7 @@ def _generate_subquery_by_type(plugins_by_timestamp: dict[str, datetime], instal
 
 
 def _format_timestamp(timestamp_millis):
-    return TIMESTAMP_FORMAT.format(datetime.fromtimestamp(timestamp_millis / 1000.0))
+    return TIMESTAMP_FORMAT.format(datetime.utcfromtimestamp(timestamp_millis / 1000.0))
 
 
 def _cursor_to_timestamp_by_plugin_mapper(accumulator: dict[str, datetime], cursor) -> dict[str, datetime]:

--- a/data-workflows/activity/tests/test_snowflake_adapter.py
+++ b/data-workflows/activity/tests/test_snowflake_adapter.py
@@ -31,8 +31,8 @@ def get_plugins_with_installs_in_window_query():
             WHERE 
                 download_type = 'pip'
                 AND project_type = 'plugin'
-                AND TO_TIMESTAMP(ingestion_timestamp) > TO_TIMESTAMP('2021-03-13 23:05:53')
-                AND TO_TIMESTAMP(ingestion_timestamp) <= TO_TIMESTAMP('2022-03-14 00:05:53')
+                AND TO_TIMESTAMP(ingestion_timestamp) > TO_TIMESTAMP('2021-03-14 07:05:53')
+                AND TO_TIMESTAMP(ingestion_timestamp) <= TO_TIMESTAMP('2022-03-14 07:05:53')
             GROUP BY file_project
             ORDER BY file_project
             """


### PR DESCRIPTION
## Description
Fixes issues with timestamp inconsistency for windows to fetch all updated plugin data.

Example issue: https://github.com/chanzuckerberg/napari-hub/actions/runs/4635611116/jobs/8203025790
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Set the status for the issue to “Pending QA & Release” upon merging
		- Provide a checklist of any relevant pre-deployment notes, e.g. whether a config or database change is needed
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
