### PR TITLE
Sort plugins by name or display name

### DIFF
--- a/frontend/src/components/SitemapPage/useCategorizedSitemapEntries.ts
+++ b/frontend/src/components/SitemapPage/useCategorizedSitemapEntries.ts
@@ -1,10 +1,9 @@
 import { useMemo } from 'react';
 
+import { NAPARI_PREFIX_REGEX } from '@/constants/search';
 import { SitemapCategory, SitemapEntry } from '@/types/sitemap';
 import { createUrl } from '@/utils';
 import { getPluginFirstLetter } from '@/utils/sitemap';
-
-const NAPARI_PREFIX_REGEX = /^napari[ -]/;
 
 function getEntryValue(entry: SitemapEntry) {
   const name = entry.name ?? entry.url.split('/').at(-1) ?? '';

--- a/frontend/src/constants/search.ts
+++ b/frontend/src/constants/search.ts
@@ -13,3 +13,8 @@ export const BEGINNING_PAGE = 1;
  * Max search results to show at a time.
  */
 export const RESULTS_PER_PAGE = 15;
+
+/**
+ * Used for removing from plugin name / display name while sorting.
+ */
+export const NAPARI_PREFIX_REGEX = /^napari[ -]/;

--- a/frontend/src/store/search/sorters.ts
+++ b/frontend/src/store/search/sorters.ts
@@ -1,3 +1,5 @@
+import { NAPARI_PREFIX_REGEX } from '@/constants/search';
+
 import { SearchSortType } from './constants';
 import { SearchResult } from './search.types';
 import { SearchResultTransformFunction } from './types';
@@ -38,12 +40,17 @@ function sortByFirstReleased(results: SearchResult[]) {
   );
 }
 
+function getPluginName({ plugin }: SearchResult) {
+  const name = plugin.display_name || plugin.name;
+  return name.toLowerCase().replace(NAPARI_PREFIX_REGEX, '');
+}
+
 function sortByPluginName(results: SearchResult[]) {
   return (
     results
       // Create a copy of the array
       .slice()
-      .sort((a, b) => a.plugin.name.localeCompare(b.plugin.name))
+      .sort((a, b) => getPluginName(a).localeCompare(getPluginName(b)))
   );
 }
 


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
4. Include screenshots / videos for PRs if there are visual changes.

A good example is https://github.com/chanzuckerberg/napari-hub/pull/77.
-->

## Description
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Set the status for the issue to “Pending QA & Release” upon merging
		- Provide a checklist of any relevant pre-deployment notes, e.g. whether a config or database change is needed
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

https://github.com/chanzuckerberg/napari-hub/issues/759

Updates the sort by plugin name functionality to sort plugins with the following rules:

1. Use display name if available, otherwise use plugin name
1.Remove `napari-` or `napari ` prefix from name or display name 
1. Make strings lowercase
1. Do locale comparison of both strings
