### PR TITLE
Add Terraform change to write items to github_dynamodb_table

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -425,8 +425,8 @@ data aws_iam_policy_document data_workflows_policy {
       "dynamodb:BatchWriteItem",
     ]
     resources = [
-    module.install_dynamodb_table.table_arn,
-    module.github_dynamodb_table.table_arn,
+        module.install_dynamodb_table.table_arn,
+        module.github_dynamodb_table.table_arn,
     ]
   }
   statement {

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -424,7 +424,10 @@ data aws_iam_policy_document data_workflows_policy {
       "dynamodb:Query",
       "dynamodb:BatchWriteItem",
     ]
-    resources = [module.install_dynamodb_table.table_arn]
+    resources = [
+    module.install_dynamodb_table.table_arn,
+    module.github_dynamodb_table.table_arn,
+    ]
   }
   statement {
     actions = [


### PR DESCRIPTION
We need to add `module.github_dynamodb_table.table_arn` to `data_workflows_policy.resources` in order for items to be written to the Dynamo tables. 

See https://github.com/chanzuckerberg/napari-hub/pull/917/files#diff-609995c52e95e7c7d346ed100be4c52ef17f853ada8931e97db7c1c061807442R372 for reference.