### PR TITLE
Fixing use of timestamp keyword in snowflake query

### DIFF
--- a/data-workflows/activity/github_activity_model.py
+++ b/data-workflows/activity/github_activity_model.py
@@ -9,7 +9,7 @@ from pynamodb.models import Model
 from pynamodb.attributes import UnicodeAttribute, NumberAttribute
 
 from utils.utils import get_current_timestamp, date_to_utc_timestamp_in_millis, datetime_to_utc_timestamp_in_millis
-from plugin.helpers import _get_cache, _get_repo_to_plugin_dict
+from plugin.helpers import _get_repo_to_plugin_dict
 
 
 LOGGER = logging.getLogger()
@@ -27,11 +27,11 @@ class GitHubActivityType(Enum):
         return github_activity_type
 
     LATEST = (datetime_to_utc_timestamp_in_millis, 'LATEST:{0}',
-              'repo AS name, to_timestamp(max(commit_author_date)) as latest_commit', 'name')
+              'repo AS name, to_timestamp(max(commit_author_date)) AS latest_commit', 'name')
     MONTH = (date_to_utc_timestamp_in_millis, 'MONTH:{1:%Y%m}:{0}',
-             'repo AS name, date_trunc("month", to_date(commit_author_date)) as month, count(*) as commit_count',
+             'repo AS name, date_trunc("month", to_date(commit_author_date)) AS month, count(*) AS commit_count',
              'name, month')
-    TOTAL = (lambda timestamp: None, 'TOTAL:{0}', 'repo AS name, count(*) as commit_count', 'name')
+    TOTAL = (lambda timestamp: None, 'TOTAL:{0}', 'repo AS name, count(*) AS commit_count', 'name')
 
     def format_to_timestamp(self, timestamp: datetime) -> Union[int, None]:
         return self.timestamp_formatter(timestamp)

--- a/data-workflows/activity/github_activity_model.py
+++ b/data-workflows/activity/github_activity_model.py
@@ -27,11 +27,11 @@ class GitHubActivityType(Enum):
         return github_activity_type
 
     LATEST = (datetime_to_utc_timestamp_in_millis, 'LATEST:{0}',
-              'repo AS name, to_timestamp(max(commit_author_date)) AS latest_commit', 'name')
+              'repo AS name, TO_TIMESTAMP(MAX(commit_author_date)) AS latest_commit', 'name')
     MONTH = (date_to_utc_timestamp_in_millis, 'MONTH:{1:%Y%m}:{0}',
-             'repo AS name, date_trunc("month", to_date(commit_author_date)) AS month, count(*) AS commit_count',
+             'repo AS name, DATE_TRUNC("month", TO_DATE(commit_author_date)) AS month, COUNT(*) AS commit_count',
              'name, month')
-    TOTAL = (lambda timestamp: None, 'TOTAL:{0}', 'repo AS name, count(*) AS commit_count', 'name')
+    TOTAL = (lambda timestamp: None, 'TOTAL:{0}', 'repo AS name, COUNT(*) AS commit_count', 'name')
 
     def format_to_timestamp(self, timestamp: datetime) -> Union[int, None]:
         return self.timestamp_formatter(timestamp)
@@ -43,7 +43,7 @@ class GitHubActivityType(Enum):
         if self is GitHubActivityType.MONTH:
             return " OR ".join(
                 [
-                    f"repo = '{name}' AND to_timestamp(commit_author_date) >= "
+                    f"repo = '{name}' AND TO_TIMESTAMP(commit_author_date) >= "
                     f"{TIMESTAMP_FORMAT.format(ts.replace(day=1))}"
                     for name, ts in plugins_by_earliest_ts.items()
                 ]

--- a/data-workflows/activity/snowflake_adapter.py
+++ b/data-workflows/activity/snowflake_adapter.py
@@ -38,7 +38,7 @@ def get_plugins_install_count_since_timestamp(plugins_by_earliest_ts: dict[str, 
     query = f"""
             SELECT 
                 LOWER(file_project) AS name, 
-                {install_activity_type.get_query_timestamp_projection()} AS timestamp, 
+                {install_activity_type.get_query_timestamp_projection()} AS ts, 
                 COUNT(*) AS count
             FROM
                 imaging.pypi.labeled_downloads
@@ -46,8 +46,8 @@ def get_plugins_install_count_since_timestamp(plugins_by_earliest_ts: dict[str, 
                 download_type = 'pip'
                 AND project_type = 'plugin'
                 AND ({_generate_subquery_by_type(plugins_by_earliest_ts, install_activity_type)})
-            GROUP BY name, timestamp
-            ORDER BY name, timestamp
+            GROUP BY name, ts
+            ORDER BY name, ts
             """
     LOGGER.info(f'Fetching data for granularity={install_activity_type.name}')
     return _mapped_query_results(query, 'PYPI', {}, _cursor_to_plugin_activity_mapper)

--- a/data-workflows/activity/tests/test_snowflake_adapter.py
+++ b/data-workflows/activity/tests/test_snowflake_adapter.py
@@ -42,7 +42,7 @@ def get_plugins_install_count_since_timestamp_query(projection, subquery):
     return f"""
             SELECT 
                 LOWER(file_project) AS name, 
-                {projection} AS timestamp, 
+                {projection} AS ts, 
                 COUNT(*) AS count
             FROM
                 imaging.pypi.labeled_downloads
@@ -50,8 +50,8 @@ def get_plugins_install_count_since_timestamp_query(projection, subquery):
                 download_type = 'pip'
                 AND project_type = 'plugin'
                 AND ({subquery})
-            GROUP BY name, timestamp
-            ORDER BY name, timestamp
+            GROUP BY name, ts
+            ORDER BY name, ts
             """
 
 


### PR DESCRIPTION
## Description

Changes introduced in this PR:

- Fixes failure in the activity data workflow because the keyword `timestamp` is used as an alias in the projections. 
- Removes unused import
- Updates `as` -> `AS` in query for consistency

<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Set the status for the issue to “Pending QA & Release” upon merging
		- Provide a checklist of any relevant pre-deployment notes, e.g. whether a config or database change is needed
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
