### PR TITLE
Fix pynamodb.exceptions.GetError 

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -402,6 +402,16 @@ data aws_iam_policy_document backend_policy {
 
   statement {
     actions = [
+      "dynamodb:BatchGetItem",
+    ]
+
+    resources = [
+      module.install_dynamodb_table.table_arn,
+    ]
+  }
+
+  statement {
+    actions = [
       "lambda:InvokeFunction"
     ]
 


### PR DESCRIPTION
## Description

Changes introduced in this PR:

- Fixes pynamodb.exceptions.GetError: Failed to batch get item by adding `BatchGetItem` in `backend_policy` in Terraform

For reference, this is what the error in Datadog looks like: https://app.datadoghq.com/apm/error-tracking?issueId=58542400-e90b-11ed-8825-da7ad0900002&from_ts=1683130608520&to_ts=1683134208520&live=true