### PR TITLE
Internal server error on napari-chatgpt fix

### DIFF
--- a/frontend/src/components/Markdown/Markdown.utils.ts
+++ b/frontend/src/components/Markdown/Markdown.utils.ts
@@ -58,7 +58,7 @@ export function getHeadersFromMarkdown(markdown: string): TOCHeader[] {
   // Convert all H2 headings into TOCHeader objects.
   return children
     .filter((node): node is HeadingNode => node.tagName === TOC_HEADER_TAG)
-    .filter((node) => node.children[0].value !== undefined)
+    .filter((node) => node.children[0]?.value !== undefined)
     .map<TOCHeader>((node) => ({
       id: node.properties.id,
       text: node.children[0].value,


### PR DESCRIPTION
## Issue
https://github.com/chanzuckerberg/napari-hub/issues/1024

## Description
https://napari-hub.org/plugins/napari-chatgpt is failing in prod and staging at the moment due to an internal server error. To be more specific, the error comes from trying to access an attribute of an empty list.
<img width="1364" alt="Screenshot 2023-05-03 at 5 53 03 PM" src="https://user-images.githubusercontent.com/70177777/236067924-a220afea-efe8-4cab-974a-91f814c09574.png">

## Changes
This PR makes node.children[0] optional, so that the error no longer occurs in the case it is an empty list accessing the `value` attribute

## Local Testing
<img width="1728" alt="Screenshot 2023-05-03 at 5 55 58 PM" src="https://user-images.githubusercontent.com/70177777/236068314-8ed03f73-56dc-434b-b411-b268f63946d5.png">