### PR TITLE
Fix workflow step header duplication

### DIFF
--- a/frontend/src/components/SearchPage/PluginComplexFilter.tsx
+++ b/frontend/src/components/SearchPage/PluginComplexFilter.tsx
@@ -226,6 +226,18 @@ export function PluginComplexFilter({ filterKey }: Props) {
 
   const isSearchEnabled = SEARCH_ENABLED_FILTERS.has(filterKey);
 
+  const options = optionsRef.current.filter(
+    (option) => option.name && option.stateKey,
+  );
+
+  if (filterKey === 'workflowStep') {
+    options.sort((option1, option2) =>
+      workflowStepGroups[option1.stateKey].localeCompare(
+        workflowStepGroups[option2.stateKey],
+      ),
+    );
+  }
+
   return (
     <ComplexFilter
       className={clsx(
@@ -335,9 +347,7 @@ export function PluginComplexFilter({ filterKey }: Props) {
           </div>
         ),
       }}
-      options={optionsRef.current.filter(
-        (option) => option.name && option.stateKey,
-      )}
+      options={options}
       value={pendingState}
       PopperComponent={StyledPopper}
     />


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
4. Include screenshots / videos for PRs if there are visual changes.

A good example is https://github.com/chanzuckerberg/napari-hub/pull/77.
-->

## Description
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Set the status for the issue to “Pending QA & Release” upon merging
		- Provide a checklist of any relevant pre-deployment notes, e.g. whether a config or database change is needed
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

https://github.com/chanzuckerberg/napari-hub/issues/995

- Fixes workflow step group duplication by sorting options by group
- Issue was that options weren't sorted by group, [which is a requirement for the feature to work](https://mui.com/material-ui/react-autocomplete/#grouped)

## Demos
<!-- Optional but recommended. Remove if not in use -->

### Before

<img width="269" alt="image" src="https://user-images.githubusercontent.com/2176050/236891037-8886c53f-02c9-4653-8c78-d5e57a99c3a7.gif">


### After

<img width="269" alt="image" src="https://user-images.githubusercontent.com/2176050/236891392-a84e8e27-0a3c-43f9-8e65-33e5f71cb468.gif">
