### PR TITLE
"Image Segmentation" should be "Image segmentation"

### DIFF
--- a/frontend/i18n/en/pluginData.json
+++ b/frontend/i18n/en/pluginData.json
@@ -77,7 +77,7 @@
       "Image fusion": "Image fusion",
       "Image reconstruction": "Image reconstruction",
       "Image registration": "Image registration",
-      "Image Segmentation": "Image Segmentation",
+      "Image Segmentation": "Image segmentation",
       "Magnetic resonance imaging": "Magnetic resonance imaging",
       "Medical imaging": "Medical imaging",
       "Morphological operations": "Morphological operations",


### PR DESCRIPTION
## Issue
https://github.com/chanzuckerberg/napari-hub/issues/437
/Users/klai/Documents/napari-hub/frontend/i18n/en/pluginData.json
## Description
For pills and filters, "Image Segmentation" should be "Image segmentation"

## Code Change
On https://github.com/chanzuckerberg/napari-hub/blob/main/frontend/i18n/en/pluginData.json#L80, we need to change the value of "Image Segmentation" to "Image segmentation". Note that the change needs to be applied to the value, and not to the key

## Actual Result
<img width="1728" alt="Screenshot 2023-05-09 at 1 08 01 PM" src="https://github.com/chanzuckerberg/napari-hub/assets/70177777/25e16bd3-e6f4-4564-b2d6-7f72c8ab41bb">