### PR TITLE
Optimize total_installs for /plugin/index

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -113,6 +113,19 @@ module install_dynamodb_table {
                           {
                             name = "type_timestamp"
                             type = "S"
+                          },
+                          {
+                            name = "is_total"
+                            type = "S"
+                          }
+                        ],
+   global_secondary_indexes = [
+                          {
+                            name               = "${local.custom_stack_name}-total-installs"
+                            hash_key           = "plugin_name"
+                            range_key          = "is_total"
+                            projection_type    = "INCLUDE"
+                            non_key_attributes = ["install_count", "last_updated_timestamp"]
                           }
                         ]
   autoscaling_enabled = var.env == "dev" ? false : true

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -118,7 +118,7 @@ module install_dynamodb_table {
                             name = "is_total"
                             type = "S"
                           }
-                        ],
+                        ]
    global_secondary_indexes = [
                           {
                             name               = "${local.custom_stack_name}-total-installs"

--- a/backend/api/models/_tests/test_install_activity.py
+++ b/backend/api/models/_tests/test_install_activity.py
@@ -39,13 +39,14 @@ class TestInstallActivity:
             return f'MONTH:{timestamp.strftime("%Y%m")}'
         return 'TOTAL:'
 
-    def _put_item(self, table, granularity, timestamp, install_count, plugin=PLUGIN_NAME):
+    def _put_item(self, table, granularity, timestamp, install_count, is_total=None, plugin=PLUGIN_NAME):
         item = {
             'plugin_name': plugin,
             'type_timestamp': self._to_type_timestamp(granularity, timestamp),
             'install_count': install_count,
             'granularity': granularity,
-            'timestamp': to_millis(timestamp)
+            'timestamp': to_millis(timestamp),
+            'is_total': is_total,
         }
         table.put_item(Item=item)
 
@@ -56,7 +57,7 @@ class TestInstallActivity:
 
     def test_get_total_installs_has_result(self, install_activity_table):
         expected = 173
-        self._put_item(install_activity_table, 'TOTAL', None, expected)
+        self._put_item(install_activity_table, 'TOTAL', None, expected, is_total='true')
 
         actual = install_activity.get_total_installs(plugin=PLUGIN_NAME)
 
@@ -100,7 +101,7 @@ class TestInstallActivity:
         ])
     def test_get_total_installs_by_plugins(self, install_activity_table, data, expected):
         for plugin, count in data:
-            self._put_item(install_activity_table, 'TOTAL', None, count, plugin=plugin)
+            self._put_item(install_activity_table, 'TOTAL', None, count, is_total='true', plugin=plugin)
 
         actual = install_activity.get_total_installs_by_plugins(plugins=['foo', 'bar'])
 

--- a/backend/api/models/_tests/test_install_activity.py
+++ b/backend/api/models/_tests/test_install_activity.py
@@ -46,8 +46,9 @@ class TestInstallActivity:
             'install_count': install_count,
             'granularity': granularity,
             'timestamp': to_millis(timestamp),
-            'is_total': is_total,
         }
+        if is_total:
+            item['is_total'] = is_total
         table.put_item(Item=item)
 
     def test_get_total_installs_has_no_result(self, install_activity_table):

--- a/data-workflows/activity/install_activity_model.py
+++ b/data-workflows/activity/install_activity_model.py
@@ -46,23 +46,24 @@ class InstallActivity(Model):
     type_timestamp = UnicodeAttribute(range_key=True)
     granularity = UnicodeAttribute(attr_name='type')
     timestamp = NumberAttribute(null=True)
+    is_total = UnicodeAttribute(null=True)
     install_count = NumberAttribute()
     last_updated_timestamp = NumberAttribute(default_for_new=get_current_timestamp)
 
     def __eq__(self, other):
         if isinstance(other, InstallActivity):
-            return ((self.plugin_name, self.type_timestamp, self.granularity, self.timestamp, self.install_count) == 
-                    (other.plugin_name, other.type_timestamp, other.granularity, other.timestamp, other.install_count))
+            return ((self.plugin_name, self.type_timestamp, self.granularity, self.timestamp, self.install_count, self.is_total) ==
+                    (other.plugin_name, other.type_timestamp, other.granularity, other.timestamp, other.install_count, other.is_total))
         return False
 
 
 def transform_and_write_to_dynamo(data: dict[str, List], activity_type: InstallActivityType) -> None:
     LOGGER.info(f'Starting item creation for install-activity type={activity_type.name}')
-
     batch = InstallActivity.batch_write()
+    is_total = "true" if activity_type is InstallActivityType.TOTAL else None
+    count = 0
 
     start = time.perf_counter()
-    count = 0
     for plugin_name, install_activities in data.items():
         for activity in install_activities:
             timestamp = activity['timestamp']
@@ -71,7 +72,8 @@ def transform_and_write_to_dynamo(data: dict[str, List], activity_type: InstallA
                                    activity_type.format_to_type_timestamp(timestamp),
                                    granularity=activity_type.name,
                                    timestamp=activity_type.format_to_timestamp(timestamp),
-                                   install_count=activity['count'])
+                                   install_count=activity['count'],
+                                   is_total=is_total)
             batch.save(item)
             count += 1
 

--- a/data-workflows/activity/install_activity_model.py
+++ b/data-workflows/activity/install_activity_model.py
@@ -52,28 +52,32 @@ class InstallActivity(Model):
 
     def __eq__(self, other):
         if isinstance(other, InstallActivity):
-            return ((self.plugin_name, self.type_timestamp, self.granularity, self.timestamp, self.install_count, self.is_total) ==
-                    (other.plugin_name, other.type_timestamp, other.granularity, other.timestamp, other.install_count, other.is_total))
+            return ((self.plugin_name, self.type_timestamp, self.granularity,
+                     self.timestamp, self.install_count, self.is_total) ==
+                    (other.plugin_name, other.type_timestamp, other.granularity,
+                     other.timestamp, other.install_count, other.is_total))
         return False
 
 
-def transform_and_write_to_dynamo(data: dict[str, List], activity_type: InstallActivityType) -> None:
+def transform_and_write_to_dynamo(data: dict[str, List],
+                                  activity_type: InstallActivityType) -> None:
     LOGGER.info(f'Starting item creation for install-activity type={activity_type.name}')
     batch = InstallActivity.batch_write()
-    is_total = "true" if activity_type is InstallActivityType.TOTAL else None
     count = 0
-
+    is_total = 'true' if activity_type is InstallActivityType.TOTAL else None
     start = time.perf_counter()
     for plugin_name, install_activities in data.items():
         for activity in install_activities:
             timestamp = activity['timestamp']
 
-            item = InstallActivity(plugin_name.lower(),
-                                   activity_type.format_to_type_timestamp(timestamp),
-                                   granularity=activity_type.name,
-                                   timestamp=activity_type.format_to_timestamp(timestamp),
-                                   install_count=activity['count'],
-                                   is_total=is_total)
+            item = InstallActivity(
+                plugin_name=plugin_name.lower(),
+                type_timestamp=activity_type.format_to_type_timestamp(timestamp),
+                granularity=activity_type.name,
+                timestamp=activity_type.format_to_timestamp(timestamp),
+                install_count=activity['count'],
+                is_total=is_total,
+            )
             batch.save(item)
             count += 1
 

--- a/data-workflows/activity/tests/test_install_activity_model.py
+++ b/data-workflows/activity/tests/test_install_activity_model.py
@@ -15,7 +15,7 @@ def sorting_key(install_activity: InstallActivity):
     return install_activity.plugin_name + ' ' + install_activity.type_timestamp
 
 
-def generate_expected(data, granularity, type_timestamp_formatter, timestamp_formatter):
+def generate_expected(data, granularity, type_timestamp_formatter, timestamp_formatter, is_total=None):
     expected = []
     for key, values in data.items():
         for val in values:
@@ -25,7 +25,9 @@ def generate_expected(data, granularity, type_timestamp_formatter, timestamp_for
                                  f'{type_timestamp_formatter(timestamp)}',
                                  granularity=granularity,
                                  timestamp=timestamp_formatter(timestamp),
-                                 install_count=val['count'])
+                                 install_count=val['count'],
+                                 is_total=is_total,
+                                 )
             expected.append(ia)
     return expected
 
@@ -117,5 +119,5 @@ class TestInstallActivityModels:
         from activity.install_activity_model import transform_and_write_to_dynamo
         transform_and_write_to_dynamo(data, InstallActivityType.TOTAL)
 
-        expected = generate_expected(data, 'TOTAL', lambda ts: f'TOTAL:', lambda ts: None)
+        expected = generate_expected(data, 'TOTAL', lambda ts: f'TOTAL:', lambda ts: None, 'true')
         self._verify(expected)


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
4. Include screenshots / videos for PRs if there are visual changes.

A good example is https://github.com/chanzuckerberg/napari-hub/pull/77.
-->

## Description
Relates to: https://github.com/chanzuckerberg/napari-hub/issues/1042

Changes introduced:
- Adds a new index to `install-activity` table on the plugin_name, and is_total field

- Adds the `is_total` attribute only to the records of type=TOTAL in data workflow

- In backend, updates the data fetch from batch get to scan of the table. 


Notes:
- On deploy of this changes, the activity workflow needs to be executed from start of time. 


