### PR TITLE
Permission issue with category table: BatchWriteItem operation

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -532,6 +532,7 @@ data aws_iam_policy_document data_workflows_policy {
     resources = [
         module.install_dynamodb_table.table_arn,
         module.github_dynamodb_table.table_arn,
+        module.category_dynamodb_table.table_arn,
         module.plugin_dynamodb_table.table_arn,
         module.plugin_metadata_dynamodb_table.table_arn,
         module.plugin_blocked_dynamodb_table.table_arn,


### PR DESCRIPTION
## Description

Changes introduced in this PR:

- Fixes pynamodb.exceptions.PutError by adding `module.category_dynamodb_table.table_arn` as a resource in  `data_workflows_policy` in Terraform 

Error Message: 
```
PutError: Failed to batch write items: An error occurred (AccessDeniedException) on request (K6HQS62M56HDU1BBBDRC5VK543VV4KQNSO5AEMVJF66Q9ASUAAJG) on table (staging-category) when calling the BatchWriteItem operation: User: arn:aws:sts::516466186502:assumed-role/staging-data-workflows/staging-data-workflows is not authorized to perform: dynamodb:BatchWriteItem on resource: arn:aws:dynamodb:us-west-2:516466186502:table/staging-category because no identity-based policy allows the dynamodb:BatchWriteItem action\