### PR TITLE
Adding installation instructions to the FAQ page

### DIFF
--- a/frontend/i18n/en/faq.mdx
+++ b/frontend/i18n/en/faq.mdx
@@ -27,6 +27,20 @@ If you think something isn’t working, don’t hesitate to reach out - it is pr
 
 </Accordion>
 
+<Accordion title="How do I install a plugin in napari?" variant="faq">
+
+Plugin authors provide their recommended installation instructions on their plugin detail page
+in the installation section. 
+
+Some plugins can be installed using the Plugins menu in napari. For this method, open napari
+and navigate to Plugins > Install/Unistall Package(s). Search for the plugin using the package name,
+which is the name in smaller font beneath the plugin name on the napari hub and may be the same as
+the plugin name. Click the blue “install” button. The plugin will move to the “Installed Plugins”
+list upon completion. If it seems that the installation failed, try restarting napari as some plugins
+may not show as installed until napari has been reopened.
+
+</Accordion>
+
 <Accordion title="How do I get help with a napari plugin?" variant="faq">
 
 Plugin authors are encouraged to add links to their listing, showing users of their plugin where to find help.


### PR DESCRIPTION
## Description
Updates the FAQ page on napari hub to add installation instructions to address the work done to close [this issue](https://github.com/chanzuckerberg/napari-hub/issues/789).
