### PR TITLE
Revert "Bump snowflake-connector-python from 2.8.0 to 2.8.3 in /backend"

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,6 +16,6 @@ datadog-lambda==3.60.0
 build==0.8.0
 pyOpenSSL==22.0.0
 pandas==1.4.4
-snowflake-connector-python==2.8.3
+snowflake-connector-python==2.8.0
 pynamodb==5.4.1
 python-slugify==8.0.1


### PR DESCRIPTION
Reverts chanzuckerberg/napari-hub#1002

Reverting version bump, as it causes `[ERROR] AttributeError: module 'lib' has no attribute 'OpenSSL_add_all_algorithms'` error. 