### PR TITLE
Remove use_dynamo_category query param

### DIFF
--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -114,19 +114,13 @@ def get_exclusion_list() -> Response:
 
 @app.route('/categories', defaults={'version': os.getenv('category_version', 'EDAM-BIOIMAGING:alpha06')})
 def get_categories(version: str) -> Response:
-    if _is_query_param_true('use_dynamo_category'):
-        return jsonify(CategoryModel.get_all_categories(version))
-
-    return jsonify(get_categories_mapping(version))
+    return jsonify(CategoryModel.get_all_categories(version))
 
 
 @app.route('/categories/<category>', defaults={'version': os.getenv('category_version', 'EDAM-BIOIMAGING:alpha06')})
 @app.route('/categories/<category>/versions/<version>')
 def get_category(category: str, version: str) -> Response:
-    if _is_query_param_true('use_dynamo_category'):
-        return jsonify(CategoryModel.get_category(category, version))
-
-    return jsonify(get_category_mapping(category, get_categories_mapping(version)))
+    return jsonify(CategoryModel.get_category(category, version))
 
 
 @app.route('/activity/update', methods=['POST'])


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
4. Include screenshots / videos for PRs if there are visual changes.

A good example is https://github.com/chanzuckerberg/napari-hub/pull/77.
-->

## Description
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Set the status for the issue to “Pending QA & Release” upon merging
		- Provide a checklist of any relevant pre-deployment notes, e.g. whether a config or database change is needed
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

https://github.com/chanzuckerberg/napari-hub/issues/1057

Remove `use_dynamo_category` query param from categories endpoint so that we always query dynamo for the categories API. This change will any new preview page builds after it gets deployed to production:

https://github.com/chanzuckerberg/napari-hub/blob/383352d13d17ef0fc2c3f5f4d2125daadd8b1bf7/backend/preview/preview.py#L57