### PR TITLE
Add README.md as a source for the description for preview page

### DIFF
--- a/backend/utils/github.py
+++ b/backend/utils/github.py
@@ -10,13 +10,13 @@ from cffconvert.citation import Citation
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import HTTPError
 
-from utils.utils import get_attribute, render_description
+from utils.utils import get_attribute
 from utils.auth import HTTPBearerAuth
 
 # Environment variable set through ecs stack terraform module
-github_client_id = os.environ.get('GITHUB_CLIENT_ID', None)
-github_client_secret = os.environ.get('GITHUB_CLIENT_SECRET', None)
-github_token = os.environ.get('GITHUB_TOKEN', None)
+github_client_id = os.environ.get("GITHUB_CLIENT_ID", None)
+github_client_secret = os.environ.get("GITHUB_CLIENT_SECRET", None)
+github_token = os.environ.get("GITHUB_TOKEN", None)
 
 auth = None
 if github_token:
@@ -24,16 +24,18 @@ if github_token:
 elif github_client_id and github_client_secret:
     auth = HTTPBasicAuth(github_client_id, github_client_secret)
 
-visibility_set = {'public', 'disabled', 'hidden'}
+visibility_set = {"public", "disabled", "hidden"}
 github_pattern = re.compile("^https://github\\.com/([^/]+)/([^/]+)")
-hub_config_keys = {'summary', 'authors', 'labels', 'visibility'}
-default_description = 'The developer has not yet provided a napari-hub specific description.'
+hub_config_keys = {"summary", "authors", "labels", "visibility"}
+default_description = (
+    "The developer has not yet provided a napari-hub specific description."
+)
 project_url_names = {
-    'Project Site': 'project_site',
-    'Documentation': 'documentation',
-    'User Support': 'support',
-    'Report Issues': 'report_issues',
-    'Twitter': 'twitter'
+    "Project Site": "project_site",
+    "Documentation": "documentation",
+    "User Support": "support",
+    "Report Issues": "report_issues",
+    "Twitter": "twitter",
 }
 
 
@@ -76,14 +78,15 @@ def get_file(
     return None
 
 
-def get_license(url: str, branch: str = 'HEAD') -> [str, None]:
+def get_license(url: str, branch: str = "HEAD") -> [str, None]:
     try:
-        api_url = url.replace("https://github.com/",
-                              "https://api.github.com/repos/")
-        response = requests.get(f'{api_url}/license?ref={branch}', auth=auth)
+        api_url = url.replace("https://github.com/", "https://api.github.com/repos/")
+        response = requests.get(f"{api_url}/license?ref={branch}", auth=auth)
         if response.status_code != requests.codes.ok:
             response.raise_for_status()
-        spdx_id = get_attribute(json.loads(response.text.strip()), ['license', "spdx_id"])
+        spdx_id = get_attribute(
+            json.loads(response.text.strip()), ["license", "spdx_id"]
+        )
         if spdx_id == "NOASSERTION":
             return None
         else:
@@ -112,7 +115,7 @@ def get_github_repo_url(project_urls: Dict[str, str]) -> [str, None]:
     return None
 
 
-def get_github_metadata(repo_url: str, branch: str = 'HEAD') -> dict:
+def get_github_metadata(repo_url: str, branch: str = "HEAD") -> dict:
     """
     Extract extra metadata from the github repo url.
 
@@ -124,26 +127,26 @@ def get_github_metadata(repo_url: str, branch: str = 'HEAD') -> dict:
 
     github_license = get_license(repo_url, branch=branch)
     if github_license is not None:
-        github_metadata['license'] = github_license
+        github_metadata["license"] = github_license
 
     description = get_description(repo_url=repo_url, branch=branch)
     if description:
-        github_metadata['description'] = description
+        github_metadata["description"] = description
 
     citation_file = get_file(repo_url, "CITATION.cff", branch=branch)
     if citation_file is not None:
         citation = get_citations(citation_file)
         if citation:
-            github_metadata['citations'] = citation
+            github_metadata["citations"] = citation
         # Try to parse names fron citation
         authors = get_citation_author(citation_file)
         # update github metadata author info
         if authors:
             github_metadata.update({"authors": authors})
-    if 'visibility' not in github_metadata:
-        github_metadata['visibility'] = 'public'
-    elif github_metadata['visibility'] not in visibility_set:
-        github_metadata['visibility'] = 'public'
+    if "visibility" not in github_metadata:
+        github_metadata["visibility"] = "public"
+    elif github_metadata["visibility"] not in visibility_set:
+        github_metadata["visibility"] = "public"
 
     yaml_file = get_file(repo_url, ".napari-hub/config.yml", branch=branch)
     if yaml_file is None:
@@ -156,18 +159,27 @@ def get_github_metadata(repo_url: str, branch: str = 'HEAD') -> dict:
         hub_config = {key: config[key] for key in hub_config_keys if key in config}
         github_metadata.update(hub_config)
 
-        project_urls = config.get('project_urls', {})
-        github_metadata.update({
-           hub_name: project_urls[yaml_name]
-           for yaml_name, hub_name in project_url_names.items() if yaml_name in project_urls
-        })
+        project_urls = config.get("project_urls", {})
+        github_metadata.update(
+            {
+                hub_name: project_urls[yaml_name]
+                for yaml_name, hub_name in project_url_names.items()
+                if yaml_name in project_urls
+            }
+        )
 
     return github_metadata
 
 
 def get_description(repo_url, branch):
-    for description_source in [".napari-hub/DESCRIPTION.md", ".napari/DESCRIPTION.md", "README.md"]:
-        description = get_file(download_url=repo_url, file=description_source, branch=branch)
+    for description_source in [
+        ".napari-hub/DESCRIPTION.md",
+        ".napari/DESCRIPTION.md",
+        "README.md",
+    ]:
+        description = get_file(
+            download_url=repo_url, file=description_source, branch=branch
+        )
         if description and default_description not in description:
             return description
     return None
@@ -182,10 +194,10 @@ def get_citations(citation_str: str) -> Union[Dict[str, str], None]:
     try:
         citation = Citation(cffstr=citation_str)
         return {
-            'citation': citation_str,
-            'RIS': citation.as_ris(),
-            'BibTex': citation.as_bibtex(),
-            'APA': citation.as_apalike()
+            "citation": citation_str,
+            "RIS": citation.as_ris(),
+            "BibTex": citation.as_bibtex(),
+            "APA": citation.as_apalike(),
         }
     except Exception as e:
         # log the invalid CITATION.cff content error
@@ -201,8 +213,13 @@ def get_artifact(url: str, token: str) -> Union[IO[bytes], None]:
 
     download_urls = json.loads(response.text.strip()).get("artifacts", [])
     for download_url in download_urls:
-        if download_url.get("name") == "preview-page" and 'archive_download_url' in download_url:
-            response = requests.get(download_url['archive_download_url'], stream=True, auth=preview_auth)
+        if (
+            download_url.get("name") == "preview-page"
+            and "archive_download_url" in download_url
+        ):
+            response = requests.get(
+                download_url["archive_download_url"], stream=True, auth=preview_auth
+            )
             if response.status_code != requests.codes.ok:
                 return None
             return response.raw
@@ -221,9 +238,20 @@ def get_citation_author(citation_str: str) -> Union[Dict[str, str], None]:
         logging.error(e)
         return []
     authors = []
-    for author_entry in citation_yaml['authors']:
-        if 'given-names' in author_entry and 'family-names' in author_entry and author_entry['given-names'] and author_entry['family-names']:
-            authors.append({'name': author_entry['given-names'] + " " + author_entry['family-names']})
-        elif 'name' in author_entry and author_entry['name']:
-            authors.append({'name': author_entry['name']})
+    for author_entry in citation_yaml["authors"]:
+        if (
+            "given-names" in author_entry
+            and "family-names" in author_entry
+            and author_entry["given-names"]
+            and author_entry["family-names"]
+        ):
+            authors.append(
+                {
+                    "name": author_entry["given-names"]
+                    + " "
+                    + author_entry["family-names"]
+                }
+            )
+        elif "name" in author_entry and author_entry["name"]:
+            authors.append({"name": author_entry["name"]})
     return authors

--- a/backend/utils/github.py
+++ b/backend/utils/github.py
@@ -126,11 +126,8 @@ def get_github_metadata(repo_url: str, branch: str = 'HEAD') -> dict:
     if github_license is not None:
         github_metadata['license'] = github_license
 
-    description = get_file(repo_url,".napari-hub/DESCRIPTION.md", branch=branch)
-    if description is None:
-        description = get_file(repo_url, ".napari/DESCRIPTION.md", branch=branch)
-
-    if description and default_description not in description:
+    description = get_description(repo_url=repo_url, branch=branch)
+    if description:
         github_metadata['description'] = description
 
     citation_file = get_file(repo_url, "CITATION.cff", branch=branch)
@@ -168,6 +165,14 @@ def get_github_metadata(repo_url: str, branch: str = 'HEAD') -> dict:
     return github_metadata
 
 
+def get_description(repo_url, branch):
+    for description_source in [".napari-hub/DESCRIPTION.md", ".napari/DESCRIPTION.md", "README.md"]:
+        description = get_file(download_url=repo_url, file=description_source, branch=branch)
+        if description and default_description not in description:
+            return description
+    return None
+
+
 def get_citations(citation_str: str) -> Union[Dict[str, str], None]:
     """
     Get citation information from the string.
@@ -203,6 +208,7 @@ def get_artifact(url: str, token: str) -> Union[IO[bytes], None]:
             return response.raw
     return None
 
+
 def get_citation_author(citation_str: str) -> Union[Dict[str, str], None]:
     """
     Parse author information from citation.
@@ -217,7 +223,7 @@ def get_citation_author(citation_str: str) -> Union[Dict[str, str], None]:
     authors = []
     for author_entry in citation_yaml['authors']:
         if 'given-names' in author_entry and 'family-names' in author_entry and author_entry['given-names'] and author_entry['family-names']:
-            authors.append({'name':author_entry['given-names'] + " " + author_entry['family-names']})
+            authors.append({'name': author_entry['given-names'] + " " + author_entry['family-names']})
         elif 'name' in author_entry and author_entry['name']:
-            authors.append({'name':author_entry['name']})
+            authors.append({'name': author_entry['name']})
     return authors


### PR DESCRIPTION
### Description and overview of changes

- Addresses https://github.com/chanzuckerberg/napari-hub/issues/1023
- I ran `black` on this file. To view the functional changes, see this commit: https://github.com/chanzuckerberg/napari-hub/commit/beac6602e28d83f9d43bcd14333c8182cf78422b

### Notes
- The reason we appear to render the README.md as the description on the napari hub site currently is that packages are commonly configured to instruct PyPI to use their README to populate the `long_description` field, which we then use to populate a plugin's description on the hub. However, we don't specifically examine the github README.md ourselves (this PR will change that).
- I am assuming the reason for the discrepancy between the napari hub plugin page, and the preview page (in terms of what is available for the description field) is due to what is available in the wheel's metadata at the time of the preview page action. Haven't verified that though.