### PR TITLE
Making metric.usage data fetch from dynamo

### DIFF
--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -137,14 +137,12 @@ def get_plugin_metrics(plugin: str) -> Response:
 
     :params str plugin: Name of the plugin in lowercase for which usage data needs to be fetched.
     :query_params limit: Number of months to be fetched for timeline. (default=12).
-    :query_params use_dynamo_metric_usage: Fetch usage data from dynamo if True else fetch from s3. (default=False)
     :query_params use_dynamo_metric_maintenance: Fetch maintenance data from dynamo if True else fetch from s3.
                   (default=False)
     """
     return jsonify(get_metrics_for_plugin(
         plugin=plugin,
         limit=request.args.get('limit', '12'),
-        use_dynamo_for_usage=_is_query_param_true('use_dynamo_metric_usage'),
         use_dynamo_for_maintenance=_is_query_param_true('use_dynamo_metric_maintenance'),
     ))
 

--- a/backend/api/s3.py
+++ b/backend/api/s3.py
@@ -6,11 +6,9 @@ import os
 import os.path
 import time
 from datetime import datetime
-from io import StringIO
 from typing import Union, IO, List, Dict, Any
 
 import boto3
-import pandas as pd
 from botocore.client import Config
 from botocore.exceptions import ClientError
 from utils.utils import send_alert
@@ -80,20 +78,6 @@ def _get_from_s3(path):
     return s3_client.get_object(Bucket=bucket, Key=_get_complete_path(path))['Body'].read().decode('utf-8')
 
 
-def get_install_timeline_data(plugin):
-    """
-    Read activity dashboard install data from s3
-
-    :param plugin: plugin name
-    :return: dataframe that consists of plugin-specific data for activity_dashboard backend endpoints
-    """
-    plugin_installs_dataframe = pd.read_csv(StringIO(_get_from_s3("activity_dashboard_data/plugin_installs.csv")))
-    plugin_df = plugin_installs_dataframe[plugin_installs_dataframe.PROJECT == plugin]
-    plugin_df = plugin_df[['MONTH', 'NUM_DOWNLOADS_BY_MONTH']]
-    plugin_df['MONTH'] = pd.to_datetime(plugin_df['MONTH'])
-    return plugin_df
-
-
 def _load_json_from_s3(path: str) -> Dict:
     """
     Load activity dashboard .json file from s3
@@ -106,10 +90,6 @@ def _load_json_from_s3(path: str) -> Dict:
     except Exception as e:
         logging.error(e)
         return {}
-
-
-def get_recent_activity_data() -> Dict:
-    return _load_json_from_s3("activity_dashboard_data/recent_installs.json")
 
 
 def get_latest_commit(plugin: str) -> Any:

--- a/backend/bdd_tests/scenarios/metric.feature
+++ b/backend/bdd_tests/scenarios/metric.feature
@@ -45,51 +45,6 @@ Feature: metrics
     And it should have zero values for maintenance.stats
 
 
-  Scenario: metrics api for valid plugin and use_dynamo_metric_usage=true
-    Given we call metrics api for napari-assistant and use_dynamo_metric_usage=true
-    Then response status is 200
-    And it should only have properties usage, maintenance
-    And it should have 12 entries for usage.timeline
-    And it should have at least one non-zero installs in usage.timeline
-    And it should have non-zero values for usage.stats
-    And it should have 12 entries for maintenance.timeline
-    And it should have at least one non-zero commits in maintenance.timeline
-    And it should have non-zero values for maintenance.stats
-
-  Scenario: metrics api for invalid plugin and use_dynamo_metric_usage=true
-    Given we call metrics api for foo and use_dynamo_metric_usage=true
-    Then response status is 200
-    And it should only have properties usage, maintenance
-    And it should have 12 entries for usage.timeline
-    And it should have all zero installs in usage.timeline
-    And it should have zero values for usage.stats
-    And it should have 12 entries for maintenance.timeline
-    And it should have all zero commits in maintenance.timeline
-    And it should have zero values for maintenance.stats
-
-  Scenario: metrics api for valid plugin with limit and use_dynamo_metric_usage=true
-    Given we call metrics api for napari-assistant with limit 5 and use_dynamo_metric_usage=true
-    Then response status is 200
-    And it should only have properties usage, maintenance
-    And it should have 5 entries for usage.timeline
-    And it should have at least one non-zero installs in usage.timeline
-    And it should have non-zero values for usage.stats
-    And it should have 5 entries for maintenance.timeline
-    And it should have at least one non-zero commits in maintenance.timeline
-    And it should have non-zero values for maintenance.stats
-
-  Scenario: metrics api for invalid plugin with limit and use_dynamo_metric_usage=true
-    Given we call metrics api for foo with limit 15 and use_dynamo_metric_usage=true
-    Then response status is 200
-    And it should only have properties usage, maintenance
-    And it should have 15 entries for usage.timeline
-    And it should have all zero installs in usage.timeline
-    And it should have zero values for usage.stats
-    And it should have 15 entries for maintenance.timeline
-    And it should have all zero commits in maintenance.timeline
-    And it should have zero values for maintenance.stats
-
-
   Scenario: metrics api for valid plugin and use_dynamo_metric_maintenance=true
     Given we call metrics api for napari-assistant and use_dynamo_metric_maintenance=true
     Then response status is 200


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
4. Include screenshots / videos for PRs if there are visual changes.

A good example is https://github.com/chanzuckerberg/napari-hub/pull/77.
-->

## Description
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Set the status for the issue to “Pending QA & Release” upon merging
		- Provide a checklist of any relevant pre-deployment notes, e.g. whether a config or database change is needed
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Relates to https://github.com/chanzuckerberg/napari-hub/issues/856

Clean up the api to return metrics.usage data from dynamo without a query parameter check. 