### PR TITLE
Home page redesign analytics

### DIFF
--- a/frontend/src/components/HomePage/FeaturedPlugins.tsx
+++ b/frontend/src/components/HomePage/FeaturedPlugins.tsx
@@ -47,6 +47,11 @@ export function FeaturedPlugins() {
         <PluginSection
           icon={SampleData}
           plugins={pluginTypeSection.plugins}
+          pluginType={pluginTypeSection.type}
+          row={0}
+          section={t('homePage:pluginSectionTitles.pluginTypes', {
+            type: pluginTypeLabels[pluginTypeSection.type],
+          })}
           seeAllLink={`/plugins?pluginType=${pluginTypeSection.type}`}
           title={
             <span className="flex items-center gap-x-sds-s">
@@ -63,30 +68,36 @@ export function FeaturedPlugins() {
       {newestSection && (
         <PluginSection
           icon={Newest}
+          metadataToShow={['first_released']}
           plugins={newestSection.plugins}
+          row={1}
+          section={t('homePage:newest')}
           seeAllLink="/plugins?sort=newest"
           title={t('homePage:newest')}
-          metadataToShow={['first_released']}
         />
       )}
 
       {recentlyUpdatedSection && (
         <PluginSection
           icon={RecentlyUpdated}
+          metadataToShow={['release_date']}
           plugins={recentlyUpdatedSection.plugins}
+          row={2}
+          section={t('homePage:recentlyUpdated')}
           seeAllLink="/plugins?sort=recentlyUpdated"
           title={t('homePage:recentlyUpdated')}
-          metadataToShow={['release_date']}
         />
       )}
 
       {topInstallsSection && (
         <PluginSection
           icon={TrendingInstalls}
+          metadataToShow={['total_installs']}
           plugins={topInstallsSection.plugins}
+          row={3}
+          section={t('homePage:pluginSectionTitles.trendingInstalls')}
           seeAllLink="/plugins?sort=totalInstalls"
           title={t('homePage:pluginSectionTitles.trendingInstalls')}
-          metadataToShow={['total_installs']}
         />
       )}
     </div>

--- a/frontend/src/components/HomePage/PluginCard.tsx
+++ b/frontend/src/components/HomePage/PluginCard.tsx
@@ -7,12 +7,17 @@ import { useMemo } from 'react';
 import { Link } from '@/components/Link';
 import { SkeletonLoader } from '@/components/SkeletonLoader';
 import { Text } from '@/components/Text';
-import { I18nKeys, PluginHomePageData } from '@/types';
+import { usePlausible } from '@/hooks';
+import { I18nKeys, PluginHomePageData, PluginType } from '@/types';
 
 interface Props {
   className?: string;
+  column: number;
   metadataToShow?: (keyof PluginHomePageData)[];
   plugin: PluginHomePageData;
+  pluginType?: PluginType;
+  row: number;
+  section: string;
 }
 
 const MAX_AUTHORS_COUNT = 3;
@@ -56,8 +61,17 @@ function MetadataValue({
   return <>plugin[pluginKey]</>;
 }
 
-export function PluginCard({ className, metadataToShow, plugin }: Props) {
+export function PluginCard({
+  className,
+  column,
+  metadataToShow,
+  plugin,
+  pluginType,
+  row,
+  section,
+}: Props) {
   const { t } = useTranslation(['pluginData']);
+  const plausible = usePlausible();
 
   return (
     <SkeletonLoader
@@ -71,6 +85,19 @@ export function PluginCard({ className, metadataToShow, plugin }: Props) {
             className,
           )}
           href={`/plugins/${plugin.name}`}
+          onClick={() =>
+            plausible('Home Plugin Section Click', {
+              row,
+              column,
+              plugin_name: plugin.name,
+              section,
+
+              // Only add `plugin_type` to payload if defined
+              ...(typeof pluginType === 'string'
+                ? { plugin_type: pluginType }
+                : {}),
+            })
+          }
         >
           <div>
             <Text variant="h4">{plugin.display_name || plugin.name}</Text>

--- a/frontend/src/components/HomePage/PluginSection.tsx
+++ b/frontend/src/components/HomePage/PluginSection.tsx
@@ -4,24 +4,30 @@ import { ComponentType, ReactNode } from 'react';
 import { IconProps } from '@/components/icons/icons.type';
 import { Link } from '@/components/Link';
 import { Text } from '@/components/Text';
-import { PluginHomePageData } from '@/types';
+import { PluginHomePageData, PluginType } from '@/types';
 
 import { PluginCard } from './PluginCard';
 
 interface Props {
   icon: ComponentType<IconProps>;
-  title: ReactNode;
-  seeAllLink: string;
-  plugins: PluginHomePageData[];
   metadataToShow?: (keyof PluginHomePageData)[];
+  plugins: PluginHomePageData[];
+  pluginType?: PluginType;
+  row: number;
+  section: string;
+  seeAllLink: string;
+  title: ReactNode;
 }
 
 export function PluginSection({
   icon: Icon,
-  title,
-  seeAllLink,
-  plugins,
   metadataToShow,
+  plugins,
+  pluginType,
+  row,
+  section,
+  seeAllLink,
+  title,
 }: Props) {
   return (
     <div className="col-span-2 screen-875:col-span-3 screen-1425:col-start-2">
@@ -45,9 +51,14 @@ export function PluginSection({
         {plugins.map((plugin, index) => (
           <PluginCard
             className={clsx(index === 2 && 'hidden screen-875:flex')}
-            key={plugin.name}
-            plugin={plugin}
+            column={index}
+            // eslint-disable-next-line react/no-array-index-key
+            key={`${plugin.name}-${index}`}
             metadataToShow={metadataToShow}
+            plugin={plugin}
+            pluginType={pluginType}
+            row={row}
+            section={section}
           />
         ))}
       </div>

--- a/frontend/src/hooks/usePlausible.ts
+++ b/frontend/src/hooks/usePlausible.ts
@@ -1,6 +1,6 @@
 import { usePlausible as usePlausibleNext } from 'next-plausible';
 
-import { PluginTabType } from '@/types/plugin';
+import { PluginTabType, PluginType } from '@/types/plugin';
 import { Logger } from '@/utils';
 
 const logger = new Logger('usePlausible.ts');
@@ -61,6 +61,14 @@ export type Events = {
   'Plugin Tab Nav': {
     plugin: string;
     tab: PluginTabType;
+  };
+
+  'Home Plugin Section Click': {
+    column: number;
+    plugin_name: string;
+    plugin_type?: PluginType;
+    row: number;
+    section: string;
   };
 };
 


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
4. Include screenshots / videos for PRs if there are visual changes.

A good example is https://github.com/chanzuckerberg/napari-hub/pull/77.
-->

## Description
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Set the status for the issue to “Pending QA & Release” upon merging
		- Provide a checklist of any relevant pre-deployment notes, e.g. whether a config or database change is needed
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

#1037

Adds a new event called `Home Plugin Section Click` with the following data:

```ts
enum PluginType {
  Widget = 'widget',
  Reader = 'reader',
  Writer = 'writer',
  SampleData = 'sample_data',
  Theme = 'theme',
}

interface Events {
  'Home Plugin Section Click': {
    column: number
    plugin_name: string
    plugin_type?: PluginType
    row: number
    section: string
  }
}
```

## Demos
<!-- Optional but recommended. Remove if not in use -->

<img width="449" alt="image" src="https://github.com/chanzuckerberg/napari-hub/assets/2176050/be8324d3-4923-42b5-8f9f-4cb9f3449542">

