### PR TITLE
Improve Enforce Release Label Workflow

### DIFF
--- a/.github/check-labels.js
+++ b/.github/check-labels.js
@@ -22,7 +22,7 @@ module.exports = async ({github, context, core}) => {
     const botCommentBody = "⚠️ This PR does not have a [release label](https://github.com/chanzuckerberg/napari-hub/blob/main/.github/release-notes.config.js). Please add one before merging.";
 
     const comments = await github.rest.issues.listComments({
-         owner: context.repo.owner,
+        owner: context.repo.owner,
         repo: context.repo.repo,
         issue_number: pr.number,
     });
@@ -33,10 +33,10 @@ module.exports = async ({github, context, core}) => {
         // If the PR does not have a release label and if the bot has not left a comment before, leave a comment and fail the test.  
         if (botComments.length === 0) {
             await github.rest.issues.createComment({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: pr.number,
-            body: botCommentBody,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: botCommentBody,
             });
 
             core.setFailed("Missing release label");

--- a/.github/check-labels.js
+++ b/.github/check-labels.js
@@ -20,7 +20,7 @@ module.exports = async ({github, context, core}) => {
   const hasRequiredLabel = labelNames.some((name) => configLabels.includes(name));
 
   if (!hasRequiredLabel) {
-    await github.issues.createComment({
+    await github.rest.issues.createComment({
       owner: context.repo.owner,
       repo: context.repo.repo,
       issue_number: pr.number,

--- a/.github/check-labels.js
+++ b/.github/check-labels.js
@@ -8,7 +8,7 @@ module.exports = async ({github, context, core}) => {
     return;
   }
 
-  const labels = await github.issues.listLabelsOnIssue({
+  const labels = await github.rest.issues.listLabelsOnIssue({
     owner: context.repo.owner,
     repo: context.repo.repo,
     issue_number: pr.number,

--- a/.github/check-labels.js
+++ b/.github/check-labels.js
@@ -1,41 +1,32 @@
-const github = require('@actions/github');
-const { Octokit } = require("@octokit/rest");
 const config = require('./release-notes.config')
 
-const octokit = new Octokit({
-  auth: process.env.GITHUB_TOKEN,
-});
-
-async function run() {
-  const { context = {} } = github;
-  const { pull_request: pr } = context.payload;
+module.exports = async ({github, context, core}) => {
+  const pr = context.payload.pull_request;
 
   if (!pr) {
-    console.log("Could not get PR number from context.");
+    console.log("Could not get PR from context");
     return;
   }
 
-  const { data: labels } = await octokit.issues.listLabelsOnIssue({
+  const labels = await github.issues.listLabelsOnIssue({
     owner: context.repo.owner,
     repo: context.repo.repo,
     issue_number: pr.number,
   });
 
-  const labelNames = labels.map((label) => label.name);
+  const labelNames = labels.data.map((label) => label.name);
   const configLabels = config.categories.flatMap((category) => category.labels);
 
   const hasRequiredLabel = labelNames.some((name) => configLabels.includes(name));
 
   if (!hasRequiredLabel) {
-    await octokit.issues.createComment({
+    await github.issues.createComment({
       owner: context.repo.owner,
       repo: context.repo.repo,
       issue_number: pr.number,
       body: "⚠️ This PR does not have a [release label](https://github.com/chanzuckerberg/napari-hub/blob/main/.github/release-notes.config.js). Please add one before merging.",
     });
 
-    throw new Error("Missing required label");
+    core.setFailed("Missing release label");
   }
 }
-
-run();

--- a/.github/check-labels.js
+++ b/.github/check-labels.js
@@ -1,32 +1,54 @@
 const config = require('./release-notes.config')
 
 module.exports = async ({github, context, core}) => {
-  const pr = context.payload.pull_request;
+    const pr = context.payload.pull_request;
 
-  if (!pr) {
-    console.log("Could not get PR from context");
-    return;
-  }
+    if (!pr) {
+        console.log("Could not get PR from context");
+        return;
+    }
 
-  const labels = await github.rest.issues.listLabelsOnIssue({
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    issue_number: pr.number,
-  });
-
-  const labelNames = labels.data.map((label) => label.name);
-  const configLabels = config.categories.flatMap((category) => category.labels);
-
-  const hasRequiredLabel = labelNames.some((name) => configLabels.includes(name));
-
-  if (!hasRequiredLabel) {
-    await github.rest.issues.createComment({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      issue_number: pr.number,
-      body: "⚠️ This PR does not have a [release label](https://github.com/chanzuckerberg/napari-hub/blob/main/.github/release-notes.config.js). Please add one before merging.",
+    const labels = await github.rest.issues.listLabelsOnIssue({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: pr.number,
     });
 
-    core.setFailed("Missing release label");
-  }
+    const labelNames = labels.data.map((label) => label.name);
+    const configLabels = config.categories.flatMap((category) => category.labels);
+    const hasRequiredLabel = labelNames.some((name) => configLabels.includes(name));
+
+    const botCommentBody = "⚠️ This PR does not have a [release label](https://github.com/chanzuckerberg/napari-hub/blob/main/.github/release-notes.config.js). Please add one before merging.";
+
+    const comments = await github.rest.issues.listComments({
+         owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: pr.number,
+    });
+
+    const botComments = comments.data.filter((comment) => comment.user.login === 'github-actions' && comment.body === botCommentBody);
+
+    if (!hasRequiredLabel) {
+        // If the PR does not have a release label and if the bot has not left a comment before, leave a comment and fail the test.  
+        if (botComments.length === 0) {
+            await github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: pr.number,
+            body: botCommentBody,
+            });
+
+            core.setFailed("Missing release label");
+        }
+    } else if (botComments.length > 0) {
+        // If the PR has a release label and the bot has left a comment before, delete it since it is no longer needed.
+        for (let comment of botComments) {
+            await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: comment.id,
+            });
+        }
+    }
 }
+  

--- a/.github/check-labels.js
+++ b/.github/check-labels.js
@@ -26,7 +26,7 @@ module.exports = async ({github, context, core}) => {
         issue_number: pr.number,
     });
 
-    const botComments = comments.data.filter((comment) => comment.user.login === 'github-actions' && comment.body === botCommentBody);
+    const botComments = comments.data.filter((comment) => comment.user.login === 'github-actions[bot]' && comment.body === botCommentBody);
 
     if (!hasRequiredLabel) {
         // If the PR does not have a release label and if the bot has not left a comment before, leave a comment and fail the test.  

--- a/.github/check-labels.js
+++ b/.github/check-labels.js
@@ -1,0 +1,41 @@
+const github = require('@actions/github');
+const { Octokit } = require("@octokit/rest");
+const config = require('./release-notes.config')
+
+const octokit = new Octokit({
+  auth: process.env.GITHUB_TOKEN,
+});
+
+async function run() {
+  const { context = {} } = github;
+  const { pull_request: pr } = context.payload;
+
+  if (!pr) {
+    console.log("Could not get PR number from context.");
+    return;
+  }
+
+  const { data: labels } = await octokit.issues.listLabelsOnIssue({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: pr.number,
+  });
+
+  const labelNames = labels.map((label) => label.name);
+  const configLabels = config.categories.flatMap((category) => category.labels);
+
+  const hasRequiredLabel = labelNames.some((name) => configLabels.includes(name));
+
+  if (!hasRequiredLabel) {
+    await octokit.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: pr.number,
+      body: "⚠️ This PR does not have a [release label](https://github.com/chanzuckerberg/napari-hub/blob/main/.github/release-notes.config.js). Please add one before merging.",
+    });
+
+    throw new Error("Missing required label");
+  }
+}
+
+run();

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -11,8 +11,7 @@ on:
       - unlabeled
       - ready_for_review
     branches:
-      #- main
-      - joshua/enforce-release-label-workflow # TODO: Remove this comment before PR
+      - main
 
 jobs:
   checkLabels:

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -11,7 +11,8 @@ on:
       - unlabeled
       - ready_for_review
     branches:
-        - main
+      #- main
+      - joshua/enforce-release-label-workflow
 
 jobs:
   checkLabels:

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -1,6 +1,6 @@
 # Workflow for enforcing labels for on main branch PRs
 
-name: Enforce Labels
+name: Enforce Release Labels
 
 on:
   pull_request_target:

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -1,4 +1,5 @@
 # Workflow for enforcing labels for on main branch PRs
+# .github/workflows/enforce-labels.yml
 
 name: Enforce Release Labels
 
@@ -21,19 +22,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Use Node.js
+      - name: Install Node.js
         uses: actions/setup-node@v2
-        with:
-            node-version: '20'
-
 
       - name: Install dependencies
-        run: npm install @octokit/rest @actions/github
+        run: npm install
 
       - name: Check for labels
-        run: |
-          node .github/check-labels.js
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const checkLabels = require('./.github/check-labels.js');
+            checkLabels({github, context, core});

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -11,7 +11,8 @@ on:
       - unlabeled
       - ready_for_review
     branches:
-      - main
+      #- main
+      - joshua/enforce-release-label-workflow # TODO: Remove this comment before PR
 
 jobs:
   checkLabels:

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -1,0 +1,38 @@
+# Workflow for enforcing labels for on main branch PRs
+
+name: Enforce Labels
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - labeled
+      - unlabeled
+      - ready_for_review
+    branches:
+        - main
+
+jobs:
+  checkLabels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+            node-version: '20'
+
+
+      - name: Install dependencies
+        run: npm install @octokit/rest @actions/github
+
+      - name: Check for labels
+        run: |
+          node .github/check-labels.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -25,11 +25,8 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v2
 
-      - name: Install dependencies
-        run: npm install
-
       - name: Check for labels
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           script: |
             const checkLabels = require('./.github/check-labels.js');

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -1,5 +1,4 @@
 # Workflow for enforcing labels for on main branch PRs
-# .github/workflows/enforce-labels.yml
 
 name: Enforce Release Labels
 
@@ -12,8 +11,7 @@ on:
       - unlabeled
       - ready_for_review
     branches:
-      #- main
-      - joshua/enforce-release-label-workflow
+      - main
 
 jobs:
   checkLabels:


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
4. Include screenshots / videos for PRs if there are visual changes.

A good example is https://github.com/chanzuckerberg/napari-hub/pull/77.
-->

## Description
An improvement of the new enforce release label workflow. Now once a release label has been added to the PR all previous warning notifications are deleted.
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Set the status for the issue to “Pending QA & Release” upon merging
		- Provide a checklist of any relevant pre-deployment notes, e.g. whether a config or database change is needed
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Demos
Workflow working on #1149 (all the bot comments have been deleted)
<!-- Optional but recommended. Remove if not in use -->
