### PR TITLE
Remove trending installs section

### DIFF
--- a/frontend/src/components/HomePage/FeaturedPlugins.tsx
+++ b/frontend/src/components/HomePage/FeaturedPlugins.tsx
@@ -1,12 +1,7 @@
 import clsx from 'clsx';
 import { useTranslation } from 'next-i18next';
 
-import {
-  Newest,
-  RecentlyUpdated,
-  SampleData,
-  TrendingInstalls,
-} from '@/components/icons';
+import { Newest, RecentlyUpdated, SampleData } from '@/components/icons';
 import { useLoadingState } from '@/context/loading';
 
 import { SkeletonLoader } from '../SkeletonLoader';
@@ -23,7 +18,6 @@ export function FeaturedPlugins() {
     plugin_types: pluginTypeSection,
     newest: newestSection,
     recently_updated: recentlyUpdatedSection,
-    top_installed: topInstallsSection,
   } = pluginSections;
 
   return (
@@ -86,18 +80,6 @@ export function FeaturedPlugins() {
           section={t('homePage:recentlyUpdated')}
           seeAllLink="/plugins?sort=recentlyUpdated"
           title={t('homePage:recentlyUpdated')}
-        />
-      )}
-
-      {topInstallsSection && (
-        <PluginSection
-          icon={TrendingInstalls}
-          metadataToShow={['total_installs']}
-          plugins={topInstallsSection.plugins}
-          row={3}
-          section={t('homePage:pluginSectionTitles.trendingInstalls')}
-          seeAllLink="/plugins?sort=totalInstalls"
-          title={t('homePage:pluginSectionTitles.trendingInstalls')}
         />
       )}
     </div>

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -36,7 +36,6 @@ export const getServerSideProps = getServerSidePropsHandler<Props>({
           PluginSectionType.pluginType,
           PluginSectionType.newest,
           PluginSectionType.recentlyUpdated,
-          PluginSectionType.topInstalls,
         ]);
       } else {
         const index = await hubAPI.getPluginIndex();


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
4. Include screenshots / videos for PRs if there are visual changes.

A good example is https://github.com/chanzuckerberg/napari-hub/pull/77.
-->

## Description
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Set the status for the issue to “Pending QA & Release” upon merging
		- Provide a checklist of any relevant pre-deployment notes, e.g. whether a config or database change is needed
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Removes `Trending Installs` section from home page redesign