### PR TITLE
Adding s3 read permission to data workflow for categories

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -542,6 +542,10 @@ data aws_iam_policy_document backend_policy {
 
 data aws_iam_policy_document data_workflows_policy {
   statement {
+    actions = ["s3:GetObject",]
+    resources = ["${local.data_bucket_arn}/*"]
+  }
+  statement {
     actions = [
       "dynamodb:BatchWriteItem",
       "dynamodb:GetItem",


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
4. Include screenshots / videos for PRs if there are visual changes.

A good example is https://github.com/chanzuckerberg/napari-hub/pull/77.
-->

## Description
Relates to: https://github.com/chanzuckerberg/napari-hub/issues/1174

Adding s3 read permissions back to data-workflows, as they are used for seeding category data.


> how this bug was introduced? 

It was introduced as a part of maintenance cleanup, where we replaced the s3 supported plugin code_repo fetch with dynamo calls.  (https://github.com/chanzuckerberg/napari-hub/pull/1148/commits/bcfc7aa3504ca557a942a040b45746ac9371c3f7)

> what the current user impact of it is? And is it critical to get released to prod soon?

This should not have any user impact, as this issue will only be raised when we try to seed the category data. All environments currently have category data, and this workflow should not be needed in the foreseeable future.  This can wait until the next release to go to prod and is not urgent. 