### PR TITLE
Metrics feature flag clean up

### DIFF
--- a/.happy/terraform/modules/cloudwatch-alarm/main.tf
+++ b/.happy/terraform/modules/cloudwatch-alarm/main.tf
@@ -71,20 +71,6 @@ resource aws_cloudwatch_log_metric_filter backend_plugin_update_successful {
   }
 }
 
-resource aws_cloudwatch_log_metric_filter backend_metrics_update_successful {
-  name            = "${var.stack_name}-backend-metrics-update-successful"
-  log_group_name  = var.backend_lambda_log_group_name
-  pattern         = "Completed data refresh for metrics successfully"
-  count           = var.metrics_enabled ? 1 : 0
-
-  metric_transformation {
-    name      = "${var.stack_name}-backend-metrics-update-successful"
-    namespace = local.metrics_namespace
-    value     = "1"
-    unit      = "Count"
-  }
-}
-
 resource aws_cloudwatch_log_metric_filter data_workflows_metrics_update_successful {
   name            = "${var.stack_name}-data-workflows-metrics-update-successful"
   log_group_name  = var.data_workflows_lambda_log_group_name
@@ -116,7 +102,6 @@ resource aws_cloudwatch_log_metric_filter data_workflows_plugin_update_successfu
 locals {
   backend_api_500_log_metric_name = var.metrics_enabled ? aws_cloudwatch_log_metric_filter.backend_api_500_log_metric[0].name : "backend_api_500_log_metric"
   backend_plugin_update_successful_name = var.metrics_enabled ? aws_cloudwatch_log_metric_filter.backend_plugin_update_successful[0].name : "backend_plugin_update_successful"
-  backend_metrics_update_successful_name = var.metrics_enabled ? aws_cloudwatch_log_metric_filter.backend_metrics_update_successful[0].name : "backend_metrics_update_successful"
   data_workflows_metrics_update_successful_name = var.metrics_enabled ? aws_cloudwatch_log_metric_filter.data_workflows_metrics_update_successful[0].name : "data_workflows_metrics_update_successful"
   data_workflows_plugin_update_successful_name = var.metrics_enabled ? aws_cloudwatch_log_metric_filter.data_workflows_plugin_update_successful[0].name : "data_workflows_plugin_update_successful"
 }
@@ -174,26 +159,6 @@ module data_workflow_plugins_missing_update_alarm {
   metric_name         = local.data_workflows_plugin_update_successful_name
   namespace           = local.metrics_namespace
   period              = local.period
-  statistic           = "Sum"
-  tags                = var.tags
-  threshold           = 1
-  treat_missing_data  = "breaching"
-}
-
-module backend_metrics_missing_update_alarm {
-  source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
-  version = "3.3.0"
-
-  alarm_actions       = [local.alarm_sns_arn]
-  alarm_name          = "${var.stack_name}-backend-metrics-missing-update-alarm"
-  alarm_description   = "Metrics update failure for backend"
-  comparison_operator = "LessThanThreshold"
-  create_metric_alarm = var.alarms_enabled
-  datapoints_to_alarm = 1
-  evaluation_periods  = 1
-  metric_name         = local.backend_metrics_update_successful_name
-  namespace           = local.metrics_namespace
-  period              = 86400
   statistic           = "Sum"
   tags                = var.tags
   threshold           = 1

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -437,18 +437,6 @@ resource "aws_cloudwatch_event_rule" "activity_rule" {
   tags                = var.tags
 }
 
-resource "aws_cloudwatch_event_target" "activity_target" {
-    rule = aws_cloudwatch_event_rule.activity_rule.name
-    arn = module.backend_lambda.function_arn
-    input_transformer {
-        input_template = jsonencode({
-          path = "/activity/update",
-          httpMethod = "POST",
-          headers = {"X-API-Key": random_uuid.api_key.result}
-        })
-    }
-}
-
 resource aws_cloudwatch_event_target activity_target_sqs {
     rule = aws_cloudwatch_event_rule.activity_rule.name
     arn = aws_sqs_queue.data_workflows_queue.arn
@@ -467,10 +455,6 @@ locals {
       service    = "events"
       source_arn = aws_cloudwatch_event_rule.update_rule.arn
     },
-    AllowExecutionFromCloudWatchForActivity = {
-      service    = "events"
-      source_arn = aws_cloudwatch_event_rule.activity_rule.arn
-    }
   }
 }
 

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -285,8 +285,6 @@ module backend_lambda {
     "DD_SERVICE" = local.custom_stack_name
     "API_URL" = var.env == "dev" ? module.api_gateway_proxy_stage.invoke_url : ""
     "PLUGINS_LAMBDA_NAME" = local.plugins_function_name
-    "SNOWFLAKE_USER" = local.snowflake_user
-    "SNOWFLAKE_PASSWORD" = local.snowflake_password
     "API_KEY" = random_uuid.api_key.result
     "STACK_NAME" = local.custom_stack_name
   }

--- a/backend/api/_tests/test_fixtures.py
+++ b/backend/api/_tests/test_fixtures.py
@@ -1,12 +1,11 @@
-import pandas as pd
 from dateutil.relativedelta import relativedelta
-from datetime import datetime
+from datetime import datetime, date, timezone
 
-BASE = datetime.today().date().replace(day=1)
+BASE = datetime.combine(date.today(), datetime.min.time()).replace(day=1, tzinfo=timezone.utc)
 
 
 def _to_timestamp(i):
-    return int(pd.Timestamp(BASE + relativedelta(months=i)).timestamp()) * 1000
+    return int((BASE + relativedelta(months=i)).timestamp()) * 1000
 
 
 def _generate_timeline(start_range, value_key, to_value, timestamp_key='timestamp'):

--- a/backend/api/_tests/test_metrics.py
+++ b/backend/api/_tests/test_metrics.py
@@ -1,68 +1,116 @@
+from typing import Dict
+from unittest.mock import Mock
+
 import pytest
 
 from api import metrics
-from api._tests.test_fixtures import generate_commits_timeline, generate_installs_timeline
+from api._tests.test_fixtures import (
+    generate_commits_timeline,
+    generate_installs_timeline,
+)
 
-PLUGIN_NAME = 'StrIng-1'
-PLUGIN_NAME_CLEAN = 'string-1'
-MOCK_PLUGIN_LATEST_COMMIT = 1672531200000
-MOCK_PLUGIN_COMMIT_ACTIVITY = generate_commits_timeline(start_range=-5)
-MOCK_PLUGIN_TOTAL_COMMITS = sum([activity.get('commits') for activity in MOCK_PLUGIN_COMMIT_ACTIVITY])
-MOCK_PLUGIN_OBJ_EMPTY = {}
-MOCK_PLUGIN_OBJ = {"name": "string-1", "code_repository": "https://github.com/user/repo"}
+PLUGIN_NAME = "StrIng-1"
+PLUGIN_NAME_CLEAN = "string-1"
+MOCK_EMPTY_PLUGIN = {}
+REPO = "user/repo"
+MOCK_PLUGIN_OBJ = {"name": "string-1", "code_repository": f"https://github.com/{REPO}"}
 
-USAGE_TIMELINE = generate_installs_timeline(start_range=-3)
+MAINTENANCE_TIMELINE = generate_commits_timeline(
+    start_range=-3, to_value=lambda i: i * 3
+)
+LATEST_COMMIT = 1672531200000
+TOTAL_COMMITS = 153
+USAGE_TIMELINE = generate_installs_timeline(start_range=-3, to_value=lambda i: i + 8)
+TOTAL_INSTALLS = 983
+RECENT_INSTALLS = 54
 
 
-def generate_expected_metrics(usage_timeline=None, total_installs=0, installs_in_last_30_days=0,
-                              latest_commit=None, total_commit=0, maintenance_timeline=None):
+def generate_expected_metrics(limit: int):
     return {
-        'usage': {
-            'timeline': usage_timeline if usage_timeline else [],
-            'stats': {
-                'total_installs': total_installs,
-                'installs_in_last_30_days': installs_in_last_30_days
-            }
+        "usage": {
+            "timeline": USAGE_TIMELINE if limit else [],
+            "stats": {
+                "total_installs": TOTAL_INSTALLS,
+                "installs_in_last_30_days": RECENT_INSTALLS,
+            },
         },
-        'maintenance': {
-            'timeline': maintenance_timeline if maintenance_timeline else [],
-            'stats': {
-                'latest_commit_timestamp': latest_commit,
-                'total_commits': total_commit
-            }
-        }
+        "maintenance": {
+            "timeline": MAINTENANCE_TIMELINE if limit else [],
+            "stats": {
+                "latest_commit_timestamp": LATEST_COMMIT,
+                "total_commits": TOTAL_COMMITS,
+            },
+        },
     }
 
 
 class TestMetricModel:
+    @pytest.fixture(autouse=True)
+    def get_plugin(self, monkeypatch) -> None:
+        self._get_plugin = Mock(side_effect=lambda plugin: self._plugin)
+        monkeypatch.setattr(metrics.plugin, "get_plugin", self._get_plugin)
 
-    @pytest.mark.parametrize('maintenance_timeline, latest_commit, total_commits, '
-                             'total_installs, recent_installs, usage_timeline, limit, get_plugin', [
-        (generate_commits_timeline(start_range=-3, to_value=lambda i: 0), None, 0, 0, 0,
-         generate_installs_timeline(start_range=-3, to_value=lambda i: 0), '3', MOCK_PLUGIN_OBJ_EMPTY),
-        ([], MOCK_PLUGIN_LATEST_COMMIT, MOCK_PLUGIN_TOTAL_COMMITS, 25, 21, [], '0', MOCK_PLUGIN_OBJ),
-        ([], MOCK_PLUGIN_LATEST_COMMIT, MOCK_PLUGIN_TOTAL_COMMITS, 25, 21, [], 'foo', MOCK_PLUGIN_OBJ),
-        ([], MOCK_PLUGIN_LATEST_COMMIT, MOCK_PLUGIN_TOTAL_COMMITS, 25, 21, [], '-5', MOCK_PLUGIN_OBJ),
-        (generate_installs_timeline(start_range=-3), MOCK_PLUGIN_LATEST_COMMIT, MOCK_PLUGIN_TOTAL_COMMITS, 25, 21,
-         generate_installs_timeline(start_range=-3), '3', MOCK_PLUGIN_OBJ)])
-    def test_metrics_api_using_dynamo(self, monkeypatch, maintenance_timeline, latest_commit,
-                                      total_commits, total_installs, recent_installs, usage_timeline, limit, get_plugin):
-        monkeypatch.setattr(metrics, 'get_plugin', self._validate_args_return_value(get_plugin))
-        monkeypatch.setattr(metrics.github_activity, 'get_total_commits', self._validate_args_return_value(total_commits))
-        monkeypatch.setattr(metrics.github_activity, 'get_latest_commit', self._validate_args_return_value(latest_commit))
-        monkeypatch.setattr(metrics.github_activity, 'get_timeline', self._validate_args_return_value(maintenance_timeline))
-        monkeypatch.setattr(metrics.install_activity, 'get_total_installs', self._validate_args_return_value(total_installs))
-        monkeypatch.setattr(metrics.install_activity, 'get_recent_installs', self._validate_args_return_value(recent_installs))
-        monkeypatch.setattr(metrics.install_activity, 'get_timeline', self._validate_args_return_value(usage_timeline))
-
-        actual = metrics.get_metrics_for_plugin(PLUGIN_NAME, limit)
-
-        expected = generate_expected_metrics(
-            total_installs=total_installs, installs_in_last_30_days=recent_installs, usage_timeline=usage_timeline,
-            latest_commit=latest_commit, total_commit=total_commits, maintenance_timeline=maintenance_timeline
+    @pytest.fixture(autouse=True)
+    def maintenance_mocks(self, monkeypatch) -> None:
+        self._get_maintenance_timeline = Mock(return_value=MAINTENANCE_TIMELINE)
+        monkeypatch.setattr(
+            metrics.github_activity, "get_timeline", self._get_maintenance_timeline
         )
-        assert actual == expected
+        self._get_total_commits = Mock(return_value=TOTAL_COMMITS)
+        monkeypatch.setattr(
+            metrics.github_activity, "get_total_commits", self._get_total_commits
+        )
+        self._get_latest_commit = Mock(return_value=LATEST_COMMIT)
+        monkeypatch.setattr(
+            metrics.github_activity, "get_latest_commit", self._get_latest_commit
+        )
 
-    @staticmethod
-    def _validate_args_return_value(value):
-        return lambda *args, **kwargs: value if args[0] == PLUGIN_NAME_CLEAN else None
+    @pytest.fixture(autouse=True)
+    def usage_mocks(self, monkeypatch) -> None:
+        self._get_usage_timeline = Mock(return_value=USAGE_TIMELINE)
+        monkeypatch.setattr(
+            metrics.install_activity, "get_timeline", self._get_usage_timeline
+        )
+        self._get_total_installs = Mock(return_value=TOTAL_INSTALLS)
+        monkeypatch.setattr(
+            metrics.install_activity, "get_total_installs", self._get_total_installs
+        )
+        self._get_recent_installs = Mock(return_value=RECENT_INSTALLS)
+        monkeypatch.setattr(
+            metrics.install_activity, "get_recent_installs", self._get_recent_installs
+        )
+
+    @pytest.mark.parametrize(
+        "limit_str, limit, plugin, repo",
+        [
+            ("3", 3, MOCK_EMPTY_PLUGIN, None,),
+            ("0", 0, MOCK_PLUGIN_OBJ, REPO,),
+            ("foo", 0, MOCK_PLUGIN_OBJ, REPO,),
+            ("-5", 0, MOCK_PLUGIN_OBJ, REPO,),
+            ("3", 3, MOCK_PLUGIN_OBJ, REPO,),
+        ],
+    )
+    def test_get_metrics_for_plugin(
+            self, limit_str: str, limit: int, plugin: Dict, repo: str
+    ):
+        self._plugin = plugin
+
+        actual = metrics.get_metrics_for_plugin(PLUGIN_NAME, limit_str)
+
+        expected = generate_expected_metrics(limit)
+        assert actual == expected
+        self._get_plugin.assert_called_once_with(PLUGIN_NAME)
+
+        if limit > 0:
+            self._get_maintenance_timeline.assert_called_once_with(
+                PLUGIN_NAME_CLEAN, repo, limit
+            )
+            self._get_usage_timeline.assert_called_once_with(PLUGIN_NAME_CLEAN, limit)
+        else:
+            self._get_maintenance_timeline.assert_not_called()
+            self._get_usage_timeline.assert_not_called()
+
+        self._get_latest_commit.assert_called_once_with(PLUGIN_NAME_CLEAN, repo)
+        self._get_total_commits.assert_called_once_with(PLUGIN_NAME_CLEAN, repo)
+        self._get_total_installs.assert_called_once_with(PLUGIN_NAME_CLEAN)
+        self._get_recent_installs.assert_called_once_with(PLUGIN_NAME_CLEAN, 30)

--- a/backend/api/_tests/test_metrics.py
+++ b/backend/api/_tests/test_metrics.py
@@ -1,6 +1,6 @@
 import pytest
 
-from api import model
+from api import metrics
 from api._tests.test_fixtures import generate_commits_timeline, generate_installs_timeline
 
 PLUGIN_NAME = 'StrIng-1'
@@ -47,16 +47,15 @@ class TestMetricModel:
          generate_installs_timeline(start_range=-3), '3', MOCK_PLUGIN_OBJ)])
     def test_metrics_api_using_dynamo(self, monkeypatch, maintenance_timeline, latest_commit,
                                       total_commits, total_installs, recent_installs, usage_timeline, limit, get_plugin):
-        monkeypatch.setattr(model, 'get_plugin', self._validate_args_return_value(get_plugin))
-        monkeypatch.setattr(model.github_activity, 'get_total_commits', self._validate_args_return_value(total_commits))
-        monkeypatch.setattr(model.github_activity, 'get_latest_commit', self._validate_args_return_value(latest_commit))
-        monkeypatch.setattr(model.github_activity, 'get_timeline', self._validate_args_return_value(maintenance_timeline))
-        monkeypatch.setattr(model.install_activity, 'get_total_installs', self._validate_args_return_value(total_installs))
-        monkeypatch.setattr(model.install_activity, 'get_recent_installs', self._validate_args_return_value(recent_installs))
-        monkeypatch.setattr(model.install_activity, 'get_timeline', self._validate_args_return_value(usage_timeline))
+        monkeypatch.setattr(metrics, 'get_plugin', self._validate_args_return_value(get_plugin))
+        monkeypatch.setattr(metrics.github_activity, 'get_total_commits', self._validate_args_return_value(total_commits))
+        monkeypatch.setattr(metrics.github_activity, 'get_latest_commit', self._validate_args_return_value(latest_commit))
+        monkeypatch.setattr(metrics.github_activity, 'get_timeline', self._validate_args_return_value(maintenance_timeline))
+        monkeypatch.setattr(metrics.install_activity, 'get_total_installs', self._validate_args_return_value(total_installs))
+        monkeypatch.setattr(metrics.install_activity, 'get_recent_installs', self._validate_args_return_value(recent_installs))
+        monkeypatch.setattr(metrics.install_activity, 'get_timeline', self._validate_args_return_value(usage_timeline))
 
-        from api.model import get_metrics_for_plugin
-        actual = get_metrics_for_plugin(PLUGIN_NAME, limit)
+        actual = metrics.get_metrics_for_plugin(PLUGIN_NAME, limit)
 
         expected = generate_expected_metrics(
             total_installs=total_installs, installs_in_last_30_days=recent_installs, usage_timeline=usage_timeline,

--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -153,21 +153,17 @@ def update_activity() -> Response:
     return app.make_response(("Complete", 204))
 
 
-@app.route('/metrics/<plugin>')
+@app.route("/metrics/<plugin>")
 def get_plugin_metrics(plugin: str) -> Response:
     """
     Fetches plugin metrics for usage, and maintenance
     :return Response: A json object with entries for usage, and maintenance
 
-    :params str plugin: Name of the plugin in lowercase for which usage data needs to be fetched.
+    :params str plugin: Name of the plugin for which usage data needs to be fetched.
     :query_params limit: Number of months to be fetched for timeline. (default=12).
-    :query_params use_dynamo_metric_maintenance: Fetch maintenance data from dynamo if True else fetch from s3.
-                  (default=False)
     """
     return jsonify(get_metrics_for_plugin(
-        plugin=plugin,
-        limit=request.args.get('limit', '12'),
-        use_dynamo_for_maintenance=_is_query_param_true('use_dynamo_metric_maintenance'),
+        plugin=plugin, limit=request.args.get("limit", "12"),
     ))
 
 

--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -157,7 +157,7 @@ def get_plugin_metrics(plugin: str) -> Response:
     :query_params limit: Number of months to be fetched for timeline. (default=12).
     """
     return jsonify(get_metrics_for_plugin(
-        plugin=plugin, limit=request.args.get("limit", "12"),
+        name=plugin, limit=request.args.get("limit", "12"),
     ))
 
 

--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -12,9 +12,9 @@ from api.plugin_collections import get_collections, get_collection
 from api.custom_wsgi import script_path_middleware
 from api.model import (
     get_public_plugins, get_index, get_plugin, get_excluded_plugins,
-    update_cache, move_artifact_to_s3, get_manifest, update_activity_data,
-    get_metrics_for_plugin
+    update_cache, move_artifact_to_s3, get_manifest
 )
+from api.metrics import get_metrics_for_plugin
 from api.models import category as categories
 from api.shield import get_shield
 from utils.utils import send_alert, reformat_ssh_key_to_pem_bytes
@@ -145,12 +145,6 @@ def get_categories(version: str) -> Response:
 @app.route('/categories/<category>/versions/<version>')
 def get_category(category: str, version: str) -> Response:
     return jsonify(categories.get_category(category, version))
-
-
-@app.route('/activity/update', methods=['POST'])
-def update_activity() -> Response:
-    update_activity_data()
-    return app.make_response(("Complete", 204))
 
 
 @app.route("/metrics/<plugin>")

--- a/backend/api/metrics.py
+++ b/backend/api/metrics.py
@@ -1,16 +1,18 @@
+import logging
 from typing import Dict, Any
 
 from api.models.plugin import get_plugin
 from api.models import install_activity, github_activity
 
+logger = logging.getLogger(__name__)
 
-def get_metrics_for_plugin(plugin: str, limit: str,) -> Dict[str, Any]:
+
+def get_metrics_for_plugin(plugin: str, limit: str) -> Dict[str, Any]:
     """
-    Fetches plugin metrics from s3 or dynamo based on the in_test variable
-    :return dict[str, Any]: A map with entries for usage and maintenance
-
-    :params str plugin: Name of the plugin for which usage data needs to be fetched.
-    :params str limit_str: Number of records to be fetched for timeline. Defaults to 0
+    Fetches plugin metrics from dynamo
+    :return Dict[str, Any]: A dict with entries for usage and maintenance
+    :params str plugin: Plugin name for which metrics needs to be fetched.
+    :params str limit_str: Number of timeline records to be fetched. Defaults to 0
     for invalid number.
     """
     repo = _get_repo_from_plugin(plugin)
@@ -37,11 +39,10 @@ def _get_repo_from_plugin(plugin):
 
 def _get_usage_data(plugin: str, limit: int) -> Dict[str, Any]:
     """
-    Fetches plugin usage_data from s3 or dynamo based on the in_test variable
-    :returns (dict[str, Any]): A dict with the structure
-    {'timeline': List, 'stats': dict[str, int]}
+    Fetches plugin usage_data from dynamo.
+    :returns Dict[str, Any]: A dict with entries for timeline and stats.
     :params str plugin: Name of the plugin in lowercase.
-    :params int limit: Sets the number of records to be fetched for timeline.
+    :params int limit: The number of records to be fetched for timeline.
     """
     return {
         "timeline": install_activity.get_timeline(plugin, limit) if limit else [],
@@ -54,11 +55,11 @@ def _get_usage_data(plugin: str, limit: int) -> Dict[str, Any]:
 
 def _get_maintenance_data(plugin: str, repo: Any, limit: int) -> Dict[str, Any]:
     """
-    Fetches plugin maintenance_data from s3 or dynamo based on the in_test variable
-    :returns (dict[str, Any]): A dict with the structure {'timeline': List, 'stats': Dict[str, int]}
+    Fetches plugin maintenance_data from dynamo.
+    :returns Dict[str, Any]: A dict with entries for timeline and stats.
     :params str plugin: Name of the plugin in lowercase.
-    :params repo: Parameter used if use_dynamo_for_maintenance is true
-    :params int limit: Sets the number of records to be fetched for timeline.
+    :params repo: Name of the repo associated to the plugin.
+    :params int limit: The number of records to be fetched for timeline.
     """
     return {
         "timeline": github_activity.get_timeline(plugin, repo, limit) if limit else [],

--- a/backend/api/metrics.py
+++ b/backend/api/metrics.py
@@ -1,35 +1,34 @@
 import logging
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
-from api.models.plugin import get_plugin
-from api.models import install_activity, github_activity
+from api.models import install_activity, github_activity, plugin
 
 logger = logging.getLogger(__name__)
 
 
-def get_metrics_for_plugin(plugin: str, limit: str) -> Dict[str, Any]:
+def get_metrics_for_plugin(name: str, limit: str) -> Dict[str, Any]:
     """
     Fetches plugin metrics from dynamo
     :return Dict[str, Any]: A dict with entries for usage and maintenance
-    :params str plugin: Plugin name for which metrics needs to be fetched.
+    :params str name: Plugin name for which metrics needs to be fetched.
     :params str limit_str: Number of timeline records to be fetched. Defaults to 0
     for invalid number.
     """
-    repo = _get_repo_from_plugin(plugin)
-    plugin = plugin.lower()
+    repo = _get_repo_from_plugin(name)
+    name = name.lower()
     month_delta = 0
 
-    if limit.isdigit() and limit != "0":
+    if limit.isdigit():
         month_delta = max(int(limit), 0)
 
     return {
-        "usage": _get_usage_data(plugin, month_delta),
-        "maintenance": _get_maintenance_data(plugin, repo, month_delta),
+        "usage": _get_usage_data(name, month_delta),
+        "maintenance": _get_maintenance_data(name, repo, month_delta),
     }
 
 
-def _get_repo_from_plugin(plugin):
-    plugin_metadata = get_plugin(plugin)
+def _get_repo_from_plugin(name: str) -> Optional[str]:
+    plugin_metadata = plugin.get_plugin(name)
     if plugin_metadata:
         repo_url = plugin_metadata.get("code_repository")
         if repo_url:
@@ -37,34 +36,34 @@ def _get_repo_from_plugin(plugin):
     return None
 
 
-def _get_usage_data(plugin: str, limit: int) -> Dict[str, Any]:
+def _get_usage_data(name: str, limit: int) -> Dict[str, Any]:
     """
     Fetches plugin usage_data from dynamo.
     :returns Dict[str, Any]: A dict with entries for timeline and stats.
-    :params str plugin: Name of the plugin in lowercase.
+    :params str name: Name of the plugin in lowercase.
     :params int limit: The number of records to be fetched for timeline.
     """
     return {
-        "timeline": install_activity.get_timeline(plugin, limit) if limit else [],
+        "timeline": install_activity.get_timeline(name, limit) if limit else [],
         "stats": {
-            "total_installs": install_activity.get_total_installs(plugin),
-            "installs_in_last_30_days": install_activity.get_recent_installs(plugin, 30)
+            "total_installs": install_activity.get_total_installs(name),
+            "installs_in_last_30_days": install_activity.get_recent_installs(name, 30),
         },
     }
 
 
-def _get_maintenance_data(plugin: str, repo: Any, limit: int) -> Dict[str, Any]:
+def _get_maintenance_data(name: str, repo: Any, limit: int) -> Dict[str, Any]:
     """
     Fetches plugin maintenance_data from dynamo.
     :returns Dict[str, Any]: A dict with entries for timeline and stats.
-    :params str plugin: Name of the plugin in lowercase.
+    :params str name: Name of the plugin in lowercase.
     :params repo: Name of the repo associated to the plugin.
     :params int limit: The number of records to be fetched for timeline.
     """
     return {
-        "timeline": github_activity.get_timeline(plugin, repo, limit) if limit else [],
+        "timeline": github_activity.get_timeline(name, repo, limit) if limit else [],
         "stats": {
-            "total_commits": github_activity.get_total_commits(plugin, repo),
-            "latest_commit_timestamp": github_activity.get_latest_commit(plugin, repo),
+            "total_commits": github_activity.get_total_commits(name, repo),
+            "latest_commit_timestamp": github_activity.get_latest_commit(name, repo),
         },
     }

--- a/backend/api/metrics.py
+++ b/backend/api/metrics.py
@@ -1,0 +1,69 @@
+from typing import Dict, Any
+
+from api.models.plugin import get_plugin
+from api.models import install_activity, github_activity
+
+
+def get_metrics_for_plugin(plugin: str, limit: str,) -> Dict[str, Any]:
+    """
+    Fetches plugin metrics from s3 or dynamo based on the in_test variable
+    :return dict[str, Any]: A map with entries for usage and maintenance
+
+    :params str plugin: Name of the plugin for which usage data needs to be fetched.
+    :params str limit_str: Number of records to be fetched for timeline. Defaults to 0
+    for invalid number.
+    """
+    repo = _get_repo_from_plugin(plugin)
+    plugin = plugin.lower()
+    month_delta = 0
+
+    if limit.isdigit() and limit != "0":
+        month_delta = max(int(limit), 0)
+
+    return {
+        "usage": _get_usage_data(plugin, month_delta),
+        "maintenance": _get_maintenance_data(plugin, repo, month_delta),
+    }
+
+
+def _get_repo_from_plugin(plugin):
+    plugin_metadata = get_plugin(plugin)
+    if plugin_metadata:
+        repo_url = plugin_metadata.get("code_repository")
+        if repo_url:
+            return repo_url.replace("https://github.com/", "")
+    return None
+
+
+def _get_usage_data(plugin: str, limit: int) -> Dict[str, Any]:
+    """
+    Fetches plugin usage_data from s3 or dynamo based on the in_test variable
+    :returns (dict[str, Any]): A dict with the structure
+    {'timeline': List, 'stats': dict[str, int]}
+    :params str plugin: Name of the plugin in lowercase.
+    :params int limit: Sets the number of records to be fetched for timeline.
+    """
+    return {
+        "timeline": install_activity.get_timeline(plugin, limit) if limit else [],
+        "stats": {
+            "total_installs": install_activity.get_total_installs(plugin),
+            "installs_in_last_30_days": install_activity.get_recent_installs(plugin, 30)
+        },
+    }
+
+
+def _get_maintenance_data(plugin: str, repo: Any, limit: int) -> Dict[str, Any]:
+    """
+    Fetches plugin maintenance_data from s3 or dynamo based on the in_test variable
+    :returns (dict[str, Any]): A dict with the structure {'timeline': List, 'stats': Dict[str, int]}
+    :params str plugin: Name of the plugin in lowercase.
+    :params repo: Parameter used if use_dynamo_for_maintenance is true
+    :params int limit: Sets the number of records to be fetched for timeline.
+    """
+    return {
+        "timeline": github_activity.get_timeline(plugin, repo, limit) if limit else [],
+        "stats": {
+            "total_commits": github_activity.get_total_commits(plugin, repo),
+            "latest_commit_timestamp": github_activity.get_latest_commit(plugin, repo),
+        },
+    }

--- a/backend/api/models/_tests/conftest.py
+++ b/backend/api/models/_tests/conftest.py
@@ -1,3 +1,5 @@
+from datetime import datetime, date, timezone
+
 import boto3
 import moto.dynamodb.urls
 import pytest
@@ -27,6 +29,12 @@ def dynamo_env_variables():
     monkeypatch.setenv("LOCAL_DYNAMO_HOST", LOCAL_DYNAMO_HOST)
     monkeypatch.setenv("AWS_REGION", AWS_REGION)
     monkeypatch.setenv("STACK_NAME", STACK_NAME)
+
+
+@pytest.fixture
+def date_utc_today() -> datetime:
+    today = datetime.combine(date.today(), datetime.min.time())
+    return today.replace(tzinfo=timezone.utc)
 
 
 def create_dynamo_table(pynamo_ddb_model: Model, table_name: str):

--- a/backend/api/models/_tests/test_github_activity.py
+++ b/backend/api/models/_tests/test_github_activity.py
@@ -1,6 +1,4 @@
-import datetime
-
-import pandas as pd
+from datetime import date, datetime, timezone
 import pytest
 from dateutil.relativedelta import relativedelta
 from moto import mock_dynamodb
@@ -72,12 +70,12 @@ class TestGitHubActivity:
         ([(to_commits(i), i) for i in range(0, 7, 2)], 4, generate_commits_timeline(-4, to_value=to_commits)),
     ])
     def test_get_maintenance_timeline(self, github_activity_table, data, month_delta, expected):
-        start = datetime.date.today().replace(day=1)
+        start = datetime.combine(date.today(), datetime.min.time()).replace(day=1, tzinfo=timezone.utc)
         for count, period in data:
-            timestamp = pd.Timestamp(start - relativedelta(months=period))
+            timestamp = (start - relativedelta(months=period))
             self._put_item(github_activity_table, 'MONTH', timestamp, count)
 
-        actual = github_activity.get_maintenance_timeline(PLUGIN_NAME, REPO_NAME, month_delta)
+        actual = github_activity.get_timeline(PLUGIN_NAME, REPO_NAME, month_delta)
 
         assert actual == expected
 

--- a/backend/api/models/github_activity.py
+++ b/backend/api/models/github_activity.py
@@ -62,7 +62,7 @@ def get_latest_commit(plugin: str, repo: str) -> Any:
         logging.info(f'get_latest_commit for plugin={plugin} repo={repo} time_taken={(time.perf_counter() - start) * 1000}ms')
 
 
-def get_maintenance_timeline(plugin: str, repo: str, month_delta: int) -> List[Dict[str, int]]:
+def get_timeline(plugin: str, repo: str, month_delta: int) -> List[Dict[str, int]]:
     """
     Fetches plugin commit count at a month level granularity from dynamo in the previous month_delta months.
     :returns List[Dict[str, int]]: Entries for the month_delta months

--- a/backend/api/s3.py
+++ b/backend/api/s3.py
@@ -68,6 +68,3 @@ def cache(content: Union[dict, list, IO[bytes]], key: str, mime: str = None):
 def _get_complete_path(path):
     return os.path.join(bucket_path, path)
 
-
-def write_data(data: str, path: str):
-    s3_client.put_object(Body=data, Bucket=bucket, Key=_get_complete_path(path))

--- a/backend/api/s3.py
+++ b/backend/api/s3.py
@@ -1,12 +1,11 @@
 import io
 import json
-import logging
 import mimetypes
 import os
 import os.path
 import time
 from datetime import datetime
-from typing import Union, IO, List, Dict, Any
+from typing import Union, IO, List, Dict
 
 import boto3
 from botocore.client import Config
@@ -72,29 +71,3 @@ def _get_complete_path(path):
 
 def write_data(data: str, path: str):
     s3_client.put_object(Body=data, Bucket=bucket, Key=_get_complete_path(path))
-
-
-def _get_from_s3(path):
-    return s3_client.get_object(Bucket=bucket, Key=_get_complete_path(path))['Body'].read().decode('utf-8')
-
-
-def _load_json_from_s3(path: str) -> Dict:
-    """
-    Load activity dashboard .json file from s3
-
-    :param path: path to file in s3
-    :return: dictionary that consists of path-specific data for activity_dashboard backend endpoints
-    """
-    try:
-        return json.loads(_get_from_s3(path))
-    except Exception as e:
-        logging.error(e)
-        return {}
-
-
-def get_latest_commit(plugin: str) -> Any:
-    return _load_json_from_s3("activity_dashboard_data/latest_commits.json").get(plugin)
-
-
-def get_commit_activity(plugin: str) -> List:
-    return _load_json_from_s3("activity_dashboard_data/commit_activity.json").get(plugin, [])

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,7 +15,5 @@ pkginfo==1.8.3
 datadog-lambda==3.60.0
 build==0.8.0
 pyOpenSSL==22.0.0
-pandas==1.4.4
-snowflake-connector-python==2.8.0
 pynamodb==5.4.1
 python-slugify==8.0.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,6 +14,6 @@ wheel==0.38.1
 pkginfo==1.8.3
 datadog-lambda==3.60.0
 build==0.8.0
-pyOpenSSL==22.0.0
+pyOpenSSL==23.2.0
 pynamodb==5.4.1
 python-slugify==8.0.1


### PR DESCRIPTION
## Description

Relates to: https://github.com/chanzuckerberg/napari-hub/issues/1178, https://github.com/chanzuckerberg/napari-hub/issues/1179, https://github.com/chanzuckerberg/napari-hub/issues/1180, https://github.com/chanzuckerberg/napari-hub/issues/1069

### Changes introduced:

- Removes `use_dynamo_metric_maintenance` feature flag  (https://github.com/chanzuckerberg/napari-hub/issues/1178)
- Removes alarms and metrics associated with backend workflow (https://github.com/chanzuckerberg/napari-hub/issues/1180)
- Removes backed workflow for updating activity workflow and associated infra components (https://github.com/chanzuckerberg/napari-hub/issues/1179)
- Removes snowflake connector package as a dependency for the backend as it is no longer used
  - Upgraded `pyOpenSSL` as removing snowflake impacts the cryptography dependency version  (https://github.com/chanzuckerberg/napari-hub/issues/1069)
- Removes pandas package as a dependency for the backend module as it is only being used for datetime manipulation 
  - Updated all date time manipulation done using pandas as a part of this
- Moved metrics processing to its module.