### PR TITLE
Enable streaming for plugins_blocked

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -253,6 +253,8 @@ module plugin_blocked_dynamodb_table {
   autoscaling_enabled = var.env == "dev" ? false : true
   create_table        = true
   tags                = var.tags
+  stream_enabled      = true
+  stream_view_type    = "KEYS_ONLY"
 }
 
 module backend_lambda {
@@ -600,7 +602,9 @@ data aws_iam_policy_document data_workflows_policy {
       "dynamodb:GetRecords",
       "dynamodb:ListStreams",
     ]
-    resources = [module.plugin_metadata_dynamodb_table.stream_arn]
+    resources = [
+      module.plugin_metadata_dynamodb_table.stream_arn,
+    ]
   }
 }
 


### PR DESCRIPTION
## Description
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Set the status for the issue to “Pending QA & Release” upon merging
		- Provide a checklist of any relevant pre-deployment notes, e.g. whether a config or database change is needed
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Relates to https://github.com/chanzuckerberg/napari-hub/issues/1182

Enables streaming for `plugin_blocked` table.