### PR TITLE
Removing backend plugin update metrics and alarms

### DIFF
--- a/.happy/terraform/modules/cloudwatch-alarm/main.tf
+++ b/.happy/terraform/modules/cloudwatch-alarm/main.tf
@@ -57,20 +57,6 @@ resource aws_cloudwatch_log_metric_filter backend_api_500_log_metric {
   }
 }
 
-resource aws_cloudwatch_log_metric_filter backend_plugin_update_successful {
-  name            = "${var.stack_name}-backend-plugin-update-successful"
-  log_group_name  = var.backend_lambda_log_group_name
-  pattern         = "plugin update successful"
-  count           = var.metrics_enabled ? 1 : 0
-
-  metric_transformation {
-    name      = "${var.stack_name}-backend-plugin-update-successful"
-    namespace = local.metrics_namespace
-    value     = "1"
-    unit      = "Count"
-  }
-}
-
 resource aws_cloudwatch_log_metric_filter data_workflows_metrics_update_successful {
   name            = "${var.stack_name}-data-workflows-metrics-update-successful"
   log_group_name  = var.data_workflows_lambda_log_group_name
@@ -101,7 +87,6 @@ resource aws_cloudwatch_log_metric_filter data_workflows_plugin_update_successfu
 
 locals {
   backend_api_500_log_metric_name = var.metrics_enabled ? aws_cloudwatch_log_metric_filter.backend_api_500_log_metric[0].name : "backend_api_500_log_metric"
-  backend_plugin_update_successful_name = var.metrics_enabled ? aws_cloudwatch_log_metric_filter.backend_plugin_update_successful[0].name : "backend_plugin_update_successful"
   data_workflows_metrics_update_successful_name = var.metrics_enabled ? aws_cloudwatch_log_metric_filter.data_workflows_metrics_update_successful[0].name : "data_workflows_metrics_update_successful"
   data_workflows_plugin_update_successful_name = var.metrics_enabled ? aws_cloudwatch_log_metric_filter.data_workflows_plugin_update_successful[0].name : "data_workflows_plugin_update_successful"
 }
@@ -123,26 +108,6 @@ module backend_api_500_alarm {
   statistic           = "Sum"
   tags                = var.tags
   threshold           = 2
-}
-
-module plugins_missing_update_alarm {
-  source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
-  version = "3.3.0"
-
-  alarm_actions       = [local.alarm_sns_arn]
-  alarm_name          = "${var.stack_name}-plugins-missing-update-alarm"
-  alarm_description   = "Plugin update failure"
-  comparison_operator = "LessThanThreshold"
-  create_metric_alarm = var.alarms_enabled
-  datapoints_to_alarm = 2
-  evaluation_periods  = 3
-  metric_name         = local.backend_plugin_update_successful_name
-  namespace           = local.metrics_namespace
-  period              = local.period
-  statistic           = "Sum"
-  tags                = var.tags
-  threshold           = 1
-  treat_missing_data  = "breaching"
 }
 
 module data_workflow_plugins_missing_update_alarm {


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
4. Include screenshots / videos for PRs if there are visual changes.

A good example is https://github.com/chanzuckerberg/napari-hub/pull/77.
-->

## Description
Depends on: https://github.com/chanzuckerberg/napari-hub/pull/1204

Relates to: https://github.com/chanzuckerberg/napari-hub/issues/1193

Removes backend alarms and metrics for plugin backend workflow completion failure.