### PR TITLE
Handling code_repository from non "Source Code"

### DIFF
--- a/napari-hub-commons/src/nhcommons/tests/utils/test_github_adapter.py
+++ b/napari-hub-commons/src/nhcommons/tests/utils/test_github_adapter.py
@@ -1,17 +1,48 @@
+from typing import Dict
+
 import pytest
 
 from nhcommons.utils.github_adapter import get_repo_url
 
 
 class TestGithubAdapter:
-
     @pytest.mark.parametrize(
-        'input, expected', [
-            ({"Source Code": 'https://www.foo.com/', 'bar': 'https://github.com/test123/foo1'},
-             'https://www.foo.com/'),
-            ({'bar': 'https://github.com/test123/foo1'}, 'https://github.com/test123/foo1'),
-            ({'bar': 'https://github1.com/test'}, None),
-        ]
+        "input_value, expected",
+        [
+            (
+                {
+                    "Source Code": "https://github.com/test123/foo1",
+                },
+                "https://github.com/test123/foo1",
+            ),
+            (
+                {
+                    "Source Code": "https://github.com/test123/foo1.git",
+                    "source": "https://github.com/test23/foo2#README.md",
+                },
+                "https://github.com/test123/foo1.git",
+            ),
+            (
+                {
+                    "Source Code": "https://www.foo.com/",
+                    "repo": "https://github.com/test123/foo1/tree/main/foo1",
+                },
+                "https://www.foo.com/",
+            ),
+            (
+                {"repo": "https://github.com/test123/foo1"},
+                "https://github.com/test123/foo1",
+            ),
+            (
+                {"repo": "https://github.com/test123/foo1/tree/main/foo1"},
+                "https://github.com/test123/foo1",
+            ),
+            (
+                {"repo": "https://github.com/test123/foo1#README.md"},
+                "https://github.com/test123/foo1",
+            ),
+            ({"bar": "https://github1.com/test"}, None),
+        ],
     )
-    def test_get_latest_plugins(self, input: str, expected: str):
-        assert expected == get_repo_url(input)
+    def test_get_repo_url(self, input_value: Dict[str, str], expected: str):
+        assert expected == get_repo_url(input_value)

--- a/napari-hub-commons/src/nhcommons/utils/github_adapter.py
+++ b/napari-hub-commons/src/nhcommons/utils/github_adapter.py
@@ -1,27 +1,34 @@
 import re
-from typing import Dict, Optional
+from typing import Dict, Optional, Match
 
 import yaml
 
 from .adapter_helpers import GithubClientHelper, CitationHelper
 from ..models.plugin_utils import PluginVisibility
 
-_URL_PATTERN = re.compile("^https://github\\.com/([^/]+)/([^/]+)")
-_DEFAULT_DESCRIPTION = "The developer has not yet provided a napari-hub " \
-                       "specific description."
+_GITHUB_URL_PATTERN = re.compile("^https://github\\.com/[^/]+/[^#./]+")
+_DEFAULT_DESCRIPTION = (
+    "The developer has not yet provided a napari-hub " "specific description."
+)
 _PROJECT_URL_NAMES = {
-    'Project Site': 'project_site',
-    'Documentation': 'documentation',
-    'User Support': 'support',
-    'Report Issues': 'report_issues',
-    'Twitter': 'twitter'
+    "Project Site": "project_site",
+    "Documentation": "documentation",
+    "User Support": "support",
+    "Report Issues": "report_issues",
+    "Twitter": "twitter",
 }
-_VISIBILITY_SET = {'public', 'disabled', 'hidden'}
-_HUB_CONFIG_KEYS = {'summary', 'authors', 'labels', 'visibility'}
+_VISIBILITY_SET = {"public", "disabled", "hidden"}
+_HUB_CONFIG_KEYS = {"summary", "authors", "labels", "visibility"}
+
+
+def _get_repo_match(url: str) -> Optional[Match]:
+    if not url:
+        return None
+    return _GITHUB_URL_PATTERN.match(url)
 
 
 def is_valid_repo_url(url: str) -> bool:
-    return url and _URL_PATTERN.match(url) is not None
+    return _get_repo_match(url) is not None
 
 
 def get_repo_url(project_urls: Dict[str, str]) -> Optional[str]:
@@ -36,14 +43,13 @@ def get_repo_url(project_urls: Dict[str, str]) -> Optional[str]:
         return source_code_url
 
     for key, url in project_urls.items():
-        match = _URL_PATTERN.match(url)
-        if match:
+        if match := _GITHUB_URL_PATTERN.match(url):
             return match.group(0)
 
     return None
 
 
-def get_github_metadata(repo_url: str, branch: str = 'HEAD') -> Dict:
+def get_github_metadata(repo_url: str, branch: str = "HEAD") -> Dict:
     """
     Extract extra metadata from the github repo url.
 
@@ -55,28 +61,28 @@ def get_github_metadata(repo_url: str, branch: str = 'HEAD') -> Dict:
     github_helper = GithubClientHelper(repo_url, branch)
     github_license = github_helper.get_license()
     if github_license:
-        github_metadata['license'] = github_license
+        github_metadata["license"] = github_license
 
     description = github_helper.get_first_valid_file(
-            [".napari-hub/DESCRIPTION.md", ".napari/DESCRIPTION.md"]
-        )
+        [".napari-hub/DESCRIPTION.md", ".napari/DESCRIPTION.md"]
+    )
 
     if description and _DEFAULT_DESCRIPTION not in description:
-        github_metadata['description'] = description
+        github_metadata["description"] = description
 
     citation_file = github_helper.get_file("CITATION.cff")
     if citation_file is not None:
         citation_helper = CitationHelper(citation_file)
         citation = citation_helper.get_citations()
         if citation:
-            github_metadata['citations'] = citation
+            github_metadata["citations"] = citation
         # Try to parse names fron citation
         authors = citation_helper.get_citation_author()
         # update github metadata author info
         if authors:
             github_metadata.update({"authors": authors})
-    if github_metadata.get('visibility') not in PluginVisibility:
-        github_metadata['visibility'] = PluginVisibility.PUBLIC.name.lower()
+    if github_metadata.get("visibility") not in PluginVisibility:
+        github_metadata["visibility"] = PluginVisibility.PUBLIC.name.lower()
 
     yaml_file = github_helper.get_first_valid_file(
         [".napari-hub/config.yml", ".napari/config.yml"]
@@ -89,16 +95,16 @@ def get_github_metadata(repo_url: str, branch: str = 'HEAD') -> Dict:
         # if the yaml.safe_load method returns None, then assign {} to config
         if config is None:
             config = {}
-        hub_config = {key: config[key] for key in _HUB_CONFIG_KEYS if
-                      key in config}
+        hub_config = {key: config[key] for key in _HUB_CONFIG_KEYS if key in config}
         github_metadata.update(hub_config)
 
-        project_urls = config.get('project_urls', {})
-        github_metadata.update({
-            hub_name: project_urls[yaml_name]
-            for yaml_name, hub_name in _PROJECT_URL_NAMES.items()
-            if yaml_name in project_urls
-        })
+        project_urls = config.get("project_urls", {})
+        github_metadata.update(
+            {
+                hub_name: project_urls[yaml_name]
+                for yaml_name, hub_name in _PROJECT_URL_NAMES.items()
+                if yaml_name in project_urls
+            }
+        )
 
     return github_metadata
-


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
4. Include screenshots / videos for PRs if there are visual changes.

A good example is https://github.com/chanzuckerberg/napari-hub/pull/77.
-->

## Description
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Set the status for the issue to “Pending QA & Release” upon merging
		- Provide a checklist of any relevant pre-deployment notes, e.g. whether a config or database change is needed
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Relates to: https://github.com/chanzuckerberg/napari-hub/issues/1156

### Changes introduced:
When fetching code_repository from non-"Source Code" fields, we parse it and clean it if necessary to ensure it conforms to the expected format. 

#### Changes in validation regex explained

Before we validated the urls against this regex: `"^https://github\\.com/([^/]+)/([^/]+)"`.

Now we are validating the urls against the regex: `"^https://github\\.com/[^/]+/[^#./]+"`.

In both cases, we check that the regex starts with `https://github.com/{org}/{repo}` and has a non-zero number of characters that are not `/`. In the newer validation, the repo value is also validated not to have `.` and `#`.

| Input      | Old validation  | New Validation |
| ----------- | ----------- | ----------- |
| "https://github.com/test123/foo1/tree/main/foo"  |  "https://github.com/test123/foo1" |  "https://github.com/test123/foo1" |
| "https://github.com/test123/foo1#README"  |  "https://github.com/test123/foo1#README" |  "https://github.com/test123/foo1" |
| "https://github.com/test123/foo1.git"  |  "https://github.com/test123/foo1.git" |  "https://github.com/test123/foo1" |


#### How is_valid_repo_url is impacted

With the changes, the `is_valid_repo_url` returns `true` whenever there is a match to the expected format `https://github.com/{org}/{repo}` even if they are followed by `#`, `.`, `/`.

| Input      | Old validation  | New Validation |
| ----------- | ----------- | ----------- |
| "https://github.com/test123/foo1/tree/main/foo"  | true |  true |
| "https://github.com/test123/foo1#README"  |  true  |  true  |
| "https://github.com/test123/foo1.git"  |  true |  true |
| "https://github.com/test123/foo1"  | true |  true |
| "https://github.com/test123"  | false |  false |

