### PR TITLE
Check for existence of github repo's `createdAt` field before displaying github commits data

### DIFF
--- a/frontend/src/components/ActivityDashboard/ActivityMaintenanceSection/ActivityMaintenanceSection.tsx
+++ b/frontend/src/components/ActivityDashboard/ActivityMaintenanceSection/ActivityMaintenanceSection.tsx
@@ -10,9 +10,11 @@ import { TotalCommits } from './TotalCommits';
 
 export function ActivityMaintenanceSection() {
   const [t] = useTranslation(['activity']);
-  const { plugin } = usePluginState();
+  const { plugin, repo } = usePluginState();
 
-  const hasRepo = !!plugin?.code_repository?.includes('github');
+  const hasRepo = !!(
+    plugin?.code_repository?.includes('github') && repo.createdAt
+  );
 
   return (
     <ActivitySection


### PR DESCRIPTION
In https://github.com/chanzuckerberg/napari-hub/blob/main/frontend/src/utils/repo.ts#L64 we retrieve the `created_at` date of a github repo. If we have unsuccessfully been able to fetch the repo, then this value will be an empty string as defined by its defaults: https://github.com/chanzuckerberg/napari-hub/blob/main/frontend/src/constants/plugin.ts#L38

Adding this check should address this bug: https://github.com/chanzuckerberg/napari-hub/issues/1220