### PR TITLE
Show message for empty stats when timestamp is null

### DIFF
--- a/frontend/src/components/ActivityDashboard/ActivityMaintenanceSection/ActivityMaintenanceSection.tsx
+++ b/frontend/src/components/ActivityDashboard/ActivityMaintenanceSection/ActivityMaintenanceSection.tsx
@@ -3,6 +3,7 @@ import { EmptyState } from 'src/components/ActivityDashboard/EmptyState';
 
 import { ActivitySection } from '@/components/ActivityDashboard/ActivitySection';
 import { usePluginState } from '@/context/plugin';
+import { usePluginMetrics } from '@/hooks';
 
 import { MonthlyCommits } from './MonthlyCommits';
 import { RecentCommit } from './RecentCommit';
@@ -11,9 +12,13 @@ import { TotalCommits } from './TotalCommits';
 export function ActivityMaintenanceSection() {
   const [t] = useTranslation(['activity']);
   const { plugin, repo } = usePluginState();
+  const { data: metrics } = usePluginMetrics(plugin?.name);
+  const stats = metrics?.maintenance.stats;
 
   const hasRepo = !!(
-    plugin?.code_repository?.includes('github') && repo.createdAt
+    plugin?.code_repository?.includes('github') &&
+    repo.createdAt &&
+    stats?.latest_commit_timestamp
   );
 
   return (


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
4. Include screenshots / videos for PRs if there are visual changes.

A good example is https://github.com/chanzuckerberg/napari-hub/pull/77.
-->

## Description
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Set the status for the issue to “Pending QA & Release” upon merging
		- Provide a checklist of any relevant pre-deployment notes, e.g. whether a config or database change is needed
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Shows message for empty stats if `latest_commit_timestamp` is `null` or empty string `''`

## Demos
<!-- Optional but recommended. Remove if not in use -->

Maintenance section for `recOrder-napari` plugin

### Before

<img width="838" alt="image" src="https://github.com/chanzuckerberg/napari-hub/assets/2176050/99935826-1fde-48b1-9520-1c05adf8dc14">

### After

<img width="808" alt="image" src="https://github.com/chanzuckerberg/napari-hub/assets/2176050/cc75a71f-55aa-4902-9465-7932046dca86">
