### PR TITLE
Update message displayed when we have no commit data for a plugin

### DIFF
--- a/frontend/i18n/en/activity.json
+++ b/frontend/i18n/en/activity.json
@@ -11,7 +11,7 @@
     "allData": "No data could be fetched for this plugin. <hubLink href='$t(learnMoreLink)'>Learn more.</hubLink>",
     "monthly": "There is not yet enough data to display for this plugin",
     "preview": "Activity not available for previews",
-    "noCodeRepo": "Metrics not available, this plugin does not have a code repository specified or the repository is not on GitHub."
+    "noCodeRepo": "Metrics not available, this plugin may not have a valid code repository specified or the repository is not on GitHub."
   },
   "monthlyInstalls": {
     "title": "Monthly installs in past year",


### PR DESCRIPTION
Addresses https://github.com/chanzuckerberg/napari-hub/issues/1220, in combination with https://github.com/chanzuckerberg/napari-hub/pull/1221 and https://github.com/chanzuckerberg/napari-hub/pull/1223