### PR TITLE
Adding back random_uuid as patch

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -98,6 +98,9 @@ module frontend_service {
   wait_for_steady_state = local.wait_for_steady_state
 }
 
+resource "random_uuid" "api_key" {
+}
+
 module install_dynamodb_table {
   source              = "../dynamo"
   table_name          = "${local.custom_stack_name}-install-activity"


### PR DESCRIPTION
## Description
This is a potential band-aid to help the issue with the cyclic dependency in the production causing deploys to fail.
