### PR TITLE
add run_attempt to e2e fixture cache key

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -21,6 +21,9 @@ defaults:
   run:
     working-directory: frontend/
 
+env:
+  FIXTURES_CACHE_KEY: e2e-fixtures-${{ github.run_id }}-${{ github.run_attempt }}
+
 jobs:
   e2e-setup:
     name: E2E Setup
@@ -81,7 +84,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: frontend/e2e/fixtures
-          key: e2e-fixtures-${{ github.run_id }}-${{ github.run_attempt }}
+          key: ${{ env.FIXTURES_CACHE_KEY }}
 
       - name: Fetch fixture data
         env:
@@ -154,7 +157,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: frontend/e2e/fixtures
-          key: e2e-fixtures-${{ github.run_id }}-${{ github.run_attempt }}
+          key: ${{ env.FIXTURES_CACHE_KEY }}
 
       - name: Run E2E Tests
         env:


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
4. Include screenshots / videos for PRs if there are visual changes.

A good example is https://github.com/chanzuckerberg/napari-hub/pull/77.
-->

## Description
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Set the status for the issue to “Pending QA & Release” upon merging
		- Provide a checklist of any relevant pre-deployment notes, e.g. whether a config or database change is needed
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Adds `github.run_attempt` to the e2e fixture cache key so that it re-fetches the hub API data fixture