### PR TITLE
Allow dev without split.io flag

### DIFF
--- a/frontend/src/utils/ssr.ts
+++ b/frontend/src/utils/ssr.ts
@@ -74,11 +74,12 @@ export function getServerSidePropsHandler<
       Object.keys(I18nResources),
     );
 
-    const featureFlags = E2E
-      ? getEnabledFeatureFlags(...FEATURE_FLAG_LIST)
-      : await FLAG_CACHE.get(FLAG_CACHE_KEY, () =>
-          getFeatureFlags(req.url ?? '/'),
-        );
+    const featureFlags =
+      E2E || !process.env.SPLIT_IO_SERVER_KEY
+        ? getEnabledFeatureFlags(...FEATURE_FLAG_LIST)
+        : await FLAG_CACHE.get(FLAG_CACHE_KEY, () =>
+            getFeatureFlags(req.url ?? '/'),
+          );
 
     // Assign to feature flag store so that server code can use the state.
     Object.assign(featureFlagsStore, featureFlags);


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
4. Include screenshots / videos for PRs if there are visual changes.

A good example is https://github.com/chanzuckerberg/napari-hub/pull/77.
-->

## Description
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Set the status for the issue to “Pending QA & Release” upon merging
		- Provide a checklist of any relevant pre-deployment notes, e.g. whether a config or database change is needed
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Updates the logic for fetching feature flags so that all flags are enabled by default if the `SPLIT_IO_SERVER_KEY` environment variable is not defined