### PR TITLE
disable frontend alarm for 404s

### DIFF
--- a/.happy/terraform/modules/cloudwatch-alarm/main.tf
+++ b/.happy/terraform/modules/cloudwatch-alarm/main.tf
@@ -88,7 +88,7 @@ resource aws_cloudwatch_log_metric_filter data_workflows_plugin_update_successfu
 resource aws_cloudwatch_log_metric_filter frontend_error {
   name            = "${var.stack_name}-frontend-error"
   log_group_name  = var.frontend_log_group_name
-  pattern         = "{ $.level = \"error\" }"
+  pattern         = "{ $.level = \"error\" && $.error != %404% }"
   count           = var.metrics_enabled ? 1 : 0
 
   metric_transformation {


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
4. Include screenshots / videos for PRs if there are visual changes.

A good example is https://github.com/chanzuckerberg/napari-hub/pull/77.
-->

## Description
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Set the status for the issue to “Pending QA & Release” upon merging
		- Provide a checklist of any relevant pre-deployment notes, e.g. whether a config or database change is needed
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

#1064

Should disable alerting the frontend alarm when a 404 request occurs