### PR TITLE
Fixing repository data being displayed incorrectly

### DIFF
--- a/frontend/src/pages/plugins/[name].tsx
+++ b/frontend/src/pages/plugins/[name].tsx
@@ -59,7 +59,7 @@ export const getServerSideProps = getServerSidePropsHandler<Props, Params>({
     }
 
     const repoData = await fetchRepoData(codeRepo);
-    Object.assign(repoData, await fetchRepoData(codeRepo));
+    Object.assign(props, repoData);
 
     if (props.repoFetchError) {
       logger.error({


### PR DESCRIPTION
Relates to https://github.com/chanzuckerberg/napari-hub/issues/1265

## Description
This fixes the regression of the plugin repository data not being displayed correctly. 

The root cause was identified as the data fetched from GitHub was not assigned to the expected object. 
