### PR TITLE
Set API_URL for dev environment

### DIFF
--- a/frontend/src/constants/env.ts
+++ b/frontend/src/constants/env.ts
@@ -2,6 +2,8 @@ export const PROD = process.env.ENV === 'prod';
 
 export const STAGING = process.env.ENV === 'staging';
 
+export const DEV = process.env.ENV === 'dev';
+
 export const E2E = process.env.E2E === 'true';
 
 export const BROWSER = typeof window !== 'undefined';

--- a/frontend/src/utils/HubAPIClient.ts
+++ b/frontend/src/utils/HubAPIClient.ts
@@ -2,7 +2,7 @@
 
 import axios, { AxiosRequestConfig } from 'axios';
 
-import { BROWSER, PROD, SERVER, STAGING } from '@/constants/env';
+import { BROWSER, DEV, PROD, SERVER, STAGING } from '@/constants/env';
 import {
   PluginData,
   PluginIndexData,
@@ -31,6 +31,10 @@ const API_URL = (() => {
 
   if (STAGING) {
     return 'https://api.staging.napari-hub.org';
+  }
+
+  if (DEV) {
+    return 'https://api.dev.napari-hub.org/dev-shared';
   }
 
   return process.env.API_URL || 'http://localhost:8081';


### PR DESCRIPTION
Sets the API_URL for dev environments to `https://api.dev.napari-hub.org/dev-shared`. 

This addresses a bug specific to dev environments, as currently the API_URL is defaulting to `localhost:8081` and certain sections of the site, such as the activity tab, do not work.