### PR TITLE
Logging pypi plugin count by page

### DIFF
--- a/napari-hub-commons/src/nhcommons/tests/utils/test_pypi_adapter.py
+++ b/napari-hub-commons/src/nhcommons/tests/utils/test_pypi_adapter.py
@@ -170,13 +170,15 @@ class TestPypiAdapter:
             )
         return MockResponse(status_code=requests.codes.not_found)
 
-    @pytest.mark.parametrize(
-        "is_valid, expected",
-        [(True, {plugin[0]: plugin[1] for plugin in plugins()}), (False, {})],
-    )
-    def test_get_all_plugins(self, is_valid: bool, expected: Dict[str, str]):
-        self._version_field = "package-snippet__version" if is_valid else "foo"
+    def test_get_all_plugins(self):
+        self._version_field = "package-snippet__version"
+        expected = {plugin[0]: plugin[1] for plugin in plugins()}
         assert expected == pypi_adapter.get_all_plugins()
+
+    def test_get_all_plugins_invalid_response(self):
+        self._version_field = "foo"
+        with pytest.raises(ValueError):
+            pypi_adapter.get_all_plugins()
 
     @pytest.mark.parametrize(
         "plugin, version, extra_fields, expected",

--- a/napari-hub-commons/src/nhcommons/utils/pypi_adapter.py
+++ b/napari-hub-commons/src/nhcommons/utils/pypi_adapter.py
@@ -33,8 +33,9 @@ def get_all_plugins() -> Dict[str, str]:
             html = response.text
             names = _NAME_PATTERN.findall(html)
             versions = _VERSION_PATTERN.findall(html)
+            logger.info(f"Count of plugins fetched for page={page} {len(packages)}")
             if len(names) != len(versions):
-                return {}
+                raise ValueError("Count of plugin and version don't match")
             for name, version in zip(names, versions):
                 packages[name] = version
             page += 1


### PR DESCRIPTION
## Description

- Adds logging for the number of plugins fetched on each page from pypi
- Raises an exception when name and version values don't match instead of returning `{}`.  This will prevent the hub from marking all the live plugins as stale because of an invalid response from pypi. 
