### PR TITLE
Remove zulip credentials from data-workflows terraform config

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -341,7 +341,6 @@ module data_workflows_lambda {
     "GITHUB_CLIENT_ID"      = local.github_client_id
     "GITHUB_CLIENT_SECRET"  = local.github_client_secret
     "PLUGINS_LAMBDA_NAME"   = local.plugins_function_name
-    "ZULIP_CREDENTIALS"     = local.zulip_credentials
   }
 
   log_retention_in_days   = local.log_retention_period


### PR DESCRIPTION
## Description
Remove `ZULIP_CREDENTIALS` from `data-workflows` lambda to prevent all updates to the napari hub Zulip stream. This is a temporary patch to prevent the noise reported in [this zulip topic](https://napari.zulipchat.com/#narrow/stream/212875-general/topic/napari.20hub.20stream.20noise).