### PR TITLE
Removing unused backend module packages

### DIFF
--- a/backend/bdd-test-requirements.txt
+++ b/backend/bdd-test-requirements.txt
@@ -1,4 +1,4 @@
 pytest-bdd==6.1.1
-requests==2.28.2
+requests==2.31.0
 python-dateutil==2.8.2
 pytest==7.2.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,10 +1,6 @@
 apig-wsgi==2.14.0
-boto3==1.26.77
 Flask==2.2.5
-Flask-GitHubApp==0.3.0
 gunicorn==20.1.0
-requests==2.28.0
-GitPython==3.1.30
 setuptools==65.5.1
 wheel==0.38.1
 pkginfo==1.8.3


### PR DESCRIPTION
## Description

- Removes packages that are no longer being used by the backend module


This will also remove the need for https://github.com/chanzuckerberg/napari-hub/pull/1256, https://github.com/chanzuckerberg/napari-hub/pull/1070 