### PR TITLE
add metric filter for RUM uncaught errors

### DIFF
--- a/.happy/terraform/modules/cloudwatch-alarm/variables.tf
+++ b/.happy/terraform/modules/cloudwatch-alarm/variables.tf
@@ -58,3 +58,8 @@ variable frontend_rum_app_name {
   type        = string
   description = "App name for frontend RUM monitor"
 }
+
+variable frontend_rum_log_group_name {
+  type        = string
+  description = "Log group name for frontend RUM monitor"
+}

--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -686,4 +686,5 @@ module alarm_and_monitoring {
   tags = var.tags
   frontend_log_group_name = module.frontend_service.cloudwatch_log_group_name
   frontend_rum_app_name = local.cloudwatch_rum_config.app_name
+  frontend_rum_log_group_name = local.cloudwatch_rum_config.log_group_name
 }


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
4. Include screenshots / videos for PRs if there are visual changes.

A good example is https://github.com/chanzuckerberg/napari-hub/pull/77.
-->

## Description
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Set the status for the issue to “Pending QA & Release” upon merging
		- Provide a checklist of any relevant pre-deployment notes, e.g. whether a config or database change is needed
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Adds a metric filter for RUM error events so that the uncaught error doesn't get triggered for errors that we can safely ignore.


## Demos
<!-- Optional but recommended. Remove if not in use -->

The pattern for the filter can be verified using the AWS cli:

```sh
AWS_PROFILE=sci-imaging aws logs describe-metric-filters \
  | jq --raw-output '.metricFilters[] | select(.filterName=="dev-shared-frontend-uncaught-error") | .filterPattern'
```
```
"com.amazon.rum.js_error_event" -"CWR: Failed to retrieve Cognito identity" -"CWR: Failed to retrieve credentials" -"ResizeObserver loop" -"Script error" -"The provided `href`" -"The request is not allowed by the user agent"
```

Tested in `dev-shared` with artificial errors created from the frontend:

<img width="724" alt="image" src="https://github.com/chanzuckerberg/napari-hub/assets/2176050/1d9a551d-d375-48eb-b4eb-3ca61c6fa62d">

The first 3 buttons are all known errors that are filtered while the last one is not. Clicking on any of the first 3 buttons correctly reports in RUM:

<img width="715" alt="image" src="https://github.com/chanzuckerberg/napari-hub/assets/2176050/d8f922d5-1c17-48e2-93c5-05a115fc6aa5">

But it does not trigger the alert. However, clicking on the last button will trigger the alert:

<img width="713" alt="image" src="https://github.com/chanzuckerberg/napari-hub/assets/2176050/a0d36ee8-3bc3-4f74-bc8b-c5397e5bf2db">

<img width="546" alt="image" src="https://github.com/chanzuckerberg/napari-hub/assets/2176050/99362c6b-f59c-4d3f-aec2-9f0994735e49">
