### PR TITLE
Filter out empty support links

### DIFF
--- a/frontend/src/components/PluginPage/SupportInfo.tsx
+++ b/frontend/src/components/PluginPage/SupportInfo.tsx
@@ -239,15 +239,17 @@ function Links({ ariaLabel, children, links }: LinksProps) {
       onClose={closeTooltip}
       title={
         <div className="flex flex-col">
-          {links.map((link) => (
-            <Link
-              className="py-sds-s px-sds-l hover:bg-hub-gray-100"
-              href={link.value}
-              key={link.value}
-            >
-              {link.label}
-            </Link>
-          ))}
+          {links
+            .filter((link) => link.value)
+            .map((link) => (
+              <Link
+                className="py-sds-s px-sds-l hover:bg-hub-gray-100"
+                href={link.value}
+                key={link.value}
+              >
+                {link.label}
+              </Link>
+            ))}
         </div>
       }
     >


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
4. Include screenshots / videos for PRs if there are visual changes.

A good example is https://github.com/chanzuckerberg/napari-hub/pull/77.
-->

## Description
<!--
Link related GitHub issues

- If this PR addresses an issue:
	- And changes require a deployment
		- Add non-closing keywords and link the issues, e.g. "Addresses #issue-number"
		- Set the status for the issue to “Pending QA & Release” upon merging
		- Provide a checklist of any relevant pre-deployment notes, e.g. whether a config or database change is needed
	- If changes do not require a deployment (e.g. documentation, CI changes, unit tests)
		- Add closing keywords and link the issues so it's automatically closed, e.g. "Closes #issue-number"
		  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Fixes issue where links like `https://napari-hub.org/plugins/[name]` were being clicked on because of an empty value for the documentation link.

## Demos
<!-- Optional but recommended. Remove if not in use -->

### Before

<img width="160" alt="image" src="https://github.com/chanzuckerberg/napari-hub/assets/2176050/134f9d49-87f2-4541-9eb0-927a00471643">
<img width="269" alt="image" src="https://github.com/chanzuckerberg/napari-hub/assets/2176050/f5ed8421-bbf7-40f4-ad91-c20a9544df55">

### After

<img width="149" alt="image" src="https://github.com/chanzuckerberg/napari-hub/assets/2176050/6aa00d4c-1292-4732-b4fa-21cddd0caa1c">
