### PR TITLE
Adding back Zulip credentials

### DIFF
--- a/.happy/terraform/modules/ecs-stack/main.tf
+++ b/.happy/terraform/modules/ecs-stack/main.tf
@@ -341,6 +341,7 @@ module data_workflows_lambda {
     "GITHUB_CLIENT_ID"      = local.github_client_id
     "GITHUB_CLIENT_SECRET"  = local.github_client_secret
     "PLUGINS_LAMBDA_NAME"   = local.plugins_function_name
+    "ZULIP_CREDENTIALS"     = local.zulip_credentials
   }
 
   log_retention_in_days   = local.log_retention_period


### PR DESCRIPTION
<!--
When creating a pull request, please follow these guidelines:

1. Keep PRs reasonably sized. Max 500 LOC is ideal. Prefer splitting into multiple PRs if you can.
2. Include a description of what your PR does and any background information for nuanced topics.
3. Do not request code reviews until the PR checks pass.
4. Include screenshots / videos for PRs if there are visual changes.

A good example is https://github.com/chanzuckerberg/napari-hub/pull/77.
-->

## Description
Relates to: https://github.com/chanzuckerberg/napari-hub/issues/1275
Depends on: https://github.com/chanzuckerberg/napari-hub/pull/1301



### Changes introduced 
Adds back Zulip credentials to the production environment. This will enable notifications to be sent to the Zulip channel. 
