### PR TITLE
Excluding RUM errors for Cannot redefine property

### DIFF
--- a/.happy/terraform/modules/cloudwatch-alarm/main.tf
+++ b/.happy/terraform/modules/cloudwatch-alarm/main.tf
@@ -117,7 +117,7 @@ resource aws_cloudwatch_log_metric_filter frontend_uncaught_error {
     "-\"Script error\"",
     "-\"The request is not allowed by the user agent\"",
     # Error from adblocker
-    "Cannot redefine property: googletag"
+    "-\"Cannot redefine property\"",
   ])
   count           = var.metrics_enabled ? 1 : 0
 

--- a/.happy/terraform/modules/cloudwatch-alarm/main.tf
+++ b/.happy/terraform/modules/cloudwatch-alarm/main.tf
@@ -117,7 +117,7 @@ resource aws_cloudwatch_log_metric_filter frontend_uncaught_error {
     "-\"Script error\"",
     "-\"The request is not allowed by the user agent\"",
     # Error from adblocker
-    "-\"Cannot redefine property\"",
+    "-\"Cannot redefine property: googletag\"",
   ])
   count           = var.metrics_enabled ? 1 : 0
 


### PR DESCRIPTION
## Description

- Updates the RUM error exclusion to not have the unsupported char: `:` 
- Adds negation to stop ad blocker error from being included in alarms