### PR TITLE
Add mechnism to ignore commits in release notes

### DIFF
--- a/.github/release-notes.config.js
+++ b/.github/release-notes.config.js
@@ -40,4 +40,11 @@ module.exports = {
       labels: [],
     },
   ],
+
+  /**
+   * Ignore specific commits that cause problems with the release notes workflow.
+   */
+  ignoreCommits: [
+    "e5b0a312ddb1d508b2d14b4c101b894f2a4c7356", // committed without PR
+  ],
 }

--- a/.github/release-notes.js
+++ b/.github/release-notes.js
@@ -24,7 +24,7 @@ async function getCommitsSinceLastRelease(exec) {
         stdout(data) {
           const hash = data.toString()
 
-          if (hash) {
+          if (hash && !config.ignoreCommits.includes(hash)) {
             hashes.push(hash)
           }
         },

--- a/.github/release-notes.js
+++ b/.github/release-notes.js
@@ -18,13 +18,13 @@ async function getCommitsSinceLastRelease(exec) {
 
   await exec.exec(
     'git',
-    ['log', '--pretty=format:"%h"', `${LATEST_RELEASE}..${TARGET_BRANCH}`],
+    ['log', '--pretty=format:"%H"', `${LATEST_RELEASE}..${TARGET_BRANCH}`],
     {
       listeners: {
         stdout(data) {
           const hash = data.toString()
 
-          if (hash && !config.ignoreCommits.includes(hash)) {
+          if (hash) {
             hashes.push(hash)
           }
         },
@@ -36,6 +36,7 @@ async function getCommitsSinceLastRelease(exec) {
     .flatMap(hash => hash.split('\n'))
     .filter(Boolean)
     .map(hash => hash.replaceAll('"', ''))
+    .filter(hash => !config.ignoreCommits.includes(hash))
 }
 
 /**


### PR DESCRIPTION
## Description
The release notes workflow depends on specific commit/PR structures, and is currently broken. This PR adds a mechanism to explicitly ignore certain commits. It also ignores the specific problematic commit.