### PR TITLE
Use ubuntu-22.04 in all workflows

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -26,7 +26,7 @@ jobs:
   # Runs pytest for backend code
   tests:
     name: Unit test with pytest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Repo
@@ -59,7 +59,7 @@ jobs:
 
   lints:
     name: Linting with Black
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/dataworkflow-tests.yml
+++ b/.github/workflows/dataworkflow-tests.yml
@@ -26,7 +26,7 @@ jobs:
   # Runs pytest for data-workflows code
   tests:
     name: Unit test with pytest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Repo
@@ -57,7 +57,7 @@ jobs:
 
   lints:
     name: Linting with Black
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   prod:
     name: deploy to production
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository == 'chanzuckerberg/napari-hub' && startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Configure AWS Credentials
@@ -48,7 +48,7 @@ jobs:
           operation: 'create-or-update'
 
   lighthouse-ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: prod
     steps:
       - uses: actions/checkout@v3
@@ -70,7 +70,7 @@ jobs:
     defaults:
       run:
         working-directory: frontend/
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: prod # Needs the production deploy to happen first before E2E tests can be ran
 
     steps:
@@ -136,7 +136,7 @@ jobs:
     defaults:
       run:
         working-directory: frontend/
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: prod-e2e-setup
 
     concurrency:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   e2e-setup:
     name: E2E Setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Repo
@@ -93,7 +93,7 @@ jobs:
 
   e2e:
     name: E2E tests ${{ matrix.browser }} ${{ matrix.shardCurrent }} / ${{ matrix.shardTotal }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: e2e-setup
 
     concurrency:

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   checkLabels:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -24,7 +24,7 @@ jobs:
   # formatting, best practices, and run unit/integration tests.
   tests:
     name: ${{ matrix.name }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/nh-commons-tests.yml
+++ b/.github/workflows/nh-commons-tests.yml
@@ -24,7 +24,7 @@ jobs:
   # Runs pytest for napari-hub-commons code
   tests:
     name: Unit test with pytest
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Repo
@@ -54,7 +54,7 @@ jobs:
 
   lints:
     name: Linting with Black
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/plugins-tests.yml
+++ b/.github/workflows/plugins-tests.yml
@@ -26,7 +26,7 @@ jobs:
   # Runs pytest for backend code
   tests:
     name: Unit test with pytest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Repo
@@ -59,7 +59,7 @@ jobs:
 
   lints:
     name: Linting with Black
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/push-rdev.yml
+++ b/.github/workflows/push-rdev.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   create-update-dev:
     name: deploy dev branch
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository == 'chanzuckerberg/napari-hub'
     steps:
       - name: Configure AWS Credentials
@@ -76,7 +76,7 @@ jobs:
 
   # Runs behave tests for backend code
   bdd-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: create-update-dev
     if: ${{ github.event_name == 'push' }}
 

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   release_notes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   pr-release-comment:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Checkout
@@ -22,7 +22,7 @@ jobs:
           commentOnPRs({github, context, core});
 
   slack-notify:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Notify Slack of Release


### PR DESCRIPTION
## Description

This pins all the workflows to the same 22.04 ubuntu release.

Some workflows are failing, specifically on installation of `libffi7`, which no longer exists in the `ubuntu-latest` runner since it moved to 24.04. I'm not sure _which_ package needs this, but I suspect a dependency of some Python package we're using.

The alternative/long-term fix is probably to update whatever package is using this. That may mean a full Python version update as well (this project is currently using 3.9, I believe).